### PR TITLE
APIGOV-19413 - update trans and metrics/usage events

### DIFF
--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -207,14 +207,15 @@ func (client *Client) Publish(batch publisher.Batch) error {
 	}
 
 	publishCount := len(batch.Events())
-	log.Infof("Publishing %d events", publishCount)
+	log.Infof("Creating %d transaction events", publishCount)
 	//update the local activity timestamp for the event to compare against
 	agent.UpdateLocalActivityTime()
 	err = client.transportClient.Publish(batch)
 	if err != nil {
+		log.Error("Failed to publish transaction event : ", err.Error())
 		return err
 	}
-	log.Infof("Published %d events", publishCount-len(batch.Events()))
+	log.Infof("%d events have been published", publishCount-len(batch.Events()))
 	return nil
 }
 

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -275,7 +275,7 @@ func (c *collector) generateLighthouseUsageEvent(transactionCount metrics.Counte
 		metric: transactionCount,
 	}
 	c.publishItemQueue = append(c.publishItemQueue, queueItem)
-	log.Infof("Generated usage events [start timestamp: %d, end timestamp: %d]", convertTimeToMillis(c.startTime), convertTimeToMillis(c.endTime))
+	log.Infof("Published usage report [start timestamp: %d, end timestamp: %d]", convertTimeToMillis(c.startTime), convertTimeToMillis(c.endTime))
 }
 
 // func (c *collector) processTransactionMetric(metricName string, metric interface{}) {
@@ -354,7 +354,7 @@ func (c *collector) publishEvents() {
 		for _, eventQueueItem := range c.publishItemQueue {
 			err := c.publisher.publishEvent(eventQueueItem.GetEvent())
 			if err != nil {
-				log.Error("Failed to publish event : ", err.Error())
+				log.Error("Failed to publish usage event : ", err.Error())
 			} else {
 				c.cleanupCounters(eventQueueItem)
 			}


### PR DESCRIPTION
The following logs have been updated

traceability
where %d is the number
1. "Creating %d transaction events"
2. "%d events have been published"
3. "Failed to publish transaction event : "

metrics and usage
1. "Creating usage event with %d transactions"
2. "Published usage report [start timestamp: %d, end timestamp: %d]"
3. "Failed to publish usage event : "