### PR TITLE
APIGOV-18347 - Fix for reporting time format

### DIFF
--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -77,7 +77,7 @@ type LighthouseUsageEvent struct {
 
 // ISO8601 - time format
 const (
-	ISO8601 = "2006-01-02T15:04:05.000Z"
+	ISO8601 = "2006-01-02T15:04:05Z07:00"
 )
 
 // ISO8601Time - time

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -256,7 +256,7 @@ func (c *collector) generateLighthouseUsageEvent(transactionCount metrics.Counte
 		SchemaID:    agent.GetCentralConfig().GetLighthouseURL() + "/api/v1/report.schema.json",
 		Granularity: int(c.endTime.Sub(c.startTime).Milliseconds()),
 		Report: map[string]LighthouseUsageReport{
-			c.endTime.Format("2006-01-02T15:04:05.000Z"): {
+			c.startTime.Format(ISO8601): {
 				Product: cmd.GetBuildDataPlaneType(),
 				Usage: map[string]int64{
 					cmd.GetBuildDataPlaneType() + ".Transactions": transactionCount.Count(),


### PR DESCRIPTION
Fix include:
- correctly formatting the time in usage report with ISO8601
- using the start time in the event report as key 
