### PR TITLE
APIGOV-18001 - oas2 and oas3 endpoint validation

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -36,7 +36,7 @@
 | 1156 | error updating subscription definition properties in AMPLIFY Central                                        | pkg/apic/ErrUpdateSubscriptionDefProperties         |
 | 1157 | error getting catalog item API server info properties                                                       | pkg/apic/ErrGetCatalogItemServerInfoProperties      |
 | 1158 | subscription manager is not in a running state                                                              | pkg/apic/ErrSubscriptionManagerDown                 |
-| 1160 | error getting endpoints for %s spec                                                                         | pkg/apic/ErrSetOasEndPoints                         |
+| 1160 | error getting endpoints for the API specification                                                           | pkg/apic/ErrSetSpecEndPoints                        |
 |      | 1300-1399 - for subscription notification errors                                                            |                                                     |
 | 1300 | error communicating with server for subscription notifications (SMTP or webhook), check SUBSCRIPTION config | pkg/notify/ErrSubscriptionNotification              |
 | 1301 | subscription notifications not configured, check SUBSCRIPTION config                                        | pkg/notify/ErrSubscriptionNoNotifications           |

--- a/errors.md
+++ b/errors.md
@@ -36,8 +36,7 @@
 | 1156 | error updating subscription definition properties in AMPLIFY Central                                        | pkg/apic/ErrUpdateSubscriptionDefProperties         |
 | 1157 | error getting catalog item API server info properties                                                       | pkg/apic/ErrGetCatalogItemServerInfoProperties      |
 | 1158 | subscription manager is not in a running state                                                              | pkg/apic/ErrSubscriptionManagerDown                 |
-| 1160 | error getting endpoints for oas2 spec                                                                       | pkg/apic/ErrSetOas2EndPoints                        |
-| 1161 | error getting endpoints for oas3 spec                                                                       | pkg/apic/ErrSetOas3EndPoints                        |
+| 1160 | error getting endpoints for %s spec                                                                         | pkg/apic/ErrSetOasEndPoints                         |
 |      | 1300-1399 - for subscription notification errors                                                            |                                                     |
 | 1300 | error communicating with server for subscription notifications (SMTP or webhook), check SUBSCRIPTION config | pkg/notify/ErrSubscriptionNotification              |
 | 1301 | subscription notifications not configured, check SUBSCRIPTION config                                        | pkg/notify/ErrSubscriptionNoNotifications           |

--- a/errors.md
+++ b/errors.md
@@ -36,6 +36,8 @@
 | 1156 | error updating subscription definition properties in AMPLIFY Central                                        | pkg/apic/ErrUpdateSubscriptionDefProperties         |
 | 1157 | error getting catalog item API server info properties                                                       | pkg/apic/ErrGetCatalogItemServerInfoProperties      |
 | 1158 | subscription manager is not in a running state                                                              | pkg/apic/ErrSubscriptionManagerDown                 |
+| 1160 | error getting endpoints for oas2 spec                                                                       | pkg/apic/ErrSetOas2EndPoints                        |
+| 1161 | error getting endpoints for oas3 spec                                                                       | pkg/apic/ErrSetOas3EndPoints                        |
 |      | 1300-1399 - for subscription notification errors                                                            |                                                     |
 | 1300 | error communicating with server for subscription notifications (SMTP or webhook), check SUBSCRIPTION config | pkg/notify/ErrSubscriptionNotification              |
 | 1301 | subscription notifications not configured, check SUBSCRIPTION config                                        | pkg/notify/ErrSubscriptionNoNotifications           |

--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -42,7 +42,6 @@ func GetAttributeOnPublishedAPI(externalAPIID string, attrName string) string {
 
 // PublishAPI - Publishes the API
 func PublishAPI(serviceBody apic.ServiceBody) error {
-	var err error
 	if agent.apicClient != nil {
 		ret, err := agent.apicClient.PublishService(serviceBody)
 		if err == nil {
@@ -50,9 +49,11 @@ func PublishAPI(serviceBody apic.ServiceBody) error {
 			if e == nil {
 				addItemToAPICache(*apiSvc)
 			}
+		} else {
+			return err
 		}
 	}
-	return err
+	return nil
 }
 
 // RegisterAPIValidator - Registers callback for validating the API on gateway

--- a/pkg/apic/errors.go
+++ b/pkg/apic/errors.go
@@ -32,6 +32,5 @@ var (
 	ErrSubscriptionManagerDown            = errors.New(1158, "subscription manager is not running")
 
 	// Service body builer
-	ErrSetOas2EndPoints = errors.New(1160, "error getting endpoints for oas2 spec")
-	ErrSetOas3EndPoints = errors.New(1161, "error getting endpoints for oas3 spec")
+	ErrSetOasEndPoints = errors.Newf(1160, "error getting endpoints for %s spec")	
 )

--- a/pkg/apic/errors.go
+++ b/pkg/apic/errors.go
@@ -32,5 +32,5 @@ var (
 	ErrSubscriptionManagerDown            = errors.New(1158, "subscription manager is not running")
 
 	// Service body builer
-	ErrSetOasEndPoints = errors.Newf(1160, "error getting endpoints for %s spec")	
+	ErrSetSpecEndPoints = errors.New(1160, "error getting endpoints for the API specification")	
 )

--- a/pkg/apic/errors.go
+++ b/pkg/apic/errors.go
@@ -30,4 +30,8 @@ var (
 	ErrUpdateSubscriptionDefProperties    = errors.New(1156, "error updating subscription definition properties in AMPLIFY Central")
 	ErrGetCatalogItemServerInfoProperties = errors.New(1157, "error getting catalog item API server info properties")
 	ErrSubscriptionManagerDown            = errors.New(1158, "subscription manager is not running")
+
+	// Service body builer
+	ErrSetOas2EndPoints = errors.New(1160, "error getting endpoints for oas2 spec")
+	ErrSetOas3EndPoints = errors.New(1161, "error getting endpoints for oas3 spec")
 )

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -48,7 +48,7 @@ func (p *oas2SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 			}
 			endPoints = append(endPoints, endPoint)
 		} else {
-			return nil, ErrSetOasEndPoints.FormatError("oas2")
+			return nil, ErrSetSpecEndPoints
 		}
 		
 	}

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -28,14 +28,30 @@ func (p *oas2SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 			port = swaggerPort
 		}
 	}
-	for _, protocol := range p.spec.Schemes {
-		endPoint := EndpointDefinition{
-			Host:     host,
-			Port:     int32(port),
-			Protocol: protocol,
-			BasePath: p.spec.BasePath,
+	if len(p.spec.Schemes) > 0 {
+		for _, protocol := range p.spec.Schemes {
+			endPoint := EndpointDefinition{
+				Host:     host,
+				Port:     int32(port),
+				Protocol: protocol,
+				BasePath: p.spec.BasePath,
+			}
+			endPoints = append(endPoints, endPoint)
 		}
-		endPoints = append(endPoints, endPoint)
+	} else {
+		if host != "" {
+			endPoint := EndpointDefinition{
+				Host:     host,
+				Port:     int32(port),
+				Protocol: "https",
+				BasePath: p.spec.BasePath,
+			}
+			endPoints = append(endPoints, endPoint)
+		} else {
+			return nil, ErrSetOas2EndPoints
+		}
+		
 	}
+	
 	return endPoints, nil
 }

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -48,7 +48,7 @@ func (p *oas2SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 			}
 			endPoints = append(endPoints, endPoint)
 		} else {
-			return nil, ErrSetOas2EndPoints
+			return nil, ErrSetOasEndPoints.FormatError("oas2")
 		}
 		
 	}

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -25,29 +25,33 @@ func (p *oas3SpecProcessor) getResourceType() string {
 
 func (p *oas3SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 	endPoints := []EndpointDefinition{}
-	for _, server := range p.spec.Servers {
-		// Add the URL string to the array
-		allURLs := []string{
-			server.URL,
-		}
-
-		defaultURL := ""
-		var err error
-		if server.Variables != nil {
-			defaultURL, allURLs, err = p.handleURLSubstitutions(server, allURLs)
+	if len(p.spec.Servers) > 0 {
+		for _, server := range p.spec.Servers {
+			// Add the URL string to the array
+			allURLs := []string{
+				server.URL,
+			}
+	
+			defaultURL := ""
+			var err error
+			if server.Variables != nil {
+				defaultURL, allURLs, err = p.handleURLSubstitutions(server, allURLs)
+				if err != nil {
+					return nil, err
+				}
+			}
+	
+			parsedEndPoints, err := p.parseURLsIntoEndpoints(defaultURL, allURLs)
 			if err != nil {
 				return nil, err
 			}
+			endPoints = append(endPoints, parsedEndPoints...)
 		}
-
-		parsedEndPoints, err := p.parseURLsIntoEndpoints(defaultURL, allURLs)
-		if err != nil {
-			return nil, err
-		}
-		endPoints = append(endPoints, parsedEndPoints...)
-	}
-
-	return endPoints, nil
+	
+		return endPoints, nil
+	} 
+	
+	return nil, ErrSetOas3EndPoints
 }
 
 func (p *oas3SpecProcessor) handleURLSubstitutions(server *openapi3.Server, allURLs []string) (string, []string, error) {

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -51,7 +51,7 @@ func (p *oas3SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 		return endPoints, nil
 	} 
 	
-	return nil, ErrSetOas3EndPoints
+	return nil, ErrSetOasEndPoints.FormatError("oas3")
 }
 
 func (p *oas3SpecProcessor) handleURLSubstitutions(server *openapi3.Server, allURLs []string) (string, []string, error) {

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -51,7 +51,7 @@ func (p *oas3SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 		return endPoints, nil
 	} 
 	
-	return nil, ErrSetOasEndPoints.FormatError("oas3")
+	return nil, ErrSetSpecEndPoints
 }
 
 func (p *oas3SpecProcessor) handleURLSubstitutions(server *openapi3.Server, allURLs []string) (string, []string, error) {


### PR DESCRIPTION
@vivekschauhan @jcollins-axway @dfeldick @kflan-io please review

oas2 and oas3 require endpoint validation. 
oas2 - check to see if schemes are empty.  If empty try and create endpoint.  If endpoint cannot be created, throw error
oas3 - check to see if servers are empty.  If empty, throw an error

