### PR TITLE
APIGOV-17281 - return hostname instead of string

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -81,7 +81,7 @@ func GetURLHostName(urlString string) string {
 		fmt.Println(err)
 		return ""
 	}
-	return host.String()
+	return host.Hostname()
 }
 
 // StringSliceContains - does the given string slice contain the specified string?


### PR DESCRIPTION
@kflan-io @dfeldick @vivekschauhan @jcollins-axway 
Please review.  Changing the return to hostname so it only returns the host portion of the url