### PR TITLE
APIGOV-18737 - Changes to reset usage/metric counter on successful publish

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -29,6 +29,11 @@ func RegisterRetryJob(newJob Job, retries int) (string, error) {
 	return globalPool.RegisterRetryJob(newJob, retries)
 }
 
+//UnregisterJob - Removes the specified job in the globalPool
+func UnregisterJob(jobID string) {
+	globalPool.UnregisterJob(jobID)
+}
+
 //JobLock - Locks the job, returns when the lock is granted
 func JobLock(id string) {
 	globalPool.JobLock(id)

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -73,6 +73,17 @@ func (p *Pool) recordCronJob(job JobExecution) string {
 	return p.recordJob(job)
 }
 
+//recordJob - Removes the specified job from jobs map
+func (p *Pool) removeJob(jobID string) {
+	p.jobsMapLock.Lock()
+	defer p.jobsMapLock.Unlock()
+	job, ok := p.jobs[jobID]
+	if ok {
+		job.stop()
+		delete(p.jobs, jobID)
+	}
+}
+
 //RegisterSingleRunJob - Runs a single run job
 func (p *Pool) RegisterSingleRunJob(newJob Job) (string, error) {
 	job, err := newBaseJob(newJob, p.failJobChan)
@@ -107,6 +118,11 @@ func (p *Pool) RegisterRetryJob(newJob Job, retries int) (string, error) {
 		return "", err
 	}
 	return p.recordJob(job), nil
+}
+
+//UnregisterJob - Removes the specified job
+func (p *Pool) UnregisterJob(jobID string) {
+	p.removeJob(jobID)
 }
 
 //GetJob - Returns the Job based on the id

--- a/pkg/traceability/sampling/sampling_test.go
+++ b/pkg/traceability/sampling/sampling_test.go
@@ -184,6 +184,7 @@ func TestShouldSample(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			waitGroup := sync.WaitGroup{}
+			sampleCounterLock := sync.Mutex{}
 			err := SetupSampling(test.config)
 			assert.Nil(t, err)
 
@@ -201,7 +202,9 @@ func TestShouldSample(t *testing.T) {
 						}
 						sample, err := ShouldSampleTransaction(testDetails)
 						if sample {
+							sampleCounterLock.Lock()
 							sampled++
+							sampleCounterLock.Unlock()
 						}
 						assert.Nil(t, err)
 					}

--- a/pkg/transaction/eventgenerator.go
+++ b/pkg/transaction/eventgenerator.go
@@ -2,7 +2,6 @@ package transaction
 
 import (
 	"encoding/json"
-	"flag"
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
@@ -27,7 +26,6 @@ type EventGenerator interface {
 // Generator - Create the events to be published to Condor
 type Generator struct {
 	shouldAddFields bool
-	collector       metric.Collector
 }
 
 // NewEventGenerator - Create a new event generator
@@ -36,11 +34,6 @@ func NewEventGenerator() EventGenerator {
 		shouldAddFields: !traceability.IsHTTPTransport(),
 	}
 	hc.RegisterHealthcheck("Event Generator", "eventgen", eventGen.healthcheck)
-	if flag.Lookup("test.v") == nil {
-		metricEventChannel := make(chan interface{})
-		eventGen.collector = metric.NewMetricCollector(metricEventChannel)
-		metric.NewMetricPublisher(metricEventChannel)
-	}
 	return eventGen
 }
 
@@ -77,8 +70,9 @@ func (e *Generator) createEvent(logEvent LogEvent, eventTime time.Time, metaData
 		if logEvent.TransactionSummary.Team != nil {
 			teamName = logEvent.TransactionSummary.Team.ID
 		}
-		if e.collector != nil {
-			e.collector.AddMetric(apiID, apiName, statusCode, int64(duration), appName, teamName)
+		collector := metric.GetMetricCollector()
+		if collector != nil {
+			collector.AddMetric(apiID, apiName, statusCode, int64(duration), appName, teamName)
 		}
 	}
 

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -28,6 +28,7 @@ type APIMetric struct {
 	Count       int64              `json:"count"`
 	Response    ResponseMetrics    `json:"response"`
 	Observation ObservationDetails `json:"observation"`
+	StartTime   time.Time          `json:"-"`
 }
 
 // V4EventDistribution - represents V7 distribution

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -90,10 +90,8 @@ var globalMetricCollector Collector
 
 // GetMetricCollector - Create metric collector
 func GetMetricCollector() Collector {
-	if globalMetricCollector == nil {
-		if flag.Lookup("test.v") == nil {
-			globalMetricCollector = createMetricCollector()
-		}
+	if globalMetricCollector == nil && flag.Lookup("test.v") == nil {
+		globalMetricCollector = createMetricCollector()
 	}
 	return globalMetricCollector
 }

--- a/pkg/transaction/metric/metricspublisher.go
+++ b/pkg/transaction/metric/metricspublisher.go
@@ -3,68 +3,44 @@ package metric
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"strconv"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
 	"github.com/Axway/agent-sdk/pkg/api"
-	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/google/uuid"
 )
 
-// Publisher - interface for metric publisher
-type Publisher interface {
-	jobs.Job
+// publisher - interface for metric publisher
+type publisher interface {
+	publishEvent(event interface{}) error
 }
 
-type publisher struct {
-	apiClient    api.Client
-	eventChannel chan interface{}
+type metricPublisher struct {
+	apiClient api.Client
 }
 
-// Status - returns the status of publisher job
-func (pj *publisher) Status() error {
+func (pj *metricPublisher) publishEvent(event interface{}) error {
+	lighthouseUsageEvent, ok := event.(LighthouseUsageEvent)
+	if ok {
+		return pj.publishToLighthouse(lighthouseUsageEvent)
+	}
+	log.Error("event was not a lighthouse event")
 	return nil
 }
 
-// Ready - indicates the publisher is ready to process
-func (pj *publisher) Ready() bool {
-	return true
-}
-
-// Execute - process the publishing of events sent on event channel
-func (pj *publisher) Execute() error {
-	for {
-		select {
-		case event, ok := <-pj.eventChannel:
-			if ok {
-				pj.publishEvent(event)
-			}
-		}
-	}
-}
-
-func (pj *publisher) publishEvent(event interface{}) {
-	lighthouseUsageEvent, ok := event.(LighthouseUsageEvent)
-	if ok {
-		pj.publishToLighthouse(lighthouseUsageEvent)
-	} else {
-		log.Error("event was not a lighthouse event")
-		// pj.publishToGatekeeper(event)
-	}
-}
-
-func (pj *publisher) publishToLighthouse(event LighthouseUsageEvent) {
+func (pj *metricPublisher) publishToLighthouse(event LighthouseUsageEvent) error {
 	token, err := agent.GetCentralAuthToken()
 	if err != nil {
-		log.Error("Error in sending usage/metric event: ", err.Error())
-		return
+		return err
 	}
 
-	b, contentType, err := createMultipartFormData(event)
+	b, contentType, err := pj.createMultipartFormData(event)
 
 	headers := map[string]string{
 		"Content-Type":  contentType,
@@ -80,23 +56,23 @@ func (pj *publisher) publishToLighthouse(event LighthouseUsageEvent) {
 	log.Debugf("Payload for Usage event : %s\n", string(b.Bytes()))
 	response, err := pj.apiClient.Send(request)
 	if err != nil {
-		log.Error("Error in sending usage/metric event: ", err.Error())
-		return
+		return err
 	}
 	if response.Code >= 400 {
 		resBody := string(response.Body)
-		log.Error("Failed to publish usage event: ", resBody)
+		return errors.New("Request failed with code: " + strconv.Itoa(response.Code) + ", content: " + resBody)
 	}
+	return nil
 }
 
-func createMultipartFormData(event LighthouseUsageEvent) (b bytes.Buffer, contentType string, err error) {
+func (pj *metricPublisher) createMultipartFormData(event LighthouseUsageEvent) (b bytes.Buffer, contentType string, err error) {
 	buffer, _ := json.Marshal(event)
 	w := multipart.NewWriter(&b)
 	defer w.Close()
 	w.WriteField("organizationId", event.OrgGUID)
 
 	var fw io.Writer
-	if fw, err = CreateFilePart(w, uuid.New().String()+".json"); err != nil {
+	if fw, err = pj.createFilePart(w, uuid.New().String()+".json"); err != nil {
 		return
 	}
 	if _, err = io.Copy(fw, bytes.NewReader(buffer)); err != nil {
@@ -107,25 +83,20 @@ func createMultipartFormData(event LighthouseUsageEvent) (b bytes.Buffer, conten
 	return
 }
 
-//CreateFilePart - adds the file part to the request
-func CreateFilePart(w *multipart.Writer, filename string) (io.Writer, error) {
+// createFilePart - adds the file part to the request
+func (pj *metricPublisher) createFilePart(w *multipart.Writer, filename string) (io.Writer, error) {
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, filename))
 	h.Set("Content-Type", "application/json")
 	return w.CreatePart(h)
 }
 
-// NewMetricPublisher - Creates publisher job
-func NewMetricPublisher(eventChannel chan interface{}) Publisher {
+// newMetricPublisher - Creates publisher job
+func newMetricPublisher() publisher {
 	centralCfg := agent.GetCentralConfig()
-	publisherJob := &publisher{
-		eventChannel: eventChannel,
-		apiClient:    api.NewClient(centralCfg.GetTLSConfig(), centralCfg.GetProxyURL()),
-	}
-	_, err := jobs.RegisterSingleRunJob(publisherJob)
-	if err != nil {
-		panic(err)
+	publisher := &metricPublisher{
+		apiClient: api.NewClient(centralCfg.GetTLSConfig(), centralCfg.GetProxyURL()),
 	}
 
-	return publisherJob
+	return publisher
 }


### PR DESCRIPTION
- Update to create publisher within collector
- Added publish queue to collector for events generated by collector
- Updates to publish events based on queue instead of channel and perform cleanup of counter on successful publish
- Updates to unregister job from global pool
- Update to expose metric collector by making GetMetricCollector API call