### PR TITLE
APIGOV-00000 - create getters for platform user info and user name

### DIFF
--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -46,6 +46,8 @@ func (m *mockSvcClient) GetConsumerInstanceByID(consumerInstanceID string) (*v1a
 func (m *mockSvcClient) GetConsumerInstancesByExternalAPIID(consumerInstanceID string) ([]*v1alpha1.ConsumerInstance, error) {
 	return nil, nil
 }
+
+func (m *mockSvcClient) GetUserName(ID string) (string, error)         { return "", nil }
 func (m *mockSvcClient) GetUserEmailAddress(ID string) (string, error) { return "", nil }
 func (m *mockSvcClient) GetSubscriptionsForCatalogItem(states []string, instanceID string) ([]apic.CentralSubscription, error) {
 	return nil, nil

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -49,7 +49,6 @@ type Client interface {
 	GetConsumerInstanceByID(consumerInstanceID string) (*v1alpha1.ConsumerInstance, error)
 	GetConsumerInstancesByExternalAPIID(externalAPIID string) ([]*v1alpha1.ConsumerInstance, error)
 	UpdateConsumerInstanceSubscriptionDefinition(externalAPIID, subscriptionDefinitionName string) error
-	GetPlatformUserInfo(ID string) (*PlatformUserInfo, error)
 	GetUserEmailAddress(ID string) (string, error)
 	GetUserName(ID string) (string, error)
 	GetSubscriptionsForCatalogItem(states []string, catalogItemID string) ([]CentralSubscription, error)
@@ -318,7 +317,7 @@ func (c *ServiceClient) sendServerRequest(url string, headers, query map[string]
 }
 
 // GetPlatformUserInfo - request the platform user info
-func (c *ServiceClient) GetPlatformUserInfo(id string) (*PlatformUserInfo, error) {
+func (c *ServiceClient) getPlatformUserInfo(id string) (*PlatformUserInfo, error) {
 	headers, err := c.createHeader()
 	if err != nil {
 		return nil, err
@@ -347,7 +346,7 @@ func (c *ServiceClient) GetPlatformUserInfo(id string) (*PlatformUserInfo, error
 // GetUserEmailAddress - request the user email
 func (c *ServiceClient) GetUserEmailAddress(id string) (string, error) {
 
-	platformUserInfo, err := c.GetPlatformUserInfo(id)
+	platformUserInfo, err := c.getPlatformUserInfo(id)
 	if err != nil {
 		return "", err
 	}
@@ -361,7 +360,7 @@ func (c *ServiceClient) GetUserEmailAddress(id string) (string, error) {
 // GetUserName - request the user name
 func (c *ServiceClient) GetUserName(id string) (string, error) {
 
-	platformUserInfo, err := c.GetPlatformUserInfo(id)
+	platformUserInfo, err := c.getPlatformUserInfo(id)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apic/client_test.go
+++ b/pkg/apic/client_test.go
@@ -126,6 +126,38 @@ func TestGetUserEmailAddress(t *testing.T) {
 	assert.Equal(t, "", addr)
 }
 
+func TestGetUserName(t *testing.T) {
+	svcClient, mockHTTPClient := GetTestServiceClient()
+
+	cfg := GetTestServiceClientCentralConfiguration(svcClient)
+	cfg.Environment = "Environment"
+	cfg.PlatformURL = "http://foo.bar:4080"
+
+	// Test DiscoveryAgent, PublishToEnvironment
+	mockHTTPClient.SetResponses([]api.MockResponse{
+		{
+			FileName: "./testdata/userinfo.json",
+			RespCode: http.StatusOK,
+		},
+	})
+
+	userName, err := svcClient.GetUserName("b0433b7f-ac38-4d29-8a64-cf645c99b99f")
+	assert.Nil(t, err)
+	assert.Equal(t, "Dale Feldick", userName)
+
+	// test a failure
+	mockHTTPClient.SetResponses([]api.MockResponse{
+		{FileName: "./testdata/userinfoerror.json",
+			RespCode:  http.StatusNotFound,
+			ErrString: "Resource Not Found",
+		},
+	})
+
+	userName, err = svcClient.GetUserName("b0433b7f-ac38-4d29-8a64-cf645c99b99g")
+	assert.NotNil(t, err)
+	assert.Equal(t, "", userName)
+}
+
 func TestHealthCheck(t *testing.T) {
 	svcClient, mockHTTPClient := GetTestServiceClient()
 	requester := svcClient.tokenRequester


### PR DESCRIPTION
Prep work for dave's demo.  Created getter for platform user info and user name.
I made the getter for the platform info private.  But we can make it public and then let the calling function grab whatever they want from the user info.  

For now, i kept the email getter, created a user name getter and just make the get platform user info generic.