### PR TITLE
APIGOV-19572 - report last activity based on activity frequency

### DIFF
--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -117,8 +117,6 @@ func PublishAPI(serviceBody apic.ServiceBody) error {
 			apiSvc, e := ret.AsInstance()
 			if e == nil {
 				addItemToAPICache(*apiSvc)
-				//update the local activity timestamp for the event to compare against
-				UpdateLocalActivityTime()
 			}
 		} else {
 			return err

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -72,8 +72,6 @@ func (su *agentStatusUpdate) Execute() error {
 			su.prevStatus = status
 			return nil
 		}
-
-		UpdateLocalActivityTime()
 	}
 
 	// If its a periodic check, tickle last activity so that UI shows agent is still alive.  Not needed for immediate check.
@@ -158,9 +156,4 @@ func runStatusUpdateCheck() error {
 		return errors.ErrStartingAgentStatusUpdate.FormatError(periodic)
 	}
 	return nil
-}
-
-// UpdateLocalActivityTime - updates the local activity timestamp for the event to compare against
-func UpdateLocalActivityTime() {
-	periodicStatusUpdate.currentActivityTime = time.Now()
 }

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -76,13 +76,14 @@ func (su *agentStatusUpdate) Execute() error {
 		UpdateLocalActivityTime()
 	}
 
-	// if the last timestamp for an event has changed, update the resource
-	if time.Time(su.currentActivityTime).After(time.Time(su.previousActivityTime)) {
-		log.Tracef("Activity change detected at %s, from previous activity at %s, updating status", su.currentActivityTime, su.previousActivityTime)
+	// If its a periodic check, tickle last activity so that UI shows agent is still alive.  Not needed for immediate check.
+	if su.typeOfStatusUpdate == periodic {
+		log.Debugf("%s -- Last activity updated", su.typeOfStatusUpdate)
 		UpdateStatus(status, "")
 		su.prevStatus = status
 		su.previousActivityTime = su.currentActivityTime
 	}
+
 	return nil
 }
 
@@ -162,8 +163,4 @@ func runStatusUpdateCheck() error {
 // UpdateLocalActivityTime - updates the local activity timestamp for the event to compare against
 func UpdateLocalActivityTime() {
 	periodicStatusUpdate.currentActivityTime = time.Now()
-}
-
-func getLocalActivityTime() time.Time {
-	return periodicStatusUpdate.currentActivityTime
 }

--- a/pkg/agent/util.go
+++ b/pkg/agent/util.go
@@ -10,15 +10,8 @@ import (
 )
 
 // getTimestamp - Returns current timestamp formatted for API Server
-// if the local status exists, return the local timestamp, otherwise return Now()
 func getTimestamp() v1.Time {
 	activityTime := time.Now()
-	if periodicStatusUpdate != nil {
-		curTime := getLocalActivityTime()
-		if !curTime.IsZero() {
-			activityTime = curTime
-		}
-	}
 	newV1Time := v1.Time(activityTime)
 	return newV1Time
 }

--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -211,8 +211,6 @@ func (client *Client) Publish(batch publisher.Batch) error {
 		log.Infof("Creating %d transaction events", publishCount)
 	}
 
-	//update the local activity timestamp for the event to compare against
-	agent.UpdateLocalActivityTime()
 	err = client.transportClient.Publish(batch)
 	if err != nil {
 		log.Error("Failed to publish transaction event : ", err.Error())


### PR DESCRIPTION
1. Checks are run based on -> CENTRAL_REPORTACTIVITYFREQUENCY
2. When frequency hits, update last activity time for agent resource (and ultimately UI)
3. Only report CENTRAL_REPORTACTIVITYFREQUENCY for periodic checks.  Filter on periodic and not immediate.  Immediate only used for agent status 
4. Refactor time since only periodic status uses it