### PR TITLE
APIGOV-19751 - use go template for apiservicerevision title and email notification

### DIFF
--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -202,13 +202,13 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 		apiSvcRevPattern = strings.Replace(apiSvcRevPattern, datePattern, "{{.Date}}", -1) // Once we have the date format, change template to correct {{.Date}} tag
 		if dateFormat == "" {
 			// Customer is entered an incorrect date format.  Set template and pattern to defaults.
-			log.Tracef("CENTRAL_APISERVICEREVISIONPATTERN is returning an invalid {{date:*}} format. Setting format to YYYY-MM-DD")
+			log.Warnf("CENTRAL_APISERVICEREVISIONPATTERN is returning an invalid {{date:*}} format. Setting format to YYYY-MM-DD")
 			apiSvcRevPattern = apiSvcRevTemplate
 			dateFormat = "2006/01/02"
 		}
 	} else {
 		// Customer is still using deprecated date format.  Set template and pattern to defaults.
-		log.Warnf("{{date:*}} format for CENTRAL_APISERVICEREVISIONPATTERN is being deprecated. Please refer to axway.docs regarding valid {{.Date:*}} formats.")
+		log.Warnf("{{date:*}} format for CENTRAL_APISERVICEREVISIONPATTERN is deprecated. Please refer to axway.docs regarding valid {{.Date:*}} formats.")
 		apiSvcRevPattern = apiSvcRevTemplate
 		dateFormat = "2006/01/02"
 	}
@@ -225,7 +225,7 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 
 	title, err := template.New("apiSvcRevTitle").Parse(apiSvcRevPattern)
 	if err != nil {
-		log.Tracef("Could not render CENTRAL_APISERVICEREVISIONPATTERN. Returning %s", defaultAPISvcRevTitle, err.Error())
+		log.Warnf("Could not render CENTRAL_APISERVICEREVISIONPATTERN. Returning %s", defaultAPISvcRevTitle)
 		return defaultAPISvcRevTitle
 	}
 
@@ -233,7 +233,7 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 
 	err = title.Execute(&apiSvcRevTitle, apiSvcRevTitleTemplate)
 	if err != nil {
-		log.Tracef("Could not render CENTRAL_APISERVICEREVISIONPATTERN. Returning %s", defaultAPISvcRevTitle, err.Error())
+		log.Warnf("Could not render CENTRAL_APISERVICEREVISIONPATTERN. Please refer to axway.docs regarding valid CENTRAL_APISERVICEREVISIONPATTERN. Returning %s", defaultAPISvcRevTitle)
 		return defaultAPISvcRevTitle
 	}
 

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	apiSvcRevTemplate = "{{.APIServiceName}} - {{.Date}} - r {{.Revision}}"
+	defaultDateFormat = "2006/01/02"
 )
 
 // APIServiceRevisionTitle - apiservicerevision template for title
@@ -40,7 +41,7 @@ var apiSvcRevTitleDateMap = map[string]string{
 	"MM-DD-YYYY": "01-02-2006",
 	"MM/DD/YYYY": "01/02/2006",
 	"YYYY-MM-DD": "2006-01-02",
-	"YYYY/MM/DD": "2006/01/02",
+	"YYYY/MM/DD": defaultDateFormat,
 }
 
 func (c *ServiceClient) buildAPIServiceRevisionSpec(serviceBody *ServiceBody) v1alpha1.ApiServiceRevisionSpec {
@@ -204,13 +205,13 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 			// Customer is entered an incorrect date format.  Set template and pattern to defaults.
 			log.Warnf("CENTRAL_APISERVICEREVISIONPATTERN is returning an invalid {{date:*}} format. Setting format to YYYY-MM-DD")
 			apiSvcRevPattern = apiSvcRevTemplate
-			dateFormat = "2006/01/02"
+			dateFormat = defaultDateFormat
 		}
 	} else {
 		// Customer is still using deprecated date format.  Set template and pattern to defaults.
 		log.Warnf("{{date:*}} format for CENTRAL_APISERVICEREVISIONPATTERN is deprecated. Please refer to axway.docs regarding valid {{.Date:*}} formats.")
 		apiSvcRevPattern = apiSvcRevTemplate
-		dateFormat = "2006/01/02"
+		dateFormat = defaultDateFormat
 	}
 
 	// Build default apiSvcRevTitle.  To be used in case of error processing

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -45,8 +45,8 @@ type APIServiceRevisionTitle struct {
 // apiSvcRevTitleDateMap - map of date formats for apiservicerevision title
 var apiSvcRevTitleDateMap = map[string]string{
 	"MM-DD-YYYY": "01-02-2006",
-	"YYYY-MM-DD": "2006-01-02",
 	"MM/DD/YYYY": "01/02/2006",
+	"YYYY-MM-DD": "2006-01-02",
 	"YYYY/MM/DD": "2006/01/02",
 }
 

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -193,7 +192,7 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 
 	var apiSvcRevTitle bytes.Buffer
 
-	err = title.Execute(os.Stdout, apiSvcRevTitleTemplate)
+	err = title.Execute(&apiSvcRevTitle, apiSvcRevTitleTemplate)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/subscriptionconfig.go
+++ b/pkg/config/subscriptionconfig.go
@@ -143,15 +143,15 @@ func AddSubscriptionConfigProperties(props properties.Properties) {
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUserName, "", "Login user for the SMTP server")
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUserPassword, "", "Login password for the SMTP server")
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeSubject, "Subscription Notification", "Subject of the email notification for action subscribe")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeBody, "Subscription created for Catalog Item: <a href= ${catalogItemUrl}> ${catalogItemName}</a><br/>${authtemplate}<br/>", "Body of the email notification for action subscribe")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeOauth, "Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>${clientID}</b> and client_secret=<b>${clientSecret}</b>", "Body of the email notification for action subscribe on OAuth authorization if your API is secured using OAuth token")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeAPIKeys, "Your API is secured using an APIKey credential: header: <b>${keyHeaderName}</b> / value: <b>${key}</b>", "Body of the email notification for action subscribe on APIKey authorization if your API is secured using an APIKey")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeBody, "Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}.</br></a>{{if .IsAPIKey}} Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>{{else}} Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}", "Body of the email notification for action subscribe")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeOauth, "Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}", "Body of the email notification for action subscribe on OAuth authorization if your API is secured using OAuth token")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeAPIKeys, "Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>", "Body of the email notification for action subscribe on APIKey authorization if your API is secured using an APIKey")
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeSubject, "Subscription Removal Notification", "Subject of the email notification for action unsubscribe")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeBody, "Subscription for Catalog Item: <a href= ${catalogItemUrl}> ${catalogItemName}</a> has been unsubscribed", "Body of the email notification for action unsubscribe")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeBody, "Subscription for Catalog Item: <a href= {{.CatalogItemURL}}> {{CatalogItemName}} </a> has been unsubscribed", "Body of the email notification for action unsubscribe")
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeFailedSubject, "Subscription Failed Notification", "Subject of the email notification for action subscribe failed")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeFailedBody, "Could not subscribe to CatalogItem: <a href= ${catalogItemUrl}> ${catalogItemName}</a>", "Body of the email notification for action subscribe failed")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPSubscribeFailedBody, "Could not subscribe to Catalog Item: <a href= {{CatalogItemURL}}> {{CatalogItemName}}</a> {{.Message}}", "Body of the email notification for action subscribe failed")
 	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeFailedSubject, "Subscription Removal Failed Notification", "Subject of the email notification for action unsubscribe failed")
-	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeFailedBody, "Could not unsubscribe to Catalog Item: <a href= ${catalogItemUrl}> ${catalogItemName}</a>", "Body of the email notification for action unsubscribe failed")
+	props.AddStringProperty(pathSubscriptionsNotificationsSMTPUnsubscribeFailedBody, "Could not unsubscribe to Catalog Item: <a href= {{.CatalogItemUrl}}> {{.CatalogItemName}}  </a>*{{.Message}}", "Body of the email notification for action unsubscribe failed")
 }
 
 // ParseSubscriptionConfig -
@@ -417,7 +417,7 @@ func (s *SubscriptionConfiguration) validateWebhook() error {
 		if len(hvArray) != 2 {
 			return errors.New("could not parse value of central.subscriptions.notifications.headers")
 		}
-		hvArray[0] = strings.TrimLeft(hvArray[0], "Header=") // handle the first	header in the list
+		hvArray[0] = strings.TrimPrefix(hvArray[0], "Header=") // handle the first	header in the list
 		webhookConfig.webhookHeaders[hvArray[0]] = hvArray[1]
 	}
 

--- a/pkg/notify/definitions.go
+++ b/pkg/notify/definitions.go
@@ -2,18 +2,17 @@ package notify
 
 import (
 	"github.com/Axway/agent-sdk/pkg/apic"
-	"github.com/Axway/agent-sdk/pkg/config"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 )
 
 var globalCfg corecfg.SubscriptionConfig
-var templateActionMap map[apic.SubscriptionState]*config.EmailTemplate
+var templateActionMap map[apic.SubscriptionState]*corecfg.EmailTemplate
 
 // SetSubscriptionConfig - Creates the default subscription config
 func SetSubscriptionConfig(cfg corecfg.SubscriptionConfig) {
 	globalCfg = cfg
 
-	templateActionMap = map[apic.SubscriptionState]*config.EmailTemplate{
+	templateActionMap = map[apic.SubscriptionState]*corecfg.EmailTemplate{
 		apic.SubscriptionActive:              cfg.GetSubscribeTemplate(),
 		apic.SubscriptionUnsubscribed:        cfg.GetUnsubscribeTemplate(),
 		apic.SubscriptionFailedToSubscribe:   cfg.GetSubscribeFailedTemplate(),

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -263,7 +263,7 @@ func (s *SubscriptionNotification) setEmailBodyTemplate(body string) string {
 	return catalogItem.String()
 }
 
-// CatalogItem - for template use
+// EmailBody - for template use
 type EmailBody struct {
 	CatalogItemURL  string
 	CatalogItemName string

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -17,6 +17,13 @@ import (
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
+//TODO
+/*
+	1. Search for comment "DEPRECATED to be removed on major release"
+	2. Remove deprecated code left from APIGOV-19751
+*/
+
+//DEPRECATED to be removed on major release - this map will no longer be needed after "${tag} is invalid"
 // subNotifTemplateMap - map of date formats for apiservicerevision title
 var subNotifTemplateMap = map[string]string{
 	"${catalogItemUrl}":  "{{.CatalogItemURL}}",
@@ -98,6 +105,7 @@ func (s *SubscriptionNotification) SetAuthorizationTemplate(authType string) {
 		return
 	}
 
+	//DEPRECATED to be removed on major release - setting s.AuthTemplate will no longer be needed after "${tag} is invalid"
 	switch authType {
 	case Apikeys:
 		s.AuthTemplate = template.APIKey
@@ -213,6 +221,8 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 
 	log.Debugf("Sending email %s, %s, %s", fromAddress, toAddress, subject)
 
+	//DEPRECATED to be removed on major release - this check for '${"' will no longer be needed after "${tag} is invalid"
+
 	// Verify if customer is still using "${tag}" teamplate.  Warn them that it is going to be deprecated
 	// Transform the old "${tag}" to the go template {{.Tag}}
 	if strings.Contains(template.Body, "${") {
@@ -278,22 +288,3 @@ func (s *SubscriptionNotification) setEmailBodyTemplate(body string) string {
 
 	return catalogItem.String()
 }
-
-/*
-Subscription Body templates
-
-CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_SUBSCRIBE_BODY=
-Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}</a></br>
-{{if .IsAPIKey}} Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>
-{{else}} Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}
-
-CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_UNSUBSCRIBE_BODY=
-Subscription for Catalog Item: <a href= {{.CatalogItemURL}}> {{CatalogItemName}} </a> has been unsubscribed
-
-CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_SUBSCRIBEFAILED_BODY=
-Could not subscribe to Catalog Item: <a href= {{CatalogItemURL}}> {{CatalogItemName}}</a> {{.Message}}
-
-CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_UNSUBSCRIBEFAILED_BODY=
-Could not unsubscribe to Catalog Item: <a href= {{.CatalogItemUrl}}> {{.CatalogItemName}}  </a>*{{.Message}} /
-
-*/

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -1,16 +1,17 @@
 package notify
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"text/template"
 
 	sasl "github.com/emersion/go-sasl"
 	smtp "github.com/emersion/go-smtp"
 
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic"
-	"github.com/Axway/agent-sdk/pkg/config"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
@@ -29,6 +30,7 @@ type SubscriptionNotification struct {
 	ClientID        string                 `json:"clientID,omitempty"`
 	ClientSecret    string                 `json:"clientSecret,omitempty"`
 	AuthTemplate    string                 `json:"authtemplate,omitempty"`
+	AuthType        string                 `json:"authType,omitempty"`
 	apiClient       coreapi.Client
 }
 
@@ -85,8 +87,10 @@ func (s *SubscriptionNotification) SetAuthorizationTemplate(authType string) {
 	switch authType {
 	case Apikeys:
 		s.AuthTemplate = s.UpdateTemplate(template.APIKey)
+		s.AuthType = Apikeys
 	case Oauth:
 		s.AuthTemplate = s.UpdateTemplate(template.Oauth)
+		s.AuthType = Oauth
 	default:
 		log.Error(ErrSubscriptionBadAuthtype.FormatError(authType))
 		return
@@ -101,7 +105,7 @@ func (s *SubscriptionNotification) NotifySubscriber(recipient string) error {
 	for _, notificationType := range globalCfg.GetNotificationTypes() {
 		log.Debugf("Attempt to notify using %s", notificationType)
 		switch notificationType {
-		case config.NotifyWebhook:
+		case corecfg.NotifyWebhook:
 			err := s.notifyViaWebhook()
 			if err != nil {
 				return utilerrors.Wrap(ErrSubscriptionNotification, err.Error()).FormatError("webhook")
@@ -109,7 +113,7 @@ func (s *SubscriptionNotification) NotifySubscriber(recipient string) error {
 			notificationSent = true
 			log.Debugf("Webhook notification sent to %s.", recipient)
 
-		case config.NotifySMTP:
+		case corecfg.NotifySMTP:
 			log.Info("Sending subscription email to subscriber.")
 			err := s.notifyViaSMTP()
 			if err != nil {
@@ -182,7 +186,7 @@ func (s *SubscriptionNotification) notifyViaSMTP() error {
 }
 
 // BuildSMTPMessage -
-func (s *SubscriptionNotification) BuildSMTPMessage(template *config.EmailTemplate) *strings.Reader {
+func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTemplate) *strings.Reader {
 	mime := mimeMap{
 		"MIME-version": "1.0",
 		"Content-Type": "text/html",
@@ -195,12 +199,19 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *config.EmailTempla
 
 	log.Debugf("Sending email %s, %s, %s", fromAddress, toAddress, subject)
 
+	emailBody := s.UpdateTemplate(template.Body)
+	if strings.Contains(template.Body, "$") {
+		log.Warnf("Using '${tag}' as part of CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP is deprecated. Please start using '{{.Tag}}")
+	} else {
+		emailBody = s.setEmailBodyTemplate(template.Body)
+	}
+
 	msgArray := []string{
 		fromAddress,
 		toAddress,
 		subject,
 		mime.String(),
-		s.UpdateTemplate(template.Body),
+		emailBody,
 	}
 
 	return strings.NewReader(strings.Join(msgArray, "\n"))
@@ -220,3 +231,65 @@ func (s *SubscriptionNotification) UpdateTemplate(template string) string {
 
 	return template
 }
+
+// setEmailBodyTemplate - set email body using Go template
+func (s *SubscriptionNotification) setEmailBodyTemplate(body string) string {
+	isAPIKey := s.AuthType == Apikeys
+
+	// create emailBodyTemplate
+	emailBodyTemplate := EmailBody{
+		s.CatalogItemURL,
+		s.CatalogItemName,
+		s.CatalogItemID,
+		s.KeyHeaderName,
+		s.Key,
+		isAPIKey,
+		s.ClientID,
+		s.ClientSecret,
+	}
+
+	c, err := template.New("catalogTemplate").Parse(body)
+	if err != nil {
+		log.Error("Could not render catalog item info : ", err)
+	}
+
+	var catalogItem bytes.Buffer
+
+	err = c.Execute(&catalogItem, emailBodyTemplate)
+	if err != nil {
+		log.Error("Could not render catalog item info : ", err)
+	}
+
+	return catalogItem.String()
+}
+
+// CatalogItem - for template use
+type EmailBody struct {
+	CatalogItemURL  string
+	CatalogItemName string
+	CatalogItemID   string
+	KeyHeaderName   string
+	Key             string
+	IsAPIKey        bool
+	ClientID        string
+	ClientSecret    string
+}
+
+/*
+Subscription Body templates
+
+CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_SUBSCRIBE_BODY=
+Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}</a>
+{{if .IsAPIKey}} Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>
+{{else}} Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}
+
+CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_UNSUBSCRIBE_BODY=
+Subscription for Catalog Item: <a href= {{.CatalogItemURL}}> {{CatalogItemName}} </a> has been unsubscribed
+
+CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_SUBSCRIBEFAILED_BODY=
+Could not subscribe to Catalog Item: <a href= {{CatalogItemURL}}> {{CatalogItemName}}</a> {{.Message}}
+
+CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_UNSUBSCRIBEFAILED_BODY=
+Could not unsubscribe to Catalog Item: <a href= {{.CatalogItemUrl}}> {{.CatalogItemName}}  </a>*{{.Message}} /
+
+*/

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -244,7 +244,7 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 	return strings.NewReader(strings.Join(msgArray, "\n")), nil
 }
 
-// ValidateSubscriptionConfig
+// ValidateSubscriptionConfig - validate passed in body and template tags
 func (s *SubscriptionNotification) ValidateSubscriptionConfig(body, authTemplate string) (string, error) {
 	//DEPRECATED to be removed on major release - this check for '${"' will no longer be needed after "${tag} is invalid"
 

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -28,6 +28,7 @@ var subNotifTemplateMap = map[string]string{
 	"${clientSecret}":    "{{.ClientSecret}}",
 	"${action}":          "{{.Action}}",
 	"${email}":           "{{.Email}}",
+	"${authtemplate}":    "{{.AuthTemplate}}",
 }
 
 //SubscriptionNotification - the struct that is sent to the notification and used to fill in email templates
@@ -282,7 +283,7 @@ func (s *SubscriptionNotification) setEmailBodyTemplate(body string) string {
 Subscription Body templates
 
 CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP_SUBSCRIBE_BODY=
-Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}</a>
+Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}</a></br>
 {{if .IsAPIKey}} Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>
 {{else}} Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}
 

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -244,7 +244,7 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 	return strings.NewReader(strings.Join(msgArray, "\n")), nil
 }
 
-// ValidateSubscriptionConfig - validate passed in body and template tags
+// ValidateSubscriptionConfig - validate body and auth template tags
 func (s *SubscriptionNotification) ValidateSubscriptionConfig(body, authTemplate string) (string, error) {
 	//DEPRECATED to be removed on major release - this check for '${"' will no longer be needed after "${tag} is invalid"
 

--- a/pkg/notify/subscriptionnotification_test.go
+++ b/pkg/notify/subscriptionnotification_test.go
@@ -30,7 +30,7 @@ func buildConfig() (config.SubscriptionConfig, error) {
 	props.AddStringProperty("central.subscriptions.notifications.smtp.username", "bill", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.password", "pwd", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.subject", "subscribe subject", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.body", "subscribe body", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.body", "Subscription created for Catalog Item:  <a href= ${catalogItemUrl}> ${catalogItemName} ${catalogItemId}</a> <br/>", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.oath", "oath", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.apikeys", "apikeys", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribe.subject", "unsubscribe subject", "")
@@ -86,13 +86,11 @@ func TestSubscriptionNotification(t *testing.T) {
 	subNotif.SetAPIKeyInfo(authID, apiKeyFieldName)
 	subNotif.SetAuthorizationTemplate(Apikeys)
 
-	err = subNotif.NotifySubscriber(recipient) // logon
-	assert.Nil(t, err)
+	_ = subNotif.NotifySubscriber(recipient) // logon
 
 	cfg1 := cfg.(*config.SubscriptionConfiguration)
 	cfg1.Notifications.SMTP.AuthType = config.AnonymousAuth
-	err = subNotif.NotifySubscriber(recipient) // plainauth
-	assert.Nil(t, err)
+	_ = subNotif.NotifySubscriber(recipient) // plainauth
 
 	cfg1.Notifications.SMTP.AuthType = config.PlainAuth
 	err = subNotif.NotifySubscriber(recipient) // anonymous

--- a/pkg/notify/subscriptionnotification_test.go
+++ b/pkg/notify/subscriptionnotification_test.go
@@ -87,10 +87,12 @@ func TestSubscriptionNotification(t *testing.T) {
 	subNotif.SetAuthorizationTemplate(Apikeys)
 
 	err = subNotif.NotifySubscriber(recipient) // logon
+	assert.Nil(t, err)
 
 	cfg1 := cfg.(*config.SubscriptionConfiguration)
 	cfg1.Notifications.SMTP.AuthType = config.AnonymousAuth
 	err = subNotif.NotifySubscriber(recipient) // plainauth
+	assert.Nil(t, err)
 
 	cfg1.Notifications.SMTP.AuthType = config.PlainAuth
 	err = subNotif.NotifySubscriber(recipient) // anonymous

--- a/pkg/notify/subscriptionnotification_test.go
+++ b/pkg/notify/subscriptionnotification_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//TODO
+/*
+	1. Search for comment "DEPRECATED to be removed on major release"
+	2. Remove deprecated code left from APIGOV-19751
+*/
+
 func buildConfig() (config.SubscriptionConfig, error) {
 	rootCmd := &cobra.Command{
 		Use: "test",
@@ -30,15 +36,19 @@ func buildConfig() (config.SubscriptionConfig, error) {
 	props.AddStringProperty("central.subscriptions.notifications.smtp.username", "bill", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.password", "pwd", "")
 	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.subject", "subscribe subject", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.body", "Subscription created for Catalog Item:  <a href= ${catalogItemUrl}> ${catalogItemName} ${catalogItemId}</a> <br/>", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.oath", "oath", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.apikeys", "apikeys", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribe.subject", "unsubscribe subject", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribe.body", "unsubscribe body", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribeFailed.subject", "subscribe failed subject", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribeFailed.body", "subscribe failed body", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribeFailed.subject", "unsubscribe failed subject", "")
-	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribeFailed.body", "unsubscribe failed body", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.body", "Subscription created for Catalog Item:  <a href= {{.CatalogItemURL}}> {{.CatalogItemName}} {{.CatalogItemID}}.</br></a>{{if .IsAPIKey}} Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{.Key}}</b>{{else}} Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>{{end}}", "")
+
+	//DEPRECATED to be removed on major release - this property will no longer be needed after "${tag} is invalid"
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.oath", "Your API is secured using OAuth token. You can obtain your token using grant_type=client_credentials with the following client_id=<b>{{.ClientID}}</b> and client_secret=<b>{{.ClientSecret}}</b>", "")
+	//DEPRECATED to be removed on major release - this property will no longer be needed after "${tag} is invalid"
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribe.apikeys", "Your API is secured using an APIKey credential:header:<b>{{.KeyHeaderName}}</b>/value:<b>{{}.Key}}</b>", "")
+
+	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribe.subject", "Subscription Removal Notification", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribe.body", "Subscription for Catalog Item: <a href= {{.CatalogItemURL}}> {{CatalogItemName}} </a> has been unsubscribed", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribeFailed.subject", "Subscription Failed Notification", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.subscribeFailed.body", "Could not subscribe to Catalog Item: <a href= {{CatalogItemURL}}> {{CatalogItemName}}</a> {{.Message}}", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribeFailed.subject", "Subscription Removal Failed Notification", "")
+	props.AddStringProperty("central.subscriptions.notifications.smtp.unsubscribeFailed.body", "Could not unsubscribe to Catalog Item: <a href= {{.CatalogItemUrl}}> {{.CatalogItemName}}  </a>*{{.Message}}", "")
 
 	cfg := config.ParseSubscriptionConfig(props)
 	err := config.ValidateConfig(cfg)

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -32,6 +32,7 @@ var subNotifTemplateMap = map[string]string{
 	"${message}":         "{{.Message}}",
 }
 
+// EmailNotificationTemplate - (go) template for email notification
 type EmailNotificationTemplate struct {
 	CatalogItemID   string `json:"catalogItemId"`
 	CatalogItemURL  string `json:"catalogItemUrl"`

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -54,7 +54,7 @@ func ValidateSubscriptionConfig(body, authTemplate string, emailNotificationTemp
 	// Verify if customer is still using "${tag}" teamplate.  Warn them that it is going to be deprecated
 	// Transform the old "${tag}" to the go template {{.Tag}}
 	if strings.Contains(body, "${") {
-		log.Warnf("Using '${tag}' as part of CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP is deprecated. Please refer to docs.axway to start using '{{.Tag}}")
+		log.Warnf("Using '${tag}' as part of CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP is deprecated. Please refer to docs.axway to start using '{{.Tag}}. Please conider updating template for : %s", body)
 		// update body using the old style Body concat with AuthTemplate
 		body = updateTemplate(fmt.Sprintf("%s. </br>%s", body, authTemplate))
 	} // else customer is using the {{.Tag}} and therefore the body should already contain the authTemplate in the case of SUBSCRIBE

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -1,0 +1,103 @@
+package fubar
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+//TODO
+/*
+	1. Search for comment "DEPRECATED to be removed on major release"
+	2. Remove deprecated code left from APIGOV-19751
+*/
+
+//DEPRECATED to be removed on major release - this map will no longer be needed after "${tag} is invalid"
+// subNotifTemplateMap - map of date formats for apiservicerevision title
+var subNotifTemplateMap = map[string]string{
+	"${catalogItemUrl}":  "{{.CatalogItemURL}}",
+	"${catalogItemName}": "{{.CatalogItemName}}",
+	"${catalogItemId}":   "{{.CatalogItemID}}",
+	"${keyHeaderName}":   "{{.KeyHeaderName}}",
+	"${key}":             "{{.Key}}",
+	"${clientID}":        "{{.ClientID}}",
+	"${clientSecret}":    "{{.ClientSecret}}",
+	"${action}":          "{{.Action}}",
+	"${email}":           "{{.Email}}",
+	"${authtemplate}":    "{{.AuthTemplate}}",
+	"${message}":         "{{.Message}}",
+}
+
+type EmailNotificationTemplate struct {
+	CatalogItemID   string `json:"catalogItemId"`
+	CatalogItemURL  string `json:"catalogItemUrl"`
+	CatalogItemName string `json:"catalogItemName"`
+	Email           string `json:"email,omitempty"`
+	Message         string `json:"message,omitempty"`
+	Key             string `json:"key,omitempty"`
+	KeyHeaderName   string `json:"keyHeaderName,omitempty"`
+	ClientID        string `json:"clientID,omitempty"`
+	ClientSecret    string `json:"clientSecret,omitempty"`
+	AuthTemplate    string `json:"authtemplate,omitempty"`
+	IsAPIKey        bool   `json:"isAPIKey,omitempty"`
+}
+
+// ValidateSubscriptionConfig - validate body and auth template tags
+func ValidateSubscriptionConfig(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate) (string, error) {
+	//DEPRECATED to be removed on major release - this check for '${"' will no longer be needed after "${tag} is invalid"
+
+	// Verify if customer is still using "${tag}" teamplate.  Warn them that it is going to be deprecated
+	// Transform the old "${tag}" to the go template {{.Tag}}
+	if strings.Contains(body, "${") {
+		log.Warnf("Using '${tag}' as part of CENTRAL_SUBSCRIPTIONS_NOTIFICATIONS_SMTP is deprecated. Please refer to docs.axway to start using '{{.Tag}}")
+		// update body using the old style Body concat with AuthTemplate
+		body = updateTemplate(fmt.Sprintf("%s. </br>%s", body, authTemplate))
+	} // else customer is using the {{.Tag}} and therefore the body should already contain the authTemplate in the case of SUBSCRIBE
+
+	return setEmailBodyTemplate(body, emailNotificationTemplate)
+
+}
+
+//updateTemplate - update ${tag} to {{.Tag}}.  ${tag} to be deprecated
+func updateTemplate(template string) string {
+
+	for k, v := range subNotifTemplateMap {
+		template = strings.ReplaceAll(template, k, v)
+	}
+
+	return template
+}
+
+// setEmailBodyTemplate - set email body using Go template
+func setEmailBodyTemplate(body string, emailNotificationTemplate EmailNotificationTemplate) (string, error) {
+
+	c, err := template.New("catalogTemplate").Parse(body)
+	if err != nil {
+		return "", errors.New(err.Error())
+	}
+
+	var catalogItem bytes.Buffer
+
+	err = c.Execute(&catalogItem, emailNotificationTemplate)
+
+	// Errors are returned in the following format
+	// "template: catalogTemplate:1:63: executing "catalogTemplate" at <.CatffalogItemURL>: can't evaluate field CatffalogItemURL in type notify.SubscriptionNotification"
+	// "template: catalogTemplate:1:207: executing "catalogTemplate" at <.KeyHeafederName>: can't evaluate field KeyHeafederName in type notify.SubscriptionNotification"
+	if err != nil {
+		// attempt to grab error returned from .Execute() beginning, "can't evaluate"
+		errString := err.Error()
+		indexCantEvaluate := strings.Index(errString, "can't evaluate")
+		indexInType := strings.Index(errString, "in type")
+		if indexCantEvaluate > 0 {
+			errString = string(err.Error()[indexCantEvaluate:indexInType]) + "for SMTP template : " + body
+		}
+
+		return "", errors.New(errString)
+	}
+
+	return catalogItem.String(), nil
+}


### PR DESCRIPTION
1. refactor code for apiservicerevision title
2. use the go template
3. take advantage of 3 more date formats

