### PR TITLE
APIGOV-19570 - Limiting the calls for subscription schema updates 

### DIFF
--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -11,6 +11,7 @@ import (
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
+	"github.com/Axway/agent-sdk/pkg/cache"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/util/errors"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
@@ -70,7 +71,7 @@ func New(cfg corecfg.CentralConfig, tokenRequester auth.PlatformTokenGetter) Cli
 
 	serviceClient := &ServiceClient{}
 	serviceClient.SetTokenGetter(tokenRequester)
-
+	serviceClient.subscriptionSchemaCache = cache.New()
 	serviceClient.OnConfigChange(cfg)
 	hc.RegisterHealthcheck(serverName, "central", serviceClient.Healthcheck)
 	return serviceClient

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -95,9 +95,7 @@ func (c *ServiceClient) enableSubscription(serviceBody *ServiceBody) bool {
 	enableSubscription := serviceBody.AuthPolicy != Passthrough
 	// if there isn't a registered subscription schema, do not enable subscriptions,
 	// or if the status is not PUBLISHED, do not enable subscriptions
-	if enableSubscription && c.RegisteredSubscriptionSchema == nil ||
-		serviceBody.Status != PublishedStatus ||
-		serviceBody.SubscriptionName == "" {
+	if serviceBody.Status != PublishedStatus || serviceBody.SubscriptionName == "" {
 		enableSubscription = false
 	}
 

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -4,6 +4,7 @@ import (
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
+	"github.com/Axway/agent-sdk/pkg/cache"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 )
 
@@ -141,7 +142,7 @@ type ServiceClient struct {
 	cfg                                corecfg.CentralConfig
 	apiClient                          coreapi.Client
 	DefaultSubscriptionSchema          SubscriptionSchema
-	RegisteredSubscriptionSchema       SubscriptionSchema
+	subscriptionSchemaCache            cache.Cache
 	subscriptionMgr                    SubscriptionManager
 	DefaultSubscriptionApprovalWebhook corecfg.WebhookConfig
 }

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -1,6 +1,8 @@
 package apic
 
 import (
+	"sync"
+
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
@@ -145,6 +147,7 @@ type ServiceClient struct {
 	subscriptionSchemaCache            cache.Cache
 	subscriptionMgr                    SubscriptionManager
 	DefaultSubscriptionApprovalWebhook corecfg.WebhookConfig
+	subscriptionRegistrationLock       sync.Mutex
 }
 
 // APIServerInfoProperty -

--- a/pkg/apic/mockserviceclient.go
+++ b/pkg/apic/mockserviceclient.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/api"
+	"github.com/Axway/agent-sdk/pkg/cache"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 )
 
@@ -51,6 +52,7 @@ func GetTestServiceClient() (*ServiceClient, *api.MockHTTPClient) {
 	svcClient := &ServiceClient{
 		cfg:                                cfg,
 		tokenRequester:                     MockTokenGetter,
+		subscriptionSchemaCache:            cache.New(),
 		apiClient:                          apiClient,
 		DefaultSubscriptionApprovalWebhook: webhook,
 		DefaultSubscriptionSchema:          NewSubscriptionSchema(cfg.GetEnvironmentName() + SubscriptionSchemaNameSuffix),

--- a/pkg/apic/subscriptionschema.go
+++ b/pkg/apic/subscriptionschema.go
@@ -123,10 +123,74 @@ func (ss *subscriptionSchema) mapStringInterface() (map[string]interface{}, erro
 // RegisterSubscriptionSchema - Adds a new subscription schema for the specified auth type. In publishToEnvironment mode
 // creates a API Server resource for subscription definition
 func (c *ServiceClient) RegisterSubscriptionSchema(subscriptionSchema SubscriptionSchema, update bool) error {
-	c.RegisteredSubscriptionSchema = subscriptionSchema
+	var registeredSpecHash uint64
+	registeredSchema := c.getCachedSubscriptionSchema(subscriptionSchema.GetSubscriptionName())
+	if registeredSchema != nil {
+		registeredSpecHash, _ = util.ComputeHash(registeredSchema.Spec)
+	} else {
+		update = true
+	}
 
+	spec, err := c.prepareSubscriptionDefinitionSpec(subscriptionSchema)
+	if err != nil {
+		return err
+	}
+	// Create New definition
+	if registeredSchema == nil {
+		return c.createSubscriptionSchema(subscriptionSchema.GetSubscriptionName(), spec)
+	}
+
+	if update {
+		// Check if the schema definitions changed before update
+		currentHash, _ := util.ComputeHash(spec)
+		if currentHash != registeredSpecHash {
+			return c.updateSubscriptionSchema(subscriptionSchema.GetSubscriptionName(), spec)
+		}
+	}
+
+	return nil
+}
+
+func (c *ServiceClient) getCachedSubscriptionSchema(defName string) *v1alpha1.ConsumerSubscriptionDefinition {
+	cachedSchema, err := c.subscriptionSchemaCache.Get(defName)
+	if err != nil {
+		registeredSchema, _ := c.getSubscriptionSchema(defName)
+		if registeredSchema != nil {
+			c.subscriptionSchemaCache.Set(defName, registeredSchema)
+		}
+		return registeredSchema
+	}
+	return cachedSchema.(*v1alpha1.ConsumerSubscriptionDefinition)
+}
+
+func (c *ServiceClient) getSubscriptionSchema(schemaName string) (*v1alpha1.ConsumerSubscriptionDefinition, error) {
+	headers, err := c.createHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	request := coreapi.Request{
+		Method:  coreapi.GET,
+		URL:     c.cfg.GetAPIServerSubscriptionDefinitionURL() + "/" + schemaName,
+		Headers: headers,
+	}
+
+	response, err := c.apiClient.Send(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Code != http.StatusOK {
+		return nil, nil
+	}
+	registeredSchema := &v1alpha1.ConsumerSubscriptionDefinition{}
+	json.Unmarshal(response.Body, registeredSchema)
+	return registeredSchema, nil
+}
+
+func (c *ServiceClient) createSubscriptionSchema(defName string, spec *v1alpha1.ConsumerSubscriptionDefinitionSpec) error {
 	//Add API Server resource - SubscriptionDefinition
-	buffer, err := c.marshalSubscriptionDefinition(subscriptionSchema)
+	buffer, err := c.marshalSubscriptionDefinition(defName, spec)
 
 	headers, err := c.createHeader()
 	if err != nil {
@@ -144,25 +208,19 @@ func (c *ServiceClient) RegisterSubscriptionSchema(subscriptionSchema Subscripti
 	if err != nil {
 		return agenterrors.Wrap(ErrSubscriptionSchemaCreate, err.Error())
 	}
-	if !(response.Code == http.StatusCreated || response.Code == http.StatusConflict) {
+	if response.Code != http.StatusCreated {
 		readResponseErrors(response.Code, response.Body)
 		return agenterrors.Wrap(ErrSubscriptionSchemaResp, coreapi.POST).FormatError(response.Code)
 	}
-	if response.Code == http.StatusConflict && update {
-		// Call update if a conflict was returned
-		return c.UpdateSubscriptionSchema(subscriptionSchema)
-	}
-
+	registeredSchema := &v1alpha1.ConsumerSubscriptionDefinition{}
+	json.Unmarshal(response.Body, registeredSchema)
+	c.subscriptionSchemaCache.Set(defName, registeredSchema)
 	return nil
 }
 
-// UpdateSubscriptionSchema - Updates a subscription schema in Publish to environment mode
-// creates a API Server resource for subscription definition
-func (c *ServiceClient) UpdateSubscriptionSchema(subscriptionSchema SubscriptionSchema) error {
-	c.RegisteredSubscriptionSchema = subscriptionSchema
-
+func (c *ServiceClient) updateSubscriptionSchema(defName string, spec *v1alpha1.ConsumerSubscriptionDefinitionSpec) error {
 	// Add API Server resource - SubscriptionDefinition
-	buffer, err := c.marshalSubscriptionDefinition(subscriptionSchema)
+	buffer, err := c.marshalSubscriptionDefinition(defName, spec)
 
 	headers, err := c.createHeader()
 	if err != nil {
@@ -170,7 +228,7 @@ func (c *ServiceClient) UpdateSubscriptionSchema(subscriptionSchema Subscription
 	}
 	request := coreapi.Request{
 		Method:  coreapi.PUT,
-		URL:     c.cfg.GetAPIServerSubscriptionDefinitionURL() + "/" + subscriptionSchema.GetSubscriptionName(),
+		URL:     c.cfg.GetAPIServerSubscriptionDefinitionURL() + "/" + defName,
 		Headers: headers,
 		Body:    buffer,
 	}
@@ -183,11 +241,23 @@ func (c *ServiceClient) UpdateSubscriptionSchema(subscriptionSchema Subscription
 		readResponseErrors(response.Code, response.Body)
 		return agenterrors.Wrap(ErrSubscriptionSchemaResp, coreapi.PUT).FormatError(response.Code)
 	}
-
+	registeredSchema := &v1alpha1.ConsumerSubscriptionDefinition{}
+	json.Unmarshal(response.Body, registeredSchema)
+	c.subscriptionSchemaCache.Set(defName, registeredSchema)
 	return nil
 }
 
-func (c *ServiceClient) marshalSubscriptionDefinition(subscriptionSchema SubscriptionSchema) ([]byte, error) {
+// UpdateSubscriptionSchema - Updates a subscription schema in Publish to environment mode
+// creates a API Server resource for subscription definition
+func (c *ServiceClient) UpdateSubscriptionSchema(subscriptionSchema SubscriptionSchema) error {
+	spec, err := c.prepareSubscriptionDefinitionSpec(subscriptionSchema)
+	if err != nil {
+		return err
+	}
+	return c.updateSubscriptionSchema(subscriptionSchema.GetSubscriptionName(), spec)
+}
+
+func (c *ServiceClient) prepareSubscriptionDefinitionSpec(subscriptionSchema SubscriptionSchema) (*v1alpha1.ConsumerSubscriptionDefinitionSpec, error) {
 	catalogSubscriptionSchema, err := subscriptionSchema.mapStringInterface()
 	if err != nil {
 		return nil, err
@@ -197,7 +267,8 @@ func (c *ServiceClient) marshalSubscriptionDefinition(subscriptionSchema Subscri
 	if c.cfg.GetSubscriptionConfig().GetSubscriptionApprovalMode() == corecfg.WebhookApproval {
 		webhooks = append(webhooks, DefaultSubscriptionWebhookName)
 	}
-	spec := v1alpha1.ConsumerSubscriptionDefinitionSpec{
+
+	return &v1alpha1.ConsumerSubscriptionDefinitionSpec{
 		Webhooks: webhooks,
 		Schema: v1alpha1.ConsumerSubscriptionDefinitionSpecSchema{
 			Properties: []v1alpha1.ConsumerSubscriptionDefinitionSpecSchemaProperties{
@@ -207,17 +278,19 @@ func (c *ServiceClient) marshalSubscriptionDefinition(subscriptionSchema Subscri
 				},
 			},
 		},
-	}
+	}, nil
+}
 
+func (c *ServiceClient) marshalSubscriptionDefinition(defName string, spec *v1alpha1.ConsumerSubscriptionDefinitionSpec) ([]byte, error) {
 	apiServerService := v1alpha1.ConsumerSubscriptionDefinition{
 		ResourceMeta: v1.ResourceMeta{
 			GroupVersionKind: v1alpha1.ConsumerSubscriptionDefinitionGVK(),
-			Name:             subscriptionSchema.GetSubscriptionName(),
+			Name:             defName,
 			Title:            "Subscription definition created by agent",
 			Attributes:       nil,
 			Tags:             nil,
 		},
-		Spec: spec,
+		Spec: *spec,
 	}
 
 	return json.Marshal(apiServerService)

--- a/pkg/apic/subscriptionschema.go
+++ b/pkg/apic/subscriptionschema.go
@@ -123,6 +123,9 @@ func (ss *subscriptionSchema) mapStringInterface() (map[string]interface{}, erro
 // RegisterSubscriptionSchema - Adds a new subscription schema for the specified auth type. In publishToEnvironment mode
 // creates a API Server resource for subscription definition
 func (c *ServiceClient) RegisterSubscriptionSchema(subscriptionSchema SubscriptionSchema, update bool) error {
+	c.subscriptionRegistrationLock.Lock()
+	defer c.subscriptionRegistrationLock.Unlock()
+
 	var registeredSpecHash uint64
 	registeredSchema := c.getCachedSubscriptionSchema(subscriptionSchema.GetSubscriptionName())
 	if registeredSchema != nil {

--- a/pkg/apic/subscriptionschemabuilder_test.go
+++ b/pkg/apic/subscriptionschemabuilder_test.go
@@ -26,6 +26,9 @@ func TestSubscriptionSchemaBuilderSetters(t *testing.T) {
 	svcClient, mockHTTPClient := GetTestServiceClient()
 	mockHTTPClient.SetResponses([]api.MockResponse{
 		{
+			RespCode: http.StatusNotFound,
+		},
+		{
 			RespCode: http.StatusCreated,
 		},
 	})
@@ -48,7 +51,7 @@ func TestSubscriptionSchemaBuilderSetters(t *testing.T) {
 		},
 	})
 	err = NewSubscriptionSchemaBuilder(svcClient).
-		SetName("name").
+		SetName("name1").
 		AddUniqueKey("key").
 		AddProperty(NewSubscriptionSchemaPropertyBuilder().
 			SetName("name").

--- a/pkg/util/healthcheck/healthchecker.go
+++ b/pkg/util/healthcheck/healthchecker.go
@@ -158,7 +158,7 @@ func HandleRequests() {
 // CheckIsRunning - Checks if another instance is already running by looking at the healthcheck
 func CheckIsRunning() error {
 	if statusConfig != nil && statusConfig.GetPort() > 0 {
-		apiClient := api.NewClient(nil, "")
+		apiClient := api.NewClientWithTimeout(nil, "", 5*time.Second)
 		req := api.Request{
 			Method: "GET",
 			URL:    "http://0.0.0.0:" + strconv.Itoa(statusConfig.GetPort()) + "/status",


### PR DESCRIPTION
- Updates the subscription schema registration logic to use a local cache to identify if the schema requires updates.
- The subscription schema is retrieved on startup using GET call and stored in local cache
- On update lookup is done against the local cached if subscription schema requires update.
- When POST or PUT calls are placed for creating/updating the subscription schema, the schema is added to the local cache