### PR TITLE
INT-00000 - expose real error

### DIFF
--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -84,9 +84,9 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 			}
 		}
 		return err
-	} else {
-		serviceBody.serviceContext.currentInstance = instanceName
 	}
+
+	serviceBody.serviceContext.currentInstance = instanceName
 
 	return err
 }

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -2,6 +2,7 @@ package apic
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -79,10 +80,10 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 		if serviceBody.serviceContext.serviceAction == addAPI {
 			_, rollbackErr := c.rollbackAPIService(*serviceBody, serviceBody.serviceContext.serviceName)
 			if rollbackErr != nil {
-				err = rollbackErr
+				return errors.New(err.Error() + rollbackErr.Error())
 			}
-			return err
 		}
+		return err
 	} else {
 		serviceBody.serviceContext.currentInstance = instanceName
 	}

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -88,9 +88,9 @@ func (c *ServiceClient) processRevision(serviceBody *ServiceBody) error {
 			}
 		}
 		return err
-	} else {
-		serviceBody.serviceContext.currentRevision = revisionName
 	}
+
+	serviceBody.serviceContext.currentRevision = revisionName
 
 	return nil
 }

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -3,6 +3,7 @@ package apic
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -83,10 +84,10 @@ func (c *ServiceClient) processRevision(serviceBody *ServiceBody) error {
 		if serviceBody.serviceContext.serviceAction == addAPI {
 			_, rollbackErr := c.rollbackAPIService(*serviceBody, serviceBody.serviceContext.serviceName)
 			if rollbackErr != nil {
-				err = rollbackErr
+				return errors.New(err.Error() + rollbackErr.Error())
 			}
-			return err
 		}
+		return err
 	} else {
 		serviceBody.serviceContext.currentRevision = revisionName
 	}

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -184,13 +184,14 @@ func (c *ServiceClient) processConsumerInstance(serviceBody *ServiceBody) error 
 		if serviceBody.serviceContext.serviceAction == addAPI {
 			_, rollbackErr := c.rollbackAPIService(*serviceBody, serviceBody.serviceContext.serviceName)
 			if rollbackErr != nil {
-				err = rollbackErr
+				return errors.New(err.Error() + rollbackErr.Error())
 			}
-			return err
 		}
+		return err
 	} else {
 		serviceBody.serviceContext.consumerInstance = consumerInstanceName
 	}
+
 	return err
 }
 

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -188,9 +188,9 @@ func (c *ServiceClient) processConsumerInstance(serviceBody *ServiceBody) error 
 			}
 		}
 		return err
-	} else {
-		serviceBody.serviceContext.consumerInstance = consumerInstanceName
 	}
+
+	serviceBody.serviceContext.consumerInstance = consumerInstanceName
 
 	return err
 }


### PR DESCRIPTION
Expose the real error from apiServiceDeployAPI.  Before this fix, the err was getting eaten and not returning.  Now, if apiServiceDeployAPI returns an err, we try to rollback.  

If addAPI && rollback returns an error, we concat rollback err and apiServiceDeployAPI  error and return that.  

If !addAPI or no error on rollback, we return the (real) apiServiceDeployAPI err.