### PR TITLE
APIGOV-18754 - Initializing start time to be minute behind for initial usage report generation

### DIFF
--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -540,6 +540,10 @@ func (c *CentralConfiguration) validateTraceabilityAgentConfig() {
 	if c.GetReportActivityFrequency() <= 0 {
 		exception.Throw(ErrBadConfig.FormatError(pathReportActivityFrequency))
 	}
+	eventAggSeconds := c.GetEventAggregationInterval().Milliseconds()
+	if eventAggSeconds < 60000 {
+		exception.Throw(ErrBadConfig.FormatError(pathEventAggregationInterval))
+	}
 }
 
 // AddCentralConfigProperties - Adds the command properties needed for Central Config

--- a/pkg/config/centralconfig_test.go
+++ b/pkg/config/centralconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -109,9 +110,15 @@ func TestTraceabilityAgentConfig(t *testing.T) {
 	assert.Equal(t, "[Error Code 1401] - error with config central.environment, please set and/or check its value", err.Error())
 
 	centralConfig.Environment = "111111"
-	err = cfgValidator.ValidateCfg()
+	centralConfig.EventAggregationInterval = 30 * time.Second
 
+	err = cfgValidator.ValidateCfg()
 	assert.Equal(t, "https://platform.axway.com", centralConfig.PlatformURL)
+	assert.NotNil(t, err)
+	assert.Equal(t, "[Error Code 1401] - error with config central.eventAggregationInterval, please set and/or check its value", err.Error())
+
+	centralConfig.EventAggregationInterval = 1 * time.Minute
+	err = cfgValidator.ValidateCfg()
 	assert.Nil(t, err)
 
 	centralConfig.ReportActivityFrequency = 0

--- a/pkg/transaction/eventgenerator_test.go
+++ b/pkg/transaction/eventgenerator_test.go
@@ -30,6 +30,7 @@ func createMapperTestConfig(authURL, tenantID, apicDeployment, envName, envID st
 			Environment:               envName,
 			APIServerVersion:          "v1alpha1",
 			SubscriptionConfiguration: corecfg.NewSubscriptionConfig(),
+			EventAggregationInterval:  5 * time.Minute,
 			ReportActivityFrequency:   2 * time.Minute,
 			Auth: &corecfg.AuthConfiguration{
 				URL:        authURL,

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -33,7 +33,9 @@ type collector struct {
 // NewMetricCollector - Create metric collector
 func NewMetricCollector(eventChannel chan interface{}) Collector {
 	metricCollector := &collector{
-		startTime:    time.Now(),
+		// Set the initial start time to be minimum 1m behind, so that the job can generate valid event
+		// if any usage event are to be generated on startup
+		startTime:    time.Now().Add(-1 * time.Minute),
 		lock:         &sync.Mutex{},
 		registry:     metrics.NewRegistry(),
 		metricMap:    make(map[string]map[string]*APIMetric),


### PR DESCRIPTION
Initializing start time to be minute behind for initial usage report generation
Added validation for event aggregation interval config