### PR TITLE
APIGOV-19886 - fix init problem causing AgentResource values to not be merged

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -105,7 +105,11 @@ func Initialize(centralCfg config.CentralConfig) error {
 		agent.apicClient.SetTokenGetter(agent.tokenRequester)
 		agent.apicClient.OnConfigChange(centralCfg)
 	}
+
 	agent.cfg = centralCfg
+	if agent.isInitialized {
+		mergeResourceWithConfig()
+	}
 
 	if !agent.isInitialized {
 		if getAgentResourceType() != "" {
@@ -274,7 +278,7 @@ func refreshResources() (bool, error) {
 		return false, err
 	}
 
-	isChanged := true
+	isChanged := agent.isInitialized
 	if agent.prevAgentResource != nil {
 		agentResHash, _ := util.ComputeHash(agent.agentResource)
 		prevAgentResHash, _ := util.ComputeHash(agent.prevAgentResource)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -162,7 +162,7 @@ func TestAgentInitialize(t *testing.T) {
 
 	da = GetAgentResource()
 	assertResource(t, da, traceabilityAgentRes)
-	assert.Equal(t, 1, agentResChangeHandlerCall)
+	assert.Equal(t, 0, agentResChangeHandlerCall)
 }
 
 func TestAgentConfigOverride(t *testing.T) {

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -44,6 +44,11 @@ func (c *ServiceClient) buildConsumerInstanceSpec(serviceBody *ServiceBody, doc 
 			if _, found := teamMap[serviceBody.TeamName]; found {
 				owningTeam = serviceBody.TeamName
 			} else {
+				if owningTeam == "" {
+					owningTeam = "the default team"
+				} else {
+					owningTeam = fmt.Sprintf("team %s", owningTeam)
+				}
 				log.Info(ErrTeamMismatch.FormatError(serviceBody.TeamName, serviceBody.APIName, owningTeam))
 			}
 		}

--- a/pkg/apic/errors.go
+++ b/pkg/apic/errors.go
@@ -34,5 +34,5 @@ var (
 	// Service body builder
 	ErrSetSpecEndPoints = errors.New(1160, "error getting endpoints for the API specification")
 
-	ErrTeamMismatch = errors.Newf(1164, "Amplify Central does not contain a team named %s for API %s. The Catalog Item will be assigned to team %s.")
+	ErrTeamMismatch = errors.Newf(1164, "Amplify Central does not contain a team named %s for API %s. The Catalog Item will be assigned to %s.")
 )


### PR DESCRIPTION
1) fix error message if no default team is provided
2) fix init problems causing merged resource values to be overwritten by config values