### PR TITLE
APIGOV-19648 - jobs and discovery cache performance changes

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -163,21 +163,25 @@ func OnAgentResourceChange(agentResourceChangeHandler ConfigChangeHandler) {
 
 func startAPIServiceCache() {
 	// register the update cache job
-	newDiscoveryCacheJob := newDiscoveryCache(false)
-	id, err := jobs.RegisterIntervalJobWithName(newDiscoveryCacheJob, agent.cfg.GetPollInterval(), "New APIs Cache")
-	if err != nil {
-		log.Errorf("could not start the New APIs cache update job: %v", err.Error())
-		return
-	}
-	log.Tracef("registered API cache update job: %s", id)
-
 	allDiscoveryCacheJob := newDiscoveryCache(true)
-	id, err = jobs.RegisterIntervalJobWithName(allDiscoveryCacheJob, time.Hour, "All APIs Cache")
+	id, err := jobs.RegisterIntervalJobWithName(allDiscoveryCacheJob, time.Hour, "All APIs Cache")
 	if err != nil {
 		log.Errorf("could not start the All APIs cache update job: %v", err.Error())
 		return
 	}
+	log.Tracef("registered API cache update all job: %s", id)
 
+	// Start the regular update after the first interval
+	go func() {
+		time.Sleep(agent.cfg.GetPollInterval())
+		newDiscoveryCacheJob := newDiscoveryCache(false)
+		id, err := jobs.RegisterIntervalJobWithName(newDiscoveryCacheJob, agent.cfg.GetPollInterval(), "New APIs Cache")
+		if err != nil {
+			log.Errorf("could not start the New APIs cache update job: %v", err.Error())
+			return
+		}
+		log.Tracef("registered API cache update job: %s", id)
+	}()
 }
 
 func isRunningInDockerContainer() bool {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic"
@@ -171,7 +172,7 @@ func startAPIServiceCache() {
 	log.Tracef("registered API cache update job: %s", id)
 
 	allDiscoveryCacheJob := newDiscoveryCache(true)
-	id, err = jobs.RegisterScheduledJobWithName(allDiscoveryCacheJob, "0 1 * * *", "All APIs Cache")
+	id, err = jobs.RegisterIntervalJobWithName(allDiscoveryCacheJob, time.Hour, "All APIs Cache")
 	if err != nil {
 		log.Errorf("could not start the All APIs cache update job: %v", err.Error())
 		return

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -161,7 +161,7 @@ func OnAgentResourceChange(agentResourceChangeHandler ConfigChangeHandler) {
 
 func startAPIServiceCache() {
 	// register the update cache job
-	id, err := jobs.RegisterIntervalJob(&discoveryCache{}, agent.cfg.GetPollInterval())
+	id, err := jobs.RegisterIntervalJobWithName(&discoveryCache{}, agent.cfg.GetPollInterval(), "Discovery Cache")
 	if err != nil {
 		log.Errorf("could not start the API cache update job: %v", err.Error())
 		return

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -173,8 +173,10 @@ func startAPIServiceCache() {
 
 	// Start the regular update after the first interval
 	go func() {
-		time.Sleep(agent.cfg.GetPollInterval())
 		newDiscoveryCacheJob := newDiscoveryCache(false)
+		newDiscoveryCacheJob.lastInstanceTime = time.Now()
+		newDiscoveryCacheJob.lastServiceTime = time.Now()
+		time.Sleep(agent.cfg.GetPollInterval())
 		id, err := jobs.RegisterIntervalJobWithName(newDiscoveryCacheJob, agent.cfg.GetPollInterval(), "New APIs Cache")
 		if err != nil {
 			log.Errorf("could not start the New APIs cache update job: %v", err.Error())

--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -108,6 +108,7 @@ func restoreCacheUpdateCalls() {
 
 func TestDiscoveryCache(t *testing.T) {
 	fakeCacheUpdateCalls()
+	dcj := newDiscoveryCache(true)
 	attributeKey := "Attr1"
 	attributeValue := "testValue"
 	emptyAPISvc := []v1.ResourceInstance{}
@@ -152,13 +153,13 @@ func TestDiscoveryCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	serverAPISvcResponse = emptyAPISvc
-	updateAPICache()
+	dcj.updateAPICache()
 	assert.Equal(t, 0, len(agent.apiMap.GetKeys()))
 	assert.False(t, IsAPIPublishedByID("1111"))
 	assert.False(t, IsAPIPublishedByID("2222"))
 
 	serverAPISvcResponse = []v1.ResourceInstance{apiSvc1}
-	updateAPICache()
+	dcj.updateAPICache()
 	assert.Equal(t, 1, len(agent.apiMap.GetKeys()))
 	assert.True(t, IsAPIPublishedByID("1111"))
 	assert.False(t, IsAPIPublishedByID("2222"))
@@ -179,7 +180,7 @@ func TestDiscoveryCache(t *testing.T) {
 	assert.True(t, IsAPIPublishedByID("2222"))
 
 	serverAPISvcResponse = []v1.ResourceInstance{apiSvc1}
-	updateAPICache()
+	dcj.updateAPICache()
 	assert.Equal(t, 1, len(agent.apiMap.GetKeys()))
 	assert.True(t, IsAPIPublishedByID("1111"))
 	assert.True(t, IsAPIPublishedByPrimaryKey("1234"))

--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -32,6 +32,10 @@ func (m *mockSvcClient) GetAPIServiceRevisions(queryParams map[string]string, UR
 	return nil, nil
 }
 
+func (m *mockSvcClient) GetAPIV1ResourceInstancesWithPageSize(queryParams map[string]string, URL string, pageSize int) ([]*v1.ResourceInstance, error) {
+	return nil, nil
+}
+
 func (m *mockSvcClient) GetAPIV1ResourceInstances(queryParams map[string]string, URL string) ([]*v1.ResourceInstance, error) {
 	return nil, nil
 }

--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
@@ -25,6 +26,12 @@ const (
 	apiServerFields      = "name,title,attributes"
 	serviceInstanceCache = "ServiceInstances"
 )
+
+var discoveryCacheLock *sync.Mutex
+
+func init() {
+	discoveryCacheLock = &sync.Mutex{}
+}
 
 type discoveryCache struct {
 	jobs.Job
@@ -58,6 +65,8 @@ func (j *discoveryCache) Status() error {
 
 //Execute -
 func (j *discoveryCache) Execute() error {
+	discoveryCacheLock.Lock()
+	defer discoveryCacheLock.Unlock()
 	log.Trace("executing API cache update job")
 	j.updateAPICache()
 	if agent.cfg.GetAgentType() == config.DiscoveryAgent {

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -32,7 +32,7 @@ func (su *agentStatusUpdate) Ready() bool {
 	}
 	// Do not start until status will be running
 	status := su.getCombinedStatus()
-	if status != AgentRunning {
+	if status != AgentRunning && su.immediateStatusChange == true {
 		return false
 	}
 
@@ -97,7 +97,7 @@ func startPeriodicStatusUpdate() {
 	periodicStatusUpdate = &agentStatusUpdate{
 		typeOfStatusUpdate: periodic,
 	}
-	_, err := jobs.RegisterIntervalJob(periodicStatusUpdate, interval)
+	_, err := jobs.RegisterIntervalJobWithName(periodicStatusUpdate, interval, "Status Update")
 
 	if err != nil {
 		log.Error(errors.ErrStartingAgentStatusUpdate.FormatError(periodic))
@@ -112,7 +112,7 @@ func startImmediateStatusUpdate() {
 		immediateStatusChange: true,
 		typeOfStatusUpdate:    immediate,
 	}
-	_, err := jobs.RegisterDetachedIntervalJob(immediateStatusUpdate, interval)
+	_, err := jobs.RegisterDetachedIntervalJobWithName(immediateStatusUpdate, interval, "Immediate Status Update")
 
 	if err != nil {
 		log.Error(errors.ErrStartingAgentStatusUpdate.FormatError(immediate))

--- a/pkg/apic/apiserver/models/api/v1/time.go
+++ b/pkg/apic/apiserver/models/api/v1/time.go
@@ -5,11 +5,11 @@ import (
 )
 
 const (
-	// apiServerTimeFormat - api-server time lacks the colon in timezone
-	apiServerTimeFormat = "2006-01-02T15:04:05.000-0700"
+	// APIServerTimeFormat - api-server time lacks the colon in timezone
+	APIServerTimeFormat = "2006-01-02T15:04:05.000-0700"
 
-	// apiServerTimeFormat - api-server time with colon in timezone
-	apiServerTimeFormat_ = "2006-01-02T15:04:05.000-07:00"
+	// APIServerTimeFormatAlt - api-server time with colon in timezone
+	APIServerTimeFormatAlt = "2006-01-02T15:04:05.000-07:00"
 )
 
 // Time - time
@@ -17,13 +17,13 @@ type Time time.Time
 
 // UnmarshalJSON - unmarshal json for time
 func (t *Time) UnmarshalJSON(bytes []byte) error {
-	tt, err := time.Parse(`"`+apiServerTimeFormat+`"`, string(bytes))
+	tt, err := time.Parse(`"`+APIServerTimeFormat+`"`, string(bytes))
 
 	if err == nil {
 		*t = Time(tt)
 		return nil
 	}
-	tt, err = time.Parse(`"`+apiServerTimeFormat_+`"`, string(bytes))
+	tt, err = time.Parse(`"`+APIServerTimeFormatAlt+`"`, string(bytes))
 	if err != nil {
 		return err
 	}
@@ -34,9 +34,9 @@ func (t *Time) UnmarshalJSON(bytes []byte) error {
 // MarshalJSON -
 func (t Time) MarshalJSON() ([]byte, error) {
 	tt := time.Time(t)
-	b := make([]byte, 0, len(apiServerTimeFormat)+2)
+	b := make([]byte, 0, len(APIServerTimeFormat)+2)
 	b = append(b, '"')
-	b = tt.AppendFormat(b, apiServerTimeFormat)
+	b = tt.AppendFormat(b, APIServerTimeFormat)
 	b = append(b, '"')
 	return b, nil
 }

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -63,6 +63,7 @@ type Client interface {
 	GetAPIServiceRevisions(queryParams map[string]string, URL, stage string) ([]*v1alpha1.APIServiceRevision, error)
 	GetAPIServiceInstances(queryParams map[string]string, URL string) ([]*v1alpha1.APIServiceInstance, error)
 	GetAPIV1ResourceInstances(queryParams map[string]string, URL string) ([]*apiv1.ResourceInstance, error)
+	GetAPIV1ResourceInstancesWithPageSize(queryParams map[string]string, URL string, pageSize int) ([]*apiv1.ResourceInstance, error)
 }
 
 // New -

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -23,6 +23,11 @@ const (
 	SubscriptionSchemaNameSuffix      = ".authsubscription"
 	DefaultSubscriptionWebhookName    = "subscriptionwebhook"
 	DefaultSubscriptionWebhookAuthKey = "webhookAuthKey"
+
+	FieldsKey = "fields"
+	QueryKey  = "query"
+
+	CreateTimestampQueryKey = "metadata.audit.createTimestamp"
 )
 
 // Constants for attributes
@@ -144,6 +149,7 @@ type ServiceClient struct {
 	RegisteredSubscriptionSchema       SubscriptionSchema
 	subscriptionMgr                    SubscriptionManager
 	DefaultSubscriptionApprovalWebhook corecfg.WebhookConfig
+	newService                         chan interface{}
 }
 
 // APIServerInfoProperty -

--- a/pkg/apic/resourcePagination.go
+++ b/pkg/apic/resourcePagination.go
@@ -53,8 +53,13 @@ func (c *ServiceClient) GetAPIServiceInstances(queryParams map[string]string, UR
 	return apiServiceIntances, nil
 }
 
-// GetAPIV1ResourceInstances - return apiv1 Resource instance
+// GetAPIV1ResourceInstances - return apiv1 Resource instance with the default page size
 func (c *ServiceClient) GetAPIV1ResourceInstances(queryParams map[string]string, URL string) ([]*apiv1.ResourceInstance, error) {
+	return c.GetAPIV1ResourceInstancesWithPageSize(queryParams, URL, apiServerPageSize)
+}
+
+// GetAPIV1ResourceInstancesWithPageSize - return apiv1 Resource instance
+func (c *ServiceClient) GetAPIV1ResourceInstancesWithPageSize(queryParams map[string]string, URL string, queryPageSize int) ([]*apiv1.ResourceInstance, error) {
 	morePages := true
 	page := 1
 
@@ -63,7 +68,7 @@ func (c *ServiceClient) GetAPIV1ResourceInstances(queryParams map[string]string,
 	for morePages {
 		query := map[string]string{
 			"page":     strconv.Itoa(page),
-			"pageSize": strconv.Itoa(apiServerPageSize),
+			"pageSize": strconv.Itoa(queryPageSize),
 		}
 
 		// Add query params for getting revisions for the service and use the latest one as last reference
@@ -83,7 +88,7 @@ func (c *ServiceClient) GetAPIV1ResourceInstances(queryParams map[string]string,
 
 		resourceInstance = append(resourceInstance, resourceInstancePage...)
 
-		if len(resourceInstancePage) < apiServerPageSize {
+		if len(resourceInstancePage) < queryPageSize {
 			morePages = false
 		} else {
 			log.Debug("More resource instance pages exist.  Continue retrieval of resource instances.")

--- a/pkg/apic/subscriptionmanager.go
+++ b/pkg/apic/subscriptionmanager.go
@@ -51,7 +51,7 @@ func newSubscriptionManager(apicClient *ServiceClient) SubscriptionManager {
 	}
 
 	if apicClient.cfg.GetSubscriptionConfig().PollingEnabled() {
-		_, err := jobs.RegisterIntervalJob(subscriptionMgr, apicClient.cfg.GetPollInterval())
+		_, err := jobs.RegisterIntervalJobWithName(subscriptionMgr, apicClient.cfg.GetPollInterval(), "Subscription Manager")
 		if err != nil {
 			log.Errorf("Error registering interval job to poll for subscriptions: %s", err.Error())
 		}

--- a/pkg/cmd/agentversionjob.go
+++ b/pkg/cmd/agentversionjob.go
@@ -205,7 +205,7 @@ func loadPage(name string) []byte {
 // startAgentVersionChecker - single run job to check for a newer agent version on jfrog
 func startAgentVersionChecker() {
 	// register the agent version checker single run job
-	id, err := jobs.RegisterSingleRunJob(&AgentVersionCheckJob{})
+	id, err := jobs.RegisterSingleRunJobWithName(&AgentVersionCheckJob{}, "Version Check")
 	if err != nil {
 		log.Errorf("could not start the agent version checker job: %v", err.Error())
 		return

--- a/pkg/jobs/definitions.go
+++ b/pkg/jobs/definitions.go
@@ -22,6 +22,7 @@ type JobExecution interface {
 	Unlock()
 	start()
 	stop()
+	getConsecutiveFails() int
 }
 
 //JobStatus - integer to represent the status of the job

--- a/pkg/jobs/detachedintervaljob.go
+++ b/pkg/jobs/detachedintervaljob.go
@@ -5,10 +5,11 @@ import (
 )
 
 //newDetachedIntervalJob - creates an interval run job, detached from other cron jobs
-func newDetachedIntervalJob(newJob Job, interval time.Duration) (JobExecution, error) {
+func newDetachedIntervalJob(newJob Job, interval time.Duration, name string) (JobExecution, error) {
 	thisJob := intervalJob{
 		baseJob{
 			id:       newUUID(),
+			name:     name,
 			job:      newJob,
 			jobType:  JobTypeDetachedInterval,
 			status:   JobStatusInitializing,

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -17,10 +17,11 @@ type intervalJob struct {
 }
 
 //newIntervalJob - creates an interval run job
-func newIntervalJob(newJob Job, interval time.Duration, failJobChan chan string) (JobExecution, error) {
+func newIntervalJob(newJob Job, interval time.Duration, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := intervalJob{
 		baseJob{
 			id:       newUUID(),
+			name:     name,
 			job:      newJob,
 			jobType:  JobTypeInterval,
 			status:   JobStatusInitializing,
@@ -43,7 +44,9 @@ func (b *intervalJob) handleExecution() {
 		b.setExecutionError()
 		log.Error(b.err)
 		b.SetStatus(JobStatusStopped)
+		b.consecutiveFails++
 	}
+	b.consecutiveFails = 0
 }
 
 //start - calls the Execute function from the Job definition

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -14,9 +14,19 @@ func RegisterSingleRunJob(newJob Job) (string, error) {
 	return globalPool.RegisterSingleRunJob(newJob)
 }
 
+//RegisterSingleRunJobWithName - Runs a single run job in the globalPool
+func RegisterSingleRunJobWithName(newJob Job, name string) (string, error) {
+	return globalPool.RegisterSingleRunJobWithName(newJob, name)
+}
+
 //RegisterIntervalJob - Runs a job with a specific interval between each run in the globalPool
 func RegisterIntervalJob(newJob Job, interval time.Duration) (string, error) {
 	return globalPool.RegisterIntervalJob(newJob, interval)
+}
+
+//RegisterIntervalJobWithName - Runs a job with a specific interval between each run in the globalPool
+func RegisterIntervalJobWithName(newJob Job, interval time.Duration, name string) (string, error) {
+	return globalPool.RegisterIntervalJobWithName(newJob, interval, name)
 }
 
 //RegisterDetachedIntervalJob - Runs a job with a specific interval between each run in the globalPool, detached from other jobs to always run
@@ -24,14 +34,29 @@ func RegisterDetachedIntervalJob(newJob Job, interval time.Duration) (string, er
 	return globalPool.RegisterDetachedIntervalJob(newJob, interval)
 }
 
+//RegisterDetachedIntervalJobWithName - Runs a job with a specific interval between each run in the globalPool, detached from other jobs to always run
+func RegisterDetachedIntervalJobWithName(newJob Job, interval time.Duration, name string) (string, error) {
+	return globalPool.RegisterDetachedIntervalJobWithName(newJob, interval, name)
+}
+
 //RegisterScheduledJob - Runs a job on a specific schedule in the globalPool
 func RegisterScheduledJob(newJob Job, schedule string) (string, error) {
 	return globalPool.RegisterScheduledJob(newJob, schedule)
 }
 
-//RegisterRetryJob - Runs a job with a limited number of retries in the globalPool
+//RegisterScheduledJobWithName - Runs a job on a specific schedule in the globalPool
+func RegisterScheduledJobWithName(newJob Job, schedule, name string) (string, error) {
+	return globalPool.RegisterScheduledJobWithName(newJob, schedule, name)
+}
+
+//RegisterRetryJob - Runs a job with a WithName
 func RegisterRetryJob(newJob Job, retries int) (string, error) {
 	return globalPool.RegisterRetryJob(newJob, retries)
+}
+
+//RegisterRetryJobWithName - Runs a job with a limited number of retries in the globalPool
+func RegisterRetryJobWithName(newJob Job, retries int, name string) (string, error) {
+	return globalPool.RegisterRetryJobWithName(newJob, retries, name)
 }
 
 //UnregisterJob - Removes the specified job in the globalPool

--- a/pkg/jobs/pool_test.go
+++ b/pkg/jobs/pool_test.go
@@ -12,7 +12,7 @@ func TestPoolCoordination(t *testing.T) {
 	testPool.retryInterval = time.Second
 	failJob := &intervalJobImpl{
 		name:      "FailedIntervalJob",
-		runTime:   50 * time.Millisecond,
+		runTime:   500 * time.Millisecond,
 		ready:     true,
 		failEvery: 3,
 		failTime:  50 * time.Millisecond,
@@ -45,7 +45,7 @@ func TestPoolCoordination(t *testing.T) {
 	// continue to get pool status to check that it was in a stopped state during test
 	wasStopped := false
 	stoppedThenStarted := false
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 200; i++ {
 		if !wasStopped && testPool.GetStatus() == PoolStatusStopped.String() {
 			wasStopped = true
 			assert.GreaterOrEqual(t, sJob.executions, 1, "The scheduled job did not run at least once before failure")

--- a/pkg/jobs/retryjob.go
+++ b/pkg/jobs/retryjob.go
@@ -14,7 +14,7 @@ type retryJob struct {
 }
 
 //newBaseJob - creates a single run job and sets up the structure for different job types
-func newRetryJob(newJob Job, retries int, failJobChan chan string) (JobExecution, error) {
+func newRetryJob(newJob Job, retries int, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := retryJob{
 		baseJob{
 			id:       newUUID(),

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -20,7 +20,7 @@ type scheduleJob struct {
 }
 
 //newScheduledJob - creates a job that is ran at a specific time (@hourly,@daily,@weekly,min hour dow dom)
-func newScheduledJob(newJob Job, schedule string, failJobChan chan string) (JobExecution, error) {
+func newScheduledJob(newJob Job, schedule, name string, failJobChan chan string) (JobExecution, error) {
 	exp, err := cronexpr.Parse(schedule)
 	if err != nil {
 		return nil, errors.Wrap(ErrRegisteringJob, err.Error()).FormatError("scheduled")

--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -290,7 +290,7 @@ func registerHealthCheckers(config *Config) error {
 		// TBD. Remove in future when Jobs interface is complete
 		ta.hcJob = hcJob
 
-		_, err := jobs.RegisterIntervalJob(hcJob, config.Timeout)
+		_, err := jobs.RegisterIntervalJobWithName(hcJob, config.Timeout, "Traceability Healthcheck")
 		if err != nil {
 			return err
 		}

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -98,7 +98,7 @@ func createMetricCollector() Collector {
 
 	if flag.Lookup("test.v") == nil {
 		var err error
-		metricCollector.jobID, err = jobs.RegisterIntervalJob(metricCollector, agent.GetCentralConfig().GetEventAggregationInterval())
+		metricCollector.jobID, err = jobs.RegisterIntervalJobWithName(metricCollector, agent.GetCentralConfig().GetEventAggregationInterval(), "Metric Collector")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
- Added ability to set page size when using api server paging methods
- Set page size for discovery cache to 100
- removed query filter on discovery cache and check locally for externalapiid attr
- getting api service instances in place of consumer instances
-- using cache to check for apis removed on dataplane
- only querying for new services and instances, hourly querying for all services and instances
- backoff implemented in jobs api

Note: not using the attribute on the agent resource, replaced with the timestamp query  