### PR TITLE
APIGOV-18214 - sonar fixes

### DIFF
--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -153,30 +153,34 @@ func validateConsumerInstances() {
 		consumerInstances := make([]apiV1.ResourceInstance, 0)
 		json.Unmarshal(response, &consumerInstances)
 
-		// Validate the API on dataplane, if not valid mark the consumer instance as "DELETED"
-		for _, consumerInstanceResource := range consumerInstances {
-			consumerInstance := &v1alpha1.ConsumerInstance{}
-			consumerInstance.FromInstance(&consumerInstanceResource)
-			externalAPIID := consumerInstance.Attributes[apic.AttrExternalAPIID]
-			externalAPIStage := consumerInstance.Attributes[apic.AttrExternalAPIStage]
-			// Check if the consumer instance was published by agent, i.e. following attributes are set
-			// - externalAPIID should not be empty
-			// - externalAPIStage could be empty for dataplanes that do not support it
-			if externalAPIID != "" && !agent.apiValidator(externalAPIID, externalAPIStage) {
-				log.Infof("API deleted from dataplane, deleting the catalog item %s from AMPLIFY Central", consumerInstance.Title)
-				err = agent.apicClient.DeleteConsumerInstance(consumerInstance.Name)
-				if err != nil {
-					log.Errorf("Unable to delete catalog item %s from AMPLIFY Central, %s", consumerInstance.Title, err.Error())
-				} else {
-					log.Infof("Deleted catalog item %s from AMPLIFY Central", consumerInstance.Title)
-				}
-			}
-		}
+		validateAPIOnDataplane(consumerInstances)
 
 		if len(consumerInstances) < apiServerPageSize {
 			morePages = false
 		}
 		page++
+	}
+}
+
+func validateAPIOnDataplane(consumerInstances []apiV1.ResourceInstance) {
+	// Validate the API on dataplane.  If API is not valid, mark the consumer instance as "DELETED"
+	for _, consumerInstanceResource := range consumerInstances {
+		consumerInstance := &v1alpha1.ConsumerInstance{}
+		consumerInstance.FromInstance(&consumerInstanceResource)
+		externalAPIID := consumerInstance.Attributes[apic.AttrExternalAPIID]
+		externalAPIStage := consumerInstance.Attributes[apic.AttrExternalAPIStage]
+		// Check if the consumer instance was published by agent, i.e. following attributes are set
+		// - externalAPIID should not be empty
+		// - externalAPIStage could be empty for dataplanes that do not support it
+		if externalAPIID != "" && !agent.apiValidator(externalAPIID, externalAPIStage) {
+			log.Infof("API deleted from dataplane, deleting the catalog item %s from AMPLIFY Central", consumerInstance.Title)
+			err := agent.apicClient.DeleteConsumerInstance(consumerInstance.Name)
+			if err != nil {
+				log.Errorf("Unable to delete catalog item %s from AMPLIFY Central, %s", consumerInstance.Title, err.Error())
+			} else {
+				log.Infof("Deleted catalog item %s from AMPLIFY Central", consumerInstance.Title)
+			}
+		}
 	}
 }
 

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -41,7 +41,7 @@ func (p *oas2SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 	// If schemes are specified create endpoint for each scheme
 	if len(p.spec.Schemes) > 0 {
 		for _, protocol := range p.spec.Schemes {
-			if validOA2Schemes[protocol] != true {
+			if !validOA2Schemes[protocol] {
 				return nil, coreerrors.Wrap(ErrSetSpecEndPoints, "invalid endpoint scheme defined in specification")
 			}
 			endPoint := createEndpointDefinition(protocol, host, port, p.spec.BasePath)

--- a/pkg/config/logconfig.go
+++ b/pkg/config/logconfig.go
@@ -98,18 +98,22 @@ func ParseAndSetupLogConfig(props properties.Properties) (LogConfig, error) {
 	return cfg, cfg.setupLogger()
 }
 
+const (
+	logLevelYAMLPath       = "logging.level"
+	logJSONYAMLPath        = "logging.json"
+	logSTDERRYAMLPath      = "logging.to_stderr"
+	logFileYAMLPath        = "logging.to_files"
+	logFilePermissionsPath = "logging.files.permissions"
+)
+
 //LogConfigOverrides - override the filebeat config options
 func LogConfigOverrides() []cfgfile.ConditionalOverride {
 	overrides := make([]cfgfile.ConditionalOverride, 0)
+	overrides = setLogLevel(overrides)
+	return overrideLogLevel(overrides)
+}
 
-	const (
-		logLevelYAMLPath       = "logging.level"
-		logJSONYAMLPath        = "logging.json"
-		logSTDERRYAMLPath      = "logging.to_stderr"
-		logFileYAMLPath        = "logging.to_files"
-		logFilePermissionsPath = "logging.files.permissions"
-	)
-
+func setLogLevel(overrides []cfgfile.ConditionalOverride) []cfgfile.ConditionalOverride {
 	// Set level to info
 	overrides = append(overrides, cfgfile.ConditionalOverride{
 		Check: func(cfg *common.Config) bool {
@@ -158,6 +162,10 @@ func LogConfigOverrides() []cfgfile.ConditionalOverride {
 		}),
 	})
 
+	return overrides
+}
+
+func overrideLogLevel(overrides []cfgfile.ConditionalOverride) []cfgfile.ConditionalOverride {
 	// Override the level to debug, if trace or debug
 	overrides = append(overrides, cfgfile.ConditionalOverride{
 		Check: func(cfg *common.Config) bool {
@@ -219,5 +227,6 @@ func LogConfigOverrides() []cfgfile.ConditionalOverride {
 			logFilePermissionsPath: "0600",
 		}),
 	})
+
 	return overrides
 }


### PR DESCRIPTION
fix the following sonar issues

pkg/agent/discoverycache.go
Refactor this function to reduce its Cognitive Complexity from 17 to the 15 allowed.

pkg/apic/specoas2processor.go
Remove this redundant boolean literal

pkg/config/logconfig.go
Refactor this function to reduce its Cognitive Complexity from 20 to the 15 allowed.