### PR TITLE
APIGOV-18327 - set req.Close to true

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -161,6 +161,9 @@ func (c *httpClient) Send(request Request) (*Response, error) {
 		cancel()
 	})
 
+	// Prevent reuse of the tcp connection to the same host
+	req.Close = true
+
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Set request Close to true.  For client requests, setting this field prevents re-use of TCP connections between requests to the same hosts