### PR TITLE
Apigov - 19048 - add back temporary "old" healthchecker

### DIFF
--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -256,7 +256,7 @@ func registerHealthCheckers(config *Config) error {
 		}
 
 		// TBD. Remove in future when Jobs interface is complete
-		err = registerOldHealthChecker(hcJob, "Traceability Agent", ta.host, config.Protocol)
+		err = registerOldHealthChecker(hcJob, ta.host)
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func registerHealthCheckers(config *Config) error {
 }
 
 // TODO: From here down all temporary until Jobs interface finishes full implementation
-func registerOldHealthChecker(hcJob *condorHealthCheckJob, name, host, protocol string) error {
+func registerOldHealthChecker(hcJob *condorHealthCheckJob, host string) error {
 	checkStatus := hcJob.agentHealthChecker.connectionHealthcheck
 
 	_, err := hc.RegisterHealthcheck("Traceability Agent", host, checkStatus)

--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -256,7 +256,7 @@ func registerHealthCheckers(config *Config) error {
 		}
 
 		// TBD. Remove in future when Jobs interface is complete
-		err = registerOldHealthChecker(hcJob, ta.host)
+		err = registerHealthChecker(hcJob, ta.host)
 		if err != nil {
 			return err
 		}
@@ -265,7 +265,7 @@ func registerHealthCheckers(config *Config) error {
 }
 
 // TODO: From here down all temporary until Jobs interface finishes full implementation
-func registerOldHealthChecker(hcJob *condorHealthCheckJob, host string) error {
+func registerHealthChecker(hcJob *condorHealthCheckJob, host string) error {
 	checkStatus := hcJob.agentHealthChecker.connectionHealthcheck
 
 	_, err := hc.RegisterHealthcheck("Traceability Agent", host, checkStatus)

--- a/pkg/traceability/traceability_test.go
+++ b/pkg/traceability/traceability_test.go
@@ -199,7 +199,7 @@ func TestCreateLogstashClient(t *testing.T) {
 
 	testConfig.Pipelining = 5
 	testConfig.Hosts = []string{
-		"somehost",
+		"somehost2",
 	}
 	group, err = createTransport(testConfig)
 	assert.Nil(t, err)


### PR DESCRIPTION
Because the jobs interface does not currently do retries and eventually fail, it does not function as a healthchecker the way the other healthcheckers do... it does not terminate the agent when there is an error. So, in order to temporarily make the agent fail on startup as expected if there is an error, I implemented both a healthchecker Job (the way we want to move to in the future) and an "old-style" healthchecker, which in the future (marked by TODO comments) will be removed.