### PR TITLE
Include json tags for finalizers and remove omitempty

### DIFF
--- a/pkg/apic/apiserver/models/api/v1/resourcemeta.go
+++ b/pkg/apic/apiserver/models/api/v1/resourcemeta.go
@@ -22,7 +22,7 @@ type ResourceMeta struct {
 	// List of tags.
 	Tags []string `json:"tags,omitempty"`
 	// Finalizer on the API server resource
-	Finalizers []Finalizer
+	Finalizers []Finalizer `json:"finalizers,omitempty"`
 }
 
 // GetName -

--- a/pkg/apic/apiserver/models/api/v1/resourcemeta.go
+++ b/pkg/apic/apiserver/models/api/v1/resourcemeta.go
@@ -18,11 +18,11 @@ type ResourceMeta struct {
 	Title    string   `json:"title,omitempty"`
 	Metadata Metadata `json:"metadata,omitempty"`
 	// Custom attributes added to objects.
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes"`
 	// List of tags.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 	// Finalizer on the API server resource
-	Finalizers []Finalizer `json:"finalizers,omitempty"`
+	Finalizers []Finalizer `json:"finalizers"`
 }
 
 // GetName -


### PR DESCRIPTION
The lack of finalizers json tags makes them un-editable. The inclusion of omitempty on the maps (attributes, tags, finalizers) makes them add only which isn't what's required.