### PR TITLE
APIGOV-18347 - Added storage for usage/metric data

### DIFF
--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/paths"
 	"github.com/elastic/beats/v7/libbeat/publisher"
 )
 
@@ -42,6 +43,11 @@ func init() {
 // SetOutputEventProcessor -
 func SetOutputEventProcessor(eventProcessor OutputEventProcessor) {
 	outputEventProcessor = eventProcessor
+}
+
+// GetDataDirPath - Returns the path of the data directory
+func GetDataDirPath() string {
+	return paths.Paths.Data
 }
 
 func makeTraceabilityAgent(

--- a/pkg/transaction/eventgenerator.go
+++ b/pkg/transaction/eventgenerator.go
@@ -34,6 +34,9 @@ func NewEventGenerator() EventGenerator {
 		shouldAddFields: !traceability.IsHTTPTransport(),
 	}
 	hc.RegisterHealthcheck("Event Generator", "eventgen", eventGen.healthcheck)
+
+	// Initialize the metric collector to load usage/metric data from previous agent execution
+	metric.GetMetricCollector()
 	return eventGen
 }
 

--- a/pkg/transaction/metric/cachestorage.go
+++ b/pkg/transaction/metric/cachestorage.go
@@ -1,0 +1,182 @@
+package metric
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/Axway/agent-sdk/pkg/cache"
+	"github.com/Axway/agent-sdk/pkg/traceability"
+)
+
+const (
+	cacheFileName     = "agent-usagemetric.json"
+	usageStartTimeKey = "usage_start_time"
+	usageCountKey     = "usage_count"
+	metricKeyPrefix   = "metric."
+)
+
+type storageCache interface {
+	initialize()
+	updateUsage(usageCount int)
+	// updateMetric(apiStatusMetric metrics.Histogram, apiMetric *APIMetric)
+	// removeMetric(apiMetric *APIMetric)
+	save()
+}
+
+type cacheStorage struct {
+	cacheFilePath string
+	collector     *collector
+	storage       cache.Cache
+	storageLock   sync.Mutex
+	isInitialized bool
+}
+
+func newStorageCache(collector *collector, cacheFilePath string) storageCache {
+	storageCache := &cacheStorage{
+		cacheFilePath: traceability.GetDataDirPath() + "/" + cacheFileName,
+		collector:     collector,
+		storageLock:   sync.Mutex{},
+		storage:       cache.New(),
+		isInitialized: false,
+	}
+
+	return storageCache
+}
+
+func (c *cacheStorage) initialize() {
+	storageCache := cache.Load(c.cacheFilePath)
+	c.loadUsage(storageCache)
+	// c.loadAPIMetric(storageCache)
+
+	// Not a job as the loop requires signal processing
+	if !c.isInitialized && flag.Lookup("test.v") == nil {
+		go c.storeCacheJob()
+	}
+	c.storage = storageCache
+	c.isInitialized = true
+}
+
+func (c *cacheStorage) loadUsage(storageCache cache.Cache) {
+	// update the collector start time
+	usageStartTime, err := c.parseTimeFromCache(storageCache, usageStartTimeKey)
+	if err == nil {
+		c.collector.startTime = usageStartTime
+	}
+
+	// update transaction counter in registry.
+	usageCount, err := storageCache.Get(usageCountKey)
+	if err == nil {
+		// un-marshalling the cache defaults the serialization of numeric values to float64
+		c.collector.updateUsage(int64(usageCount.(float64)))
+	}
+}
+
+func (c *cacheStorage) updateUsage(usageCount int) {
+	if !c.isInitialized {
+		return
+	}
+
+	c.storageLock.Lock()
+	defer c.storageLock.Unlock()
+	c.storage.Set(usageStartTimeKey, c.collector.startTime)
+	c.storage.Set(usageCountKey, usageCount)
+}
+
+// func (c *cacheStorage) loadAPIMetric(storageCache cache.Cache) {
+// 	cacheKeys := storageCache.GetKeys()
+// 	for _, cacheKey := range cacheKeys {
+// 		if strings.Contains(cacheKey, metricKeyPrefix) {
+// 			cacheItem, _ := storageCache.Get(cacheKey)
+
+// 			buffer, _ := json.Marshal(cacheItem)
+// 			var apiMetric cachedMetric
+// 			json.Unmarshal(buffer, &apiMetric)
+
+// 			storageCache.Set(cacheKey, apiMetric)
+
+// 			var apiStatusMetric *APIMetric
+// 			for _, duration := range apiMetric.Values {
+// 				apiStatusMetric = c.collector.updateMetric(apiMetric.API.ID, apiMetric.API.Name, apiMetric.StatusCode, duration)
+// 			}
+// 			if apiStatusMetric != nil {
+// 				apiStatusMetric.StartTime = apiMetric.StartTime
+// 			}
+// 		}
+// 	}
+// }
+
+// func (c *cacheStorage) updateMetric(apiStatusMetric metrics.Histogram, apiMetric *APIMetric) {
+// 	if !c.isInitialized {
+// 		return
+// 	}
+
+// 	c.storageLock.Lock()
+// 	defer c.storageLock.Unlock()
+
+// 	cachedAPIMetric := cachedMetric{
+// 		API:        apiMetric.API,
+// 		StatusCode: apiMetric.StatusCode,
+// 		Count:      apiStatusMetric.Count(),
+// 		Values:     apiStatusMetric.Sample().Values(),
+// 		StartTime:  apiMetric.StartTime,
+// 	}
+// 	c.storage.Set(metricKeyPrefix + apiMetric.API.ID + "."+apiMetric.StatusCode, cachedAPIMetric)
+// }
+
+// func (c *cacheStorage) removeMetric(apiMetric *APIMetric) {
+// 	if !c.isInitialized {
+// 		return
+// 	}
+
+// 	c.storageLock.Lock()
+// 	defer c.storageLock.Unlock()
+// 	c.storage.Delete(metricKeyPrefix + apiMetric.API.ID + "." + apiMetric.StatusCode)
+// }
+
+func (c *cacheStorage) save() {
+	if !c.isInitialized {
+		return
+	}
+
+	c.storageLock.Lock()
+	defer c.storageLock.Unlock()
+
+	c.storage.Save(c.cacheFilePath)
+}
+
+func (c *cacheStorage) storeCacheJob() {
+	cachetimeTicker := time.NewTicker(5 * time.Second)
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	for {
+		select {
+		case <-cachetimeTicker.C:
+			c.save()
+		case <-signals:
+			c.save()
+			break
+		}
+	}
+}
+
+func (c *cacheStorage) parseTimeFromCache(storage cache.Cache, key string) (time.Time, error) {
+	resultTime := time.Now()
+	item, err := storage.Get(key)
+	if err != nil {
+		return time.Now(), err
+	}
+	cachedTimeStr, ok := item.(string)
+	if ok {
+		resultTime, _ = time.Parse(time.RFC3339, cachedTimeStr)
+	} else {
+		cachedTime, ok := item.(time.Time)
+		if ok {
+			resultTime = cachedTime
+		}
+	}
+	return resultTime, nil
+}

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -31,13 +31,22 @@ type APIMetric struct {
 	StartTime   time.Time          `json:"-"`
 }
 
-// V4EventDistribution - represents V7 distribution
+// cachedMetric - struct to hold metric specific that gets cached and used for agent recovery
+type cachedMetric struct {
+	API        APIDetails `json:"api"`
+	StatusCode string     `json:"statusCode"`
+	Count      int64      `json:"count"`
+	Values     []int64    `json:"values"`
+	StartTime  time.Time  `json:"startTime"`
+}
+
+// // V4EventDistribution - represents V7 distribution
 // type V4EventDistribution struct {
 // 	Environment string `json:"environment"`
 // 	Version     string `json:"version"`
 // }
 
-// V4Event - represents V7 event
+// // V4Event - represents V7 event
 // type V4Event struct {
 // 	ID           string              `json:"id"`
 // 	Timestamp    int64               `json:"timestamp"`

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/agent"
 	"github.com/Axway/agent-sdk/pkg/cmd"
 	"github.com/Axway/agent-sdk/pkg/jobs"
+	"github.com/Axway/agent-sdk/pkg/traceability"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	jwt "github.com/dgrijalva/jwt-go"
 	metrics "github.com/rcrowley/go-metrics"
@@ -31,6 +32,7 @@ type collector struct {
 	publishItemQueue []publishQueueItem
 	jobID            string
 	publisher        publisher
+	storage          storageCache
 }
 
 type publishQueueItem interface {
@@ -64,14 +66,13 @@ func (qi *usageEventQueueItem) GetMetric() interface{} {
 
 // type metricEventQueueItem struct {
 // 	metricEventPublishItem
-// 	// event     V4Event
+// 	event     V4Event
 // 	metric    metrics.Histogram
 // 	apiMetric *APIMetric
 // }
 
 // func (qi *metricEventQueueItem) GetEvent() interface{} {
-// 	// return qi.
-// 	return nil
+// 	return qi.event
 // }
 
 // func (qi *metricEventQueueItem) GetMetric() interface{} {
@@ -108,10 +109,16 @@ func createMetricCollector() Collector {
 		publisher:        newMetricPublisher(),
 	}
 
-	var err error
-	metricCollector.jobID, err = jobs.RegisterIntervalJob(metricCollector, agent.GetCentralConfig().GetEventAggregationInterval())
-	if err != nil {
-		panic(err)
+	// Create and initialize the storage cache for usage/metric by loading from disk
+	metricCollector.storage = newStorageCache(metricCollector, traceability.GetDataDirPath()+"/"+cacheFileName)
+	metricCollector.storage.initialize()
+
+	if flag.Lookup("test.v") == nil {
+		var err error
+		metricCollector.jobID, err = jobs.RegisterIntervalJob(metricCollector, agent.GetCentralConfig().GetEventAggregationInterval())
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return metricCollector
@@ -152,34 +159,43 @@ func convertTimeToMillis(tm time.Time) int64 {
 func (c *collector) AddMetric(apiID, apiName, statusCode string, duration int64, appName, teamName string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	transactionCount := c.getOrRegisterCounter("transaction.count")
-	transactionCount.Inc(1)
-
-	// apiStatusDuration := c.getOrRegisterHistogram("transaction.status." + apiID + "." + statusCode)
-
-	// apiStatusMap, ok := c.metricMap[apiID]
-	// if !ok {
-	// 	apiStatusMap = make(map[string]*APIMetric)
-	// 	c.metricMap[apiID] = apiStatusMap
-	// }
-
-	// _, ok = apiStatusMap[statusCode]
-	// if !ok {
-	// 	// First api metric for api+statuscode,
-	// 	// setup the start time to be used for reporting metric event
-	// 	apiStatusMap[statusCode] = &APIMetric{
-	// 		API: APIDetails{
-	// 			Name: apiName,
-	// 			ID:   apiID,
-	// 		},
-	// 		StatusCode: statusCode,
-	// 		StartTime:  time.Now(),
-	// 	}
-	// }
-
-	// apiStatusDuration.Update(duration)
+	c.updateUsage(1)
+	// c.updateMetric(apiID, apiName, statusCode, duration)
 }
+
+func (c *collector) updateUsage(count int64) {
+	transactionCount := c.getOrRegisterCounter("transaction.count")
+	transactionCount.Inc(count)
+	c.storage.updateUsage(int(transactionCount.Count()))
+}
+
+// func (c *collector) updateMetric(apiID, apiName, statusCode string, duration int64) *APIMetric {
+// 	apiStatusDuration := c.getOrRegisterHistogram("transaction.status." + apiID + "." + statusCode)
+
+// 	apiStatusMap, ok := c.metricMap[apiID]
+// 	if !ok {
+// 		apiStatusMap = make(map[string]*APIMetric)
+// 		c.metricMap[apiID] = apiStatusMap
+// 	}
+
+// 	_, ok = apiStatusMap[statusCode]
+// 	if !ok {
+// 		// First api metric for api+statuscode,
+// 		// setup the start time to be used for reporting metric event
+// 		apiStatusMap[statusCode] = &APIMetric{
+// 			API: APIDetails{
+// 				Name: apiName,
+// 				ID:   apiID,
+// 			},
+// 			StatusCode: statusCode,
+// 			StartTime:  time.Now(),
+// 		}
+// 	}
+
+// 	apiStatusDuration.Update(duration)
+// 	c.storage.updateMetric(apiStatusDuration, apiStatusMap[statusCode])
+// 	return apiStatusMap[statusCode]
+// }
 
 func (c *collector) cleanup() {
 	c.publishItemQueue = make([]publishQueueItem, 0)
@@ -329,27 +345,32 @@ func (c *collector) getOrRegisterHistogram(name string) metrics.Histogram {
 }
 
 func (c *collector) publishEvents() {
-	for _, eventQueueItem := range c.publishItemQueue {
-		err := c.publisher.publishEvent(eventQueueItem.GetEvent())
-		if err != nil {
-			log.Error("Failed to publish event : ", err.Error())
-		} else {
-			c.cleanupCounters(eventQueueItem)
+	if len(c.publishItemQueue) > 0 {
+		defer c.storage.save()
+
+		for _, eventQueueItem := range c.publishItemQueue {
+			err := c.publisher.publishEvent(eventQueueItem.GetEvent())
+			if err != nil {
+				log.Error("Failed to publish event : ", err.Error())
+			} else {
+				c.cleanupCounters(eventQueueItem)
+			}
 		}
 	}
 }
 
 func (c *collector) cleanupCounters(eventQueueItem publishQueueItem) {
-	usageEventItem, ok := eventQueueItem.(usageEventPublishItem)
-	if ok {
-		c.cleanupUsageCounter(usageEventItem)
-		return
-	}
-
+	// // Check metricEventPublishItem interface first since usageEventPublishItem will pass for metric event item as well
 	// metricEventItem, ok := eventQueueItem.(metricEventPublishItem)
 	// if ok {
 	// 	c.cleanupMetricCounter(metricEventItem)
+	// 	return
 	// }
+
+	usageEventItem, ok := eventQueueItem.(usageEventPublishItem)
+	if ok {
+		c.cleanupUsageCounter(usageEventItem)
+	}
 }
 
 func (c *collector) cleanupUsageCounter(usageEventItem usageEventPublishItem) {
@@ -359,6 +380,7 @@ func (c *collector) cleanupUsageCounter(usageEventItem usageEventPublishItem) {
 		// Clean up the usage counter and reset the start time to current endTime
 		counter.Clear()
 		c.startTime = c.endTime
+		c.storage.updateUsage(0)
 	}
 }
 
@@ -369,6 +391,7 @@ func (c *collector) cleanupUsageCounter(usageEventItem usageEventPublishItem) {
 // 		// Clean up entry in api status metric map and histogram counter
 // 		apiStatusMap, ok := c.metricMap[metricEventItem.GetAPIID()]
 // 		if ok {
+// 			c.storage.removeMetric(apiStatusMap[metricEventItem.GetStatusCode()])
 // 			delete(apiStatusMap, metricEventItem.GetStatusCode())
 // 			if len(apiStatusMap) != 0 {
 // 				c.metricMap[metricEventItem.GetAPIID()] = apiStatusMap

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -5,13 +5,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
 	"github.com/Axway/agent-sdk/pkg/cmd"
 	"github.com/Axway/agent-sdk/pkg/config"
-	"github.com/Axway/agent-sdk/pkg/jobs"
+	"github.com/elastic/beats/v7/libbeat/paths"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,21 +35,25 @@ func createCentralCfg(url, env string) *config.CentralConfiguration {
 
 var accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNjE0NjA0NzE0LCJleHAiOjE2NDYxNDA3MTQsImF1ZCI6InRlc3RhdWQiLCJzdWIiOiIxMjM0NTYiLCJvcmdfZ3VpZCI6IjEyMzQtMTIzNC0xMjM0LTEyMzQifQ.5Uqt0oFhMgmI-sLQKPGkHwknqzlTxv-qs9I_LmZ18LQ"
 
-func TestMetricCollector(t *testing.T) {
-	lighthouseEventCount := 0
-	transactionCount := 0
-	failUsageEvent := false
-	s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+type testHTTPServer struct {
+	lighthouseEventCount int
+	transactionCount     int
+	failUsageEvent       bool
+	server               *httptest.Server
+}
+
+func (s *testHTTPServer) startServer() {
+	s.server = httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.RequestURI, "/auth") {
 			token := "{\"access_token\":\"" + accessToken + "\",\"expires_in\": 12235677}"
 			resp.Write([]byte(token))
 		}
 		if strings.Contains(req.RequestURI, "/lighthouse") {
-			if failUsageEvent {
+			if s.failUsageEvent {
 				resp.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			lighthouseEventCount++
+			s.lighthouseEventCount++
 			req.ParseMultipartForm(1 << 20)
 			for _, fileHeaders := range req.MultipartForm.File {
 				for _, fileHeader := range fileHeaders {
@@ -61,26 +66,46 @@ func TestMetricCollector(t *testing.T) {
 					json.Unmarshal(body, &usageEvent)
 					for _, report := range usageEvent.Report {
 						for _, usage := range report.Usage {
-							transactionCount = transactionCount + int(usage)
+							s.transactionCount += int(usage)
 						}
 					}
 				}
 			}
 		}
 	}))
+}
 
-	defer s.Close()
-	cfg := createCentralCfg(s.URL, "demo")
-	cfg.LighthouseURL = s.URL + "/lighthouse"
+func (s *testHTTPServer) closeServer() {
+	if s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s *testHTTPServer) resetConfig() {
+	s.lighthouseEventCount = 0
+	s.transactionCount = 0
+	s.failUsageEvent = false
+}
+
+func cleanUpCachedMetricFile() {
+	os.Remove("./" + cacheFileName)
+}
+
+func TestMetricCollector(t *testing.T) {
+	defer cleanUpCachedMetricFile()
+	s := &testHTTPServer{}
+	defer s.closeServer()
+	s.startServer()
+	paths.Paths.Data = "."
+
+	cfg := createCentralCfg(s.server.URL, "demo")
+	cfg.LighthouseURL = s.server.URL + "/lighthouse"
 	cfg.PlatformEnvironmentID = "267bd671-e5e2-4679-bcc3-bbe7b70f30fd"
 	cmd.BuildDataPlaneType = "Azure"
 	agent.Initialize(cfg)
 
 	myCollector := createMetricCollector()
 	metricCollector := myCollector.(*collector)
-	metricCollector.orgGUID = metricCollector.getOrgGUID()
-	jobs.GetJob(metricCollector.jobID)
-	jobs.UnregisterJob(metricCollector.jobID)
 
 	testCases := []struct {
 		name                     string
@@ -125,14 +150,68 @@ func TestMetricCollector(t *testing.T) {
 				for i := 0; i < test.apiTransactionCount[l]; i++ {
 					metricCollector.AddMetric("111", "111", "200", 10, "", "")
 				}
-				failUsageEvent = test.failUsageEventOnServer[l]
+				s.failUsageEvent = test.failUsageEventOnServer[l]
 				metricCollector.Execute()
-				assert.Equal(t, test.expectedLHEvents[l], lighthouseEventCount)
-				assert.Equal(t, test.expectedTransactionCount[l], transactionCount)
+				assert.Equal(t, test.expectedLHEvents[l], s.lighthouseEventCount)
+				assert.Equal(t, test.expectedTransactionCount[l], s.transactionCount)
 			}
-			lighthouseEventCount = 0
-			transactionCount = 0
-			failUsageEvent = false
+			s.resetConfig()
 		})
 	}
+}
+
+func TestMetricCollectorCache(t *testing.T) {
+	defer cleanUpCachedMetricFile()
+	s := &testHTTPServer{}
+	defer s.closeServer()
+	s.startServer()
+
+	cfg := createCentralCfg(s.server.URL, "demo")
+	cfg.LighthouseURL = s.server.URL + "/lighthouse"
+	cfg.PlatformEnvironmentID = "267bd671-e5e2-4679-bcc3-bbe7b70f30fd"
+	cmd.BuildDataPlaneType = "Azure"
+	agent.Initialize(cfg)
+
+	paths.Paths.Data = "."
+	myCollector := createMetricCollector()
+	metricCollector := myCollector.(*collector)
+
+	metricCollector.AddMetric("111", "111", "200", 5, "", "")
+	metricCollector.AddMetric("111", "111", "200", 10, "", "")
+	metricCollector.Execute()
+	metricCollector.AddMetric("111", "111", "401", 15, "", "")
+	metricCollector.AddMetric("222", "222", "200", 20, "", "")
+	metricCollector.AddMetric("222", "222", "200", 10, "", "")
+
+	// No event generation/publish, store the cache
+	metricCollector.storage.save()
+	// Validate only one usage report sent with first 2 transactions
+	assert.Equal(t, 1, s.lighthouseEventCount)
+	assert.Equal(t, 2, s.transactionCount)
+	s.resetConfig()
+
+	// Recreate the collector that loads the stored metrics, so 3 transactions
+	myCollector = createMetricCollector()
+	metricCollector = myCollector.(*collector)
+
+	metricCollector.AddMetric("111", "111", "200", 5, "", "")
+	metricCollector.AddMetric("111", "111", "200", 10, "", "")
+	metricCollector.AddMetric("111", "111", "401", 15, "", "")
+	metricCollector.AddMetric("222", "222", "200", 20, "", "")
+	metricCollector.AddMetric("222", "222", "200", 10, "", "")
+
+	metricCollector.Execute()
+	// Validate only one usage report sent with 3 previous transactions and 5 new transactions
+	assert.Equal(t, 1, s.lighthouseEventCount)
+	assert.Equal(t, 8, s.transactionCount)
+
+	s.resetConfig()
+	// Recreate the collector that loads the stored metrics, 0 transactions
+	myCollector = createMetricCollector()
+	metricCollector = myCollector.(*collector)
+
+	metricCollector.Execute()
+	// Validate only no usage report sent as no previous or new transactions
+	assert.Equal(t, 0, s.lighthouseEventCount)
+	assert.Equal(t, 0, s.transactionCount)
 }


### PR DESCRIPTION
- Changes to load cached usage/metric data on agent initialization
- Changes to update the counters/metric in cache as the registry is updated
- Added cache store job that triggers every 5 sec to store the data to disk
- Changes to reset the cached counter when the counters in registry are reset.