### PR TITLE
APIGOV-18029 - Changes to use secret reference in config

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -54,6 +54,7 @@
 | 1404 | invalid value for statusHealthCheckInterval. Value must be between 30 seconds and 5 minutes                 | pkg/config/ErrStatusHealthCheckInterval             |
 | 1405 | a key file could not be read                                                                                | pkg/config/ErrReadingKeyFile                        |
 | 1410 | invalid configuration settings for the logging setup                                                        | pkg/config/ErrInvalidLogConfig                      |
+| 1411 | invalid secret reference                                                                                    | pkg/cmd/properties/ErrInvalidSecretReference        |
 |      | 1500-1599 - errors related to traceability output transport                                                 |                                                     |
 | 1503 | http transport is not connected                                                                             | pkg/traceability/ErrHTTPNotConnected                |
 | 1504 | failed to encode the json content                                                                           | pkg/traceability/ErrJSONEncodeFailed                |

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -11,11 +11,20 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/util"
+	"github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
+
+// ErrInvalidSecretReference - Error for parsing properties with secret reference
+var ErrInvalidSecretReference = errors.Newf(1411, "invalid secret reference - %s, please check the value for %s config")
+
+// SecretPropertyResover - interface for resolving property values with secret references
+type SecretPropertyResover interface {
+	ResolveSecret(secretRef string) (string, error)
+}
 
 // Properties - Root Command Properties interface for all configs to use for adding and parsing values
 type Properties interface {
@@ -49,6 +58,7 @@ var aliasKeyPrefix string
 type properties struct {
 	Properties
 	rootCmd             *cobra.Command
+	secretResolver      SecretPropertyResover
 	flattenedProperties map[string]string
 }
 
@@ -63,6 +73,17 @@ func NewProperties(rootCmd *cobra.Command) Properties {
 	cmdprops := &properties{
 		rootCmd:             rootCmd,
 		flattenedProperties: make(map[string]string),
+	}
+
+	return cmdprops
+}
+
+// NewPropertiesWithSecretResolver - Creates a new Properties struct with secret resolver for string property/flag
+func NewPropertiesWithSecretResolver(rootCmd *cobra.Command, secretResolver SecretPropertyResover) Properties {
+	cmdprops := &properties{
+		rootCmd:             rootCmd,
+		flattenedProperties: make(map[string]string),
+		secretResolver:      secretResolver,
 	}
 
 	return cmdprops
@@ -222,9 +243,25 @@ func (p *properties) parseStringValue(key string) string {
 	return s
 }
 
+func (p *properties) resolveSecretReference(cfgName, cfgValue string) string {
+	if p.secretResolver != nil {
+		secretValue, err := p.secretResolver.ResolveSecret(cfgValue)
+		if err != nil {
+			// only log the error and return empty string,
+			// validation on config triggers the agent to return error to root command
+			log.Error(ErrInvalidSecretReference.FormatError(err.Error(), cfgName))
+			cfgValue = ""
+		}
+		if secretValue != "" {
+			cfgValue = secretValue
+		}
+	}
+	return cfgValue
+}
+
 func (p *properties) StringPropertyValue(name string) string {
 	s := p.parseStringValue(name)
-
+	s = p.resolveSecretReference(name, s)
 	p.addPropertyToFlatMap(name, s)
 	return s
 }
@@ -235,6 +272,7 @@ func (p *properties) StringFlagValue(name string) (bool, string) {
 		return false, ""
 	}
 	fv := flag.Value.String()
+	fv = p.resolveSecretReference(name, fv)
 	p.addPropertyToFlatMap(name, fv)
 	return true, fv
 }

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -21,8 +21,8 @@ import (
 // ErrInvalidSecretReference - Error for parsing properties with secret reference
 var ErrInvalidSecretReference = errors.Newf(1411, "invalid secret reference - %s, please check the value for %s config")
 
-// SecretPropertyResover - interface for resolving property values with secret references
-type SecretPropertyResover interface {
+// SecretPropertyResolver - interface for resolving property values with secret references
+type SecretPropertyResolver interface {
 	ResolveSecret(secretRef string) (string, error)
 }
 
@@ -58,7 +58,7 @@ var aliasKeyPrefix string
 type properties struct {
 	Properties
 	rootCmd             *cobra.Command
-	secretResolver      SecretPropertyResover
+	secretResolver      SecretPropertyResolver
 	flattenedProperties map[string]string
 }
 
@@ -79,7 +79,7 @@ func NewProperties(rootCmd *cobra.Command) Properties {
 }
 
 // NewPropertiesWithSecretResolver - Creates a new Properties struct with secret resolver for string property/flag
-func NewPropertiesWithSecretResolver(rootCmd *cobra.Command, secretResolver SecretPropertyResover) Properties {
+func NewPropertiesWithSecretResolver(rootCmd *cobra.Command, secretResolver SecretPropertyResolver) Properties {
 	cmdprops := &properties{
 		rootCmd:             rootCmd,
 		flattenedProperties: make(map[string]string),

--- a/pkg/cmd/properties/resolver/secretResolver.go
+++ b/pkg/cmd/properties/resolver/secretResolver.go
@@ -1,0 +1,114 @@
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Axway/agent-sdk/pkg/agent"
+	coreapi "github.com/Axway/agent-sdk/pkg/api"
+	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/cache"
+	"github.com/Axway/agent-sdk/pkg/cmd/properties"
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+const (
+	secretConfigPrefix  = "@Secret."
+	secretMapItemPrefix = "SecretResource_"
+)
+
+// SecretResolver - Interface to resolve secret reference
+type SecretResolver interface {
+	properties.SecretPropertyResover
+	ResetResolver()
+}
+
+type secretResolver struct {
+	SecretResolver
+	secretsCache cache.Cache
+}
+
+// NewSecretResolver - create a new secret resolver
+func NewSecretResolver() SecretResolver {
+	return &secretResolver{
+		secretsCache: cache.New(),
+	}
+}
+
+// parseSecretRef - parses the secret reference with prefixed secret name ane key
+func (s *secretResolver) parseSecretRef(secretRef string) (string, string) {
+	// parse secret and key from @Secret.secretName.key
+	secretRef = strings.TrimSpace(secretRef)
+	if strings.HasPrefix(secretRef, secretConfigPrefix) {
+		secretRef = secretRef[len(secretConfigPrefix):]
+		secretRefElements := strings.Split(secretRef, ".")
+		if len(secretRefElements) > 1 {
+			return secretRefElements[0], strings.Join(secretRefElements[1:], ".")
+		}
+	}
+	return "", ""
+}
+
+func (s *secretResolver) getSecret(secretName string) (*v1alpha1.Secret, error) {
+	secretResourceURL := agent.GetCentralConfig().GetEnvironmentURL() + "/secrets/" + secretName
+
+	response, err := agent.GetCentralClient().ExecuteAPI(coreapi.GET, secretResourceURL, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	secret := &v1alpha1.Secret{}
+	err = json.Unmarshal(response, secret)
+	return secret, err
+}
+
+func (s *secretResolver) parseKeyValueFromSecretSpec(secret *v1alpha1.Secret, key string) (string, error) {
+	// Return empty string if secret key not found
+	keyVal, ok := secret.Spec.Data[key]
+	if !ok {
+		msg := fmt.Sprintf("key %s not found in secret %s", key, secret.Name)
+		return "", errors.New(msg)
+	}
+	return keyVal, nil
+}
+
+func (s *secretResolver) ResolveSecret(secretRef string) (string, error) {
+	// Do not parse secret reference until central config is parsed and initialized
+	// secret ref be applied to agent config only and not central config
+	cfg := agent.GetCentralConfig()
+	if cfg == nil || reflect.ValueOf(cfg).IsNil() {
+		return secretRef, nil
+	}
+
+	secretName, key := s.parseSecretRef(secretRef)
+	if secretName != "" && key != "" {
+		var secret *v1alpha1.Secret
+		// Get cached secret to resolve key
+		cachedSecret, err := s.secretsCache.Get(secretMapItemPrefix + secretName)
+		if err != nil {
+			// Secret not cached, get the secret from API server
+			secret, err = s.getSecret(secretName)
+			if err != nil {
+				log.Trace(err.Error())
+				msg := fmt.Sprintf("unable to resolve secret %s", secretName)
+				return "", errors.New(msg)
+			}
+			s.secretsCache.Set(secretMapItemPrefix+secret.GetName(), secret)
+		} else {
+			secret, _ = cachedSecret.(*v1alpha1.Secret)
+		}
+		keyVal, err := s.parseKeyValueFromSecretSpec(secret, key)
+		if err != nil {
+			return "", err
+		}
+		return keyVal, nil
+	}
+	// Not a secret ref, return it as value
+	return secretRef, nil
+}
+
+func (s *secretResolver) ResetResolver() {
+	s.secretsCache = cache.New()
+}

--- a/pkg/cmd/properties/resolver/secretResolver.go
+++ b/pkg/cmd/properties/resolver/secretResolver.go
@@ -22,7 +22,7 @@ const (
 
 // SecretResolver - Interface to resolve secret reference
 type SecretResolver interface {
-	properties.SecretPropertyResover
+	properties.SecretPropertyResolver
 	ResetResolver()
 }
 


### PR DESCRIPTION
- Changes to secure string based configuration by using reference of secret resource in Central
- Secret resolver gets hooked by in property parser for string flags and property
- Secret resolver parses the secret and key from the reference string value in config and gets the secret from API server
- The secret is cached to minimize the number of API calls to API server to fetch secret in case same secret is used for multiple config
- Also includes a fix to setup beats logger to allow logging any log entries during agent initialization