### PR TITLE
APIGOV-19050 - Update product struct for ID and Version

### DIFF
--- a/pkg/transaction/definitions.go
+++ b/pkg/transaction/definitions.go
@@ -66,7 +66,7 @@ type Summary struct {
 	StatusDetail string       `json:"statusDetail,omitempty"`
 	Duration     int          `json:"duration"`
 	Application  *Application `json:"application,omitempty"`
-	Product      string       `json:"product,omitempty"`
+	Product      *Product     `json:"product,omitempty"`
 	Team         *Team        `json:"team,omitempty"`
 
 	Proxy      *Proxy      `json:"proxy,omitempty"`
@@ -78,6 +78,11 @@ type Summary struct {
 type Application struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
+}
+
+type Product struct {
+	ID      string `json:"id,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // Team  - Represents the team used in transaction summary event

--- a/pkg/transaction/definitions.go
+++ b/pkg/transaction/definitions.go
@@ -80,6 +80,7 @@ type Application struct {
 	Name string `json:"name,omitempty"`
 }
 
+// Product - Represents the prodcut used in the transaction summary event
 type Product struct {
 	ID      string `json:"id,omitempty"`
 	Version string `json:"version,omitempty"`

--- a/pkg/transaction/logeventbuilder.go
+++ b/pkg/transaction/logeventbuilder.go
@@ -547,10 +547,8 @@ func (b *transactionSummaryBuilder) validateLogEvent() error {
 		return errors.New("Transaction entry point details are not set in transaction summary event")
 	}
 
-	if b.logEvent.TransactionSummary.Product != nil {
-		if b.logEvent.TransactionSummary.Product.ID == "" {
-			return errors.New("Product ID property not set in transaction summary event")
-		}
+	if b.logEvent.TransactionSummary.Product != nil && b.logEvent.TransactionSummary.Product.ID == "" {
+		return errors.New("Product ID property not set in transaction summary event")
 	}
 	return nil
 }

--- a/pkg/transaction/logeventbuilder.go
+++ b/pkg/transaction/logeventbuilder.go
@@ -78,7 +78,7 @@ type SummaryBuilder interface {
 	SetStatus(status TxSummaryStatus, statusDetail string) SummaryBuilder
 	SetDuration(duration int) SummaryBuilder
 	SetApplication(appID, appName string) SummaryBuilder
-	SetProduct(product string) SummaryBuilder
+	SetProduct(id, version string) SummaryBuilder
 	SetTeam(teamID string) SummaryBuilder
 	SetProxy(proxyID, proxyName string, proxyRevision int) SummaryBuilder
 	SetRunTime(runtimeID, runtimeName string) SummaryBuilder
@@ -443,11 +443,14 @@ func (b *transactionSummaryBuilder) SetApplication(appID, appName string) Summar
 	return b
 }
 
-func (b *transactionSummaryBuilder) SetProduct(product string) SummaryBuilder {
+func (b *transactionSummaryBuilder) SetProduct(id, version string) SummaryBuilder {
 	if b.err != nil {
 		return b
 	}
-	b.logEvent.TransactionSummary.Product = product
+	b.logEvent.TransactionSummary.Product = &Product{
+		ID:      id,
+		Version: version,
+	}
 	return b
 }
 
@@ -544,5 +547,10 @@ func (b *transactionSummaryBuilder) validateLogEvent() error {
 		return errors.New("Transaction entry point details are not set in transaction summary event")
 	}
 
+	if b.logEvent.TransactionSummary.Product != nil {
+		if b.logEvent.TransactionSummary.Product.ID == "" {
+			return errors.New("Product ID property not set in transaction summary event")
+		}
+	}
 	return nil
 }

--- a/pkg/transaction/logeventbuilder_test.go
+++ b/pkg/transaction/logeventbuilder_test.go
@@ -250,7 +250,7 @@ func TestSummaryBuilder(t *testing.T) {
 		SetTimestamp(timeStamp).
 		SetStatus(TxSummaryStatusSuccess, "200").
 		SetDuration(10).
-		SetProduct("product").
+		SetProduct("2222", "1.0").
 		SetRunTime("1111", "runtime1").
 		SetEntryPoint("http", "GET", "/test", "somehost.com").
 		Build()
@@ -276,7 +276,9 @@ func TestSummaryBuilder(t *testing.T) {
 	assert.Equal(t, "", logEvent.TransactionSummary.Proxy.Name)
 	assert.Equal(t, 0, logEvent.TransactionSummary.Proxy.Revision)
 
-	assert.Equal(t, "product", logEvent.TransactionSummary.Product)
+	assert.NotNil(t, logEvent.TransactionSummary.Product)
+	assert.Equal(t, "2222", logEvent.TransactionSummary.Product.ID)
+	assert.Equal(t, "1.0", logEvent.TransactionSummary.Product.Version)
 
 	assert.NotNil(t, logEvent.TransactionSummary.Runtime)
 	assert.Equal(t, "1111", logEvent.TransactionSummary.Runtime.ID)


### PR DESCRIPTION
Update the struct to for ID and Version to match definitions.json
"product": {
      "type": "object",
      "description": "Descriptor of the product",
      "properties": {
        "id": {
          "type": "string",
          "description": "Product id"
        },
        "version": {
          "type": "string",
          "description": "Product version"
        }
      },
      "required": [
        "id"
      ]
    },
