### PR TITLE
APIGOV-17949 - update resource version

### DIFF
--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -41,6 +41,7 @@ func (c *ServiceClient) buildAPIServiceResource(serviceBody *ServiceBody, servic
 }
 
 func (c *ServiceClient) updateAPIServiceResource(apiSvc *v1alpha1.APIService, serviceBody *ServiceBody) {
+	apiSvc.ResourceMeta.Metadata.ResourceVersion = ""
 	apiSvc.Title = serviceBody.NameToPush
 	apiSvc.ResourceMeta.Attributes = c.buildAPIResourceAttributes(serviceBody, apiSvc.ResourceMeta.Attributes, true)
 	apiSvc.ResourceMeta.Tags = c.mapToTagsArray(serviceBody.Tags)

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -36,6 +36,7 @@ func (c *ServiceClient) buildAPIServiceInstanceResource(serviceBody *ServiceBody
 }
 
 func (c *ServiceClient) updateInstanceResource(instance *v1alpha1.APIServiceInstance, serviceBody *ServiceBody, endpoints []v1alpha1.ApiServiceInstanceSpecEndpoint) {
+	instance.ResourceMeta.Metadata.ResourceVersion = ""
 	instance.Title = serviceBody.NameToPush
 	instance.Attributes = c.buildAPIResourceAttributes(serviceBody, instance.Attributes, false)
 	instance.Tags = c.mapToTagsArray(serviceBody.Tags)

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -38,6 +38,7 @@ func (c *ServiceClient) buildAPIServiceRevisionResource(serviceBody *ServiceBody
 }
 
 func (c *ServiceClient) updateRevisionResource(revision *v1alpha1.APIServiceRevision, serviceBody *ServiceBody) {
+	revision.ResourceMeta.Metadata.ResourceVersion = ""
 	revision.Title = serviceBody.NameToPush
 	revision.ResourceMeta.Attributes = c.buildAPIResourceAttributes(serviceBody, revision.ResourceMeta.Attributes, false)
 	revision.ResourceMeta.Tags = c.mapToTagsArray(serviceBody.Tags)

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -240,6 +240,7 @@ func (c *ServiceClient) updateEnvironmentStatus(apiEnvironment *v1alpha1.Environ
 		return nil
 	}
 	apiEnvironment.Attributes[attribute] = "true"
+	apiEnvironment.ResourceMeta.Metadata.ResourceVersion = ""
 
 	buffer, err := json.Marshal(apiEnvironment)
 	if err != nil {

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -79,11 +79,12 @@ func (c *ServiceClient) buildConsumerInstance(serviceBody *ServiceBody, consumer
 	}
 }
 
-func (c *ServiceClient) updateConsumerInstanceResource(revision *v1alpha1.ConsumerInstance, serviceBody *ServiceBody, doc string) {
-	revision.Title = serviceBody.NameToPush
-	revision.ResourceMeta.Attributes = c.buildAPIResourceAttributes(serviceBody, revision.ResourceMeta.Attributes, false)
-	revision.ResourceMeta.Tags = c.mapToTagsArray(serviceBody.Tags)
-	revision.Spec = c.buildConsumerInstanceSpec(serviceBody, doc)
+func (c *ServiceClient) updateConsumerInstanceResource(consumerInstance *v1alpha1.ConsumerInstance, serviceBody *ServiceBody, doc string) {
+	consumerInstance.ResourceMeta.Metadata.ResourceVersion = ""
+	consumerInstance.Title = serviceBody.NameToPush
+	consumerInstance.ResourceMeta.Attributes = c.buildAPIResourceAttributes(serviceBody, consumerInstance.ResourceMeta.Attributes, false)
+	consumerInstance.ResourceMeta.Tags = c.mapToTagsArray(serviceBody.Tags)
+	consumerInstance.Spec = c.buildConsumerInstanceSpec(serviceBody, doc)
 }
 
 //processConsumerInstance - deal with either a create or update of a consumerInstance


### PR DESCRIPTION
Set resource version in PUTs for
apiservice
apiservicerevision
apiserviceinstance
consumerinstance

@vivekschauhan @jcollins-axway  I also updated resource version in client.  However, Vivek, jason and I was a part of a meeting with Seby, Chandan, and Ashutosh... talking about removing the xj-axway-agent env var.  Somehow they are seeing this being set multiple times past agent startup...  We are thinking at this point, we can remove this code.  We can discuss.

Along with that, do you think we need to update the following?
service.go
- line 262
- line 330

subscriptionschema.go
-line 170.

In these instances, we are doing a POST before doing a PUT.  I know you said maybe we need to do a GET on the object first...  what are your thoughts?  The above changes are necessary... what about the service.go and subscripitonschema.go