### PR TITLE
APIGOV-18147 - unidentified inbound policy

### DIFF
--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -133,9 +133,11 @@ func (c *ServiceClient) updateConsumerInstanceResource(consumerInstance *v1alpha
 //processConsumerInstance - deal with either a create or update of a consumerInstance
 func (c *ServiceClient) processConsumerInstance(serviceBody *ServiceBody) error {
 
+	// Allow catalog asset to be created.  However, set to pass-through so subscriptions aren't enabled
 	if !isValidAuthPolicy(serviceBody.AuthPolicy) {
-		log.Warnf("'%s' has an inbound policy of (%s) and is not supported. Catalog asset will not be created. ", serviceBody.APIName, serviceBody.AuthPolicy)
-		return nil
+		log.Warnf("'%s' has an inbound policy of (%s) and is not supported. Catalog asset will be created with a pass-through inbound policy. ", serviceBody.APIName, serviceBody.AuthPolicy)
+		serviceBody.AuthPolicy = Passthrough
+		serviceBody.Status = UnidentifiedInboundPolicy
 	}
 
 	var doc = ""

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -51,9 +51,10 @@ const (
 
 // consts for status
 const (
-	DeprecatedStatus  = "DEPRECATED"
-	PublishedStatus   = "PUBLISHED"
-	UnpublishedStatus = "UNPUBLISHED"
+	DeprecatedStatus          = "DEPRECATED"
+	PublishedStatus           = "PUBLISHED"
+	UnpublishedStatus         = "UNPUBLISHED"
+	UnidentifiedInboundPolicy = "Unidentified Inbound Policy"
 )
 
 // consts for update serverity

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -54,7 +54,7 @@ const (
 	DeprecatedStatus          = "DEPRECATED"
 	PublishedStatus           = "PUBLISHED"
 	UnpublishedStatus         = "UNPUBLISHED"
-	UnidentifiedInboundPolicy = "Unidentified Inbound Policy"
+	UnidentifiedInboundPolicy = "UNIDENTIFIED INBOUND POLICY"
 )
 
 // consts for update serverity


### PR DESCRIPTION
Current valid policies {"verify-api-key", "pass-through", "verify-oauth-token"}
If policy is not valid, still allow the catalog asset to be created.  However, do not allow subscription.  Set auth policy and status on serviceBody.  Auth policy "pass-through" is not allowed subscriptions.