### PR TITLE
APIGOV-19810 - create concrete struct for Owner rather than using interface

### DIFF
--- a/pkg/apic/apiserver/models/api/v1/owner.go
+++ b/pkg/apic/apiserver/models/api/v1/owner.go
@@ -10,16 +10,16 @@ type OwnerType uint
 
 // values for Owner.Team
 const (
-	OwnerTeam OwnerType = iota
+	TeamOwner OwnerType = iota
 )
 
 // map of ownertype to string
 var ownerTypeToString = map[OwnerType]string{
-	OwnerTeam: "team",
+	TeamOwner: "team",
 }
 
 var ownerTypeFromString = map[string]OwnerType{
-	"team": OwnerTeam,
+	"team": TeamOwner,
 }
 
 // Owner structure.
@@ -59,7 +59,7 @@ func (o *Owner) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON -
 func (o *Owner) UnmarshalJSON(bytes []byte) error {
 	type Alias Owner
-	aux := &struct {
+	aux := struct {
 		*Alias
 		Type string
 	}{

--- a/pkg/apic/apiserver/models/api/v1/owner.go
+++ b/pkg/apic/apiserver/models/api/v1/owner.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// OwnerType -
+type OwnerType uint
+
+// values for Owner.Team
+const (
+	OwnerTeam OwnerType = iota
+)
+
+// map of ownertype to string
+var ownerTypeToString = map[OwnerType]string{
+	OwnerTeam: "team",
+}
+
+var ownerTypeFromString = map[string]OwnerType{
+	"team": OwnerTeam,
+}
+
+// Owner structure.
+type Owner struct {
+	Type OwnerType `json:"type,omitempty"`
+	ID   string    `json:"id"`
+}
+
+// SetType -
+func (o *Owner) SetType(t OwnerType) {
+	o.Type = t
+}
+
+// SetID -
+func (o *Owner) SetID(id string) {
+	o.ID = id
+}
+
+// MarshalJSON -
+func (o *Owner) MarshalJSON() ([]byte, error) {
+	var t string
+	var ok bool
+	if t, ok = ownerTypeToString[o.Type]; !ok {
+		return nil, fmt.Errorf("unknown owner type %d", o.Type)
+	}
+
+	type Alias Owner
+	return json.Marshal(&struct {
+		*Alias
+		Type string
+	}{
+		Alias: (*Alias)(o),
+		Type:  t,
+	})
+}
+
+// UnmarshalJSON -
+func (o *Owner) UnmarshalJSON(bytes []byte) error {
+	type Alias Owner
+	aux := &struct {
+		*Alias
+		Type string
+	}{
+		Alias: (*Alias)(o),
+	}
+
+	if err := json.Unmarshal(bytes, &aux); err != nil {
+		return err
+	}
+
+	var t OwnerType
+	var ok bool
+	if t, ok = ownerTypeFromString[aux.Type]; !ok {
+		return fmt.Errorf("unknown owner type %d", o.Type)
+	}
+	o.Type = t
+	return nil
+}

--- a/pkg/apic/apiserver/models/api/v1/resourceinstance.go
+++ b/pkg/apic/apiserver/models/api/v1/resourceinstance.go
@@ -9,7 +9,7 @@ import (
 type ResourceInstance struct {
 	ResourceMeta
 
-	Owner *Owner `json:"owner,omitempty"`
+	Owner *Owner `json:"owner"`
 	// Resource instance specs.
 	Spec map[string]interface{} `json:"spec"`
 

--- a/pkg/apic/apiserver/models/api/v1/resourceinstance.go
+++ b/pkg/apic/apiserver/models/api/v1/resourceinstance.go
@@ -9,7 +9,7 @@ import (
 type ResourceInstance struct {
 	ResourceMeta
 
-	Owner interface{} `json:"owner,omitempty"`
+	Owner *Owner `json:"owner,omitempty"`
 	// Resource instance specs.
 	Spec map[string]interface{} `json:"spec"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/Asset.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/Asset.go
@@ -40,7 +40,7 @@ type Asset struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References AssetReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRelease.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRelease.go
@@ -40,7 +40,7 @@ type AssetRelease struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References AssetReleaseReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRequest.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRequest.go
@@ -38,7 +38,7 @@ func init() {
 type AssetRequest struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec AssetRequestSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRequestDefinition.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/AssetRequestDefinition.go
@@ -38,7 +38,7 @@ func init() {
 type AssetRequestDefinition struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References interface{} `json:"references"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/AssetResource.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/AssetResource.go
@@ -38,7 +38,7 @@ func init() {
 type AssetResource struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References AssetResourceReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/Category.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/Category.go
@@ -38,7 +38,7 @@ func init() {
 type Category struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec CategorySpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/Document.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/Document.go
@@ -38,7 +38,7 @@ func init() {
 type Document struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec DocumentSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/Product.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/Product.go
@@ -42,7 +42,7 @@ type Product struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ProductSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/ReleaseTag.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/ReleaseTag.go
@@ -38,7 +38,7 @@ func init() {
 type ReleaseTag struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References ReleaseTagReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/Stage.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/Stage.go
@@ -40,7 +40,7 @@ type Stage struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec StageSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/CommandLineInterface.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/CommandLineInterface.go
@@ -38,7 +38,7 @@ func init() {
 type CommandLineInterface struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec CommandLineInterfaceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceDefinition.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceDefinition.go
@@ -38,7 +38,7 @@ func init() {
 type ResourceDefinition struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ResourceDefinitionSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceDefinitionVersion.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceDefinitionVersion.go
@@ -38,7 +38,7 @@ func init() {
 type ResourceDefinitionVersion struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ResourceDefinitionVersionSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceGroup.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/ResourceGroup.go
@@ -38,7 +38,7 @@ func init() {
 type ResourceGroup struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec interface{} `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/APIService.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/APIService.go
@@ -38,7 +38,7 @@ func init() {
 type APIService struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ApiServiceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/APIServiceInstance.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/APIServiceInstance.go
@@ -38,7 +38,7 @@ func init() {
 type APIServiceInstance struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ApiServiceInstanceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/APIServiceRevision.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/APIServiceRevision.go
@@ -38,7 +38,7 @@ func init() {
 type APIServiceRevision struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ApiServiceRevisionSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/APISpec.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/APISpec.go
@@ -38,7 +38,7 @@ func init() {
 type APISpec struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ApiSpecSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/AccessRequest.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/AccessRequest.go
@@ -38,7 +38,7 @@ func init() {
 type AccessRequest struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec AccessRequestSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/AccessRequestDefinition.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/AccessRequestDefinition.go
@@ -38,7 +38,7 @@ func init() {
 type AccessRequestDefinition struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec AccessRequestDefinitionSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/AssetMapping.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/AssetMapping.go
@@ -38,7 +38,7 @@ func init() {
 type AssetMapping struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec AssetMappingSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/AssetMappingTemplate.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/AssetMappingTemplate.go
@@ -38,7 +38,7 @@ func init() {
 type AssetMappingTemplate struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec AssetMappingTemplateSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/ConsumerInstance.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/ConsumerInstance.go
@@ -38,7 +38,7 @@ func init() {
 type ConsumerInstance struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References ConsumerInstanceReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/ConsumerSubscriptionDefinition.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/ConsumerSubscriptionDefinition.go
@@ -38,7 +38,7 @@ func init() {
 type ConsumerSubscriptionDefinition struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ConsumerSubscriptionDefinitionSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/CorsRule.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/CorsRule.go
@@ -38,7 +38,7 @@ func init() {
 type CorsRule struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec CorsRuleSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/Deployment.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Deployment.go
@@ -38,7 +38,7 @@ func init() {
 type Deployment struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec DeploymentSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/DiscoveryAgent.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/DiscoveryAgent.go
@@ -38,7 +38,7 @@ func init() {
 type DiscoveryAgent struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec DiscoveryAgentSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/Environment.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Environment.go
@@ -38,7 +38,7 @@ func init() {
 type Environment struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec EnvironmentSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/GovernanceAgent.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/GovernanceAgent.go
@@ -38,7 +38,7 @@ func init() {
 type GovernanceAgent struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Runtimeconfig interface{} `json:"runtimeconfig"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/Integration.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Integration.go
@@ -38,7 +38,7 @@ func init() {
 type Integration struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec IntegrationSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/K8SCluster.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/K8SCluster.go
@@ -38,7 +38,7 @@ func init() {
 type K8SCluster struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec K8SClusterSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/K8SResource.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/K8SResource.go
@@ -38,7 +38,7 @@ func init() {
 type K8SResource struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec K8SResourceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/Mesh.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Mesh.go
@@ -38,7 +38,7 @@ func init() {
 type Mesh struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec interface{} `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/MeshDiscovery.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/MeshDiscovery.go
@@ -38,7 +38,7 @@ func init() {
 type MeshDiscovery struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec MeshDiscoverySpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/MeshService.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/MeshService.go
@@ -38,7 +38,7 @@ func init() {
 type MeshService struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec MeshServiceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/MeshWorkload.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/MeshWorkload.go
@@ -38,7 +38,7 @@ func init() {
 type MeshWorkload struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec MeshWorkloadSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/OAS3Document.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/OAS3Document.go
@@ -38,7 +38,7 @@ func init() {
 type OAS3Document struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec interface{} `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/ReleaseTag.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/ReleaseTag.go
@@ -38,7 +38,7 @@ func init() {
 type ReleaseTag struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	References ReleaseTagReferences `json:"references"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/ResourceDiscovery.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/ResourceDiscovery.go
@@ -38,7 +38,7 @@ func init() {
 type ResourceDiscovery struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ResourceDiscoverySpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/ResourceHook.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/ResourceHook.go
@@ -38,7 +38,7 @@ func init() {
 type ResourceHook struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec ResourceHookSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/Secret.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Secret.go
@@ -21,7 +21,7 @@ var (
 )
 
 const (
-	SecretScope = "Integration"
+	SecretScope = "Environment"
 
 	SecretResourceName = "secrets"
 )
@@ -38,7 +38,7 @@ func init() {
 type Secret struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec SecretSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/SpecDiscovery.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/SpecDiscovery.go
@@ -38,7 +38,7 @@ func init() {
 type SpecDiscovery struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec SpecDiscoverySpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/TraceabilityAgent.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/TraceabilityAgent.go
@@ -38,7 +38,7 @@ func init() {
 type TraceabilityAgent struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec TraceabilityAgentSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/VirtualAPI.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/VirtualAPI.go
@@ -40,7 +40,7 @@ type VirtualAPI struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec VirtualApiSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/VirtualAPIRelease.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/VirtualAPIRelease.go
@@ -40,7 +40,7 @@ type VirtualAPIRelease struct {
 
 	Icon interface{} `json:"icon"`
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec VirtualApiReleaseSpec `json:"spec"`
 

--- a/pkg/apic/apiserver/models/management/v1alpha1/VirtualService.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/VirtualService.go
@@ -38,7 +38,7 @@ func init() {
 type VirtualService struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec VirtualServiceSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/Webhook.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/Webhook.go
@@ -38,7 +38,7 @@ func init() {
 type Webhook struct {
 	apiv1.ResourceMeta
 
-	Owner interface{} `json:"owner"`
+	Owner *apiv1.Owner `json:"owner"`
 
 	Spec WebhookSpec `json:"spec"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_deployment_spec.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_deployment_spec.go
@@ -13,4 +13,6 @@ package v1alpha1
 type DeploymentSpec struct {
 	// The name of an APIServiceInstance resource that specifies where the API is deployed.
 	VirtualAPIRelease string `json:"virtualAPIRelease"`
+	// The fully qualifield virtual host name as described in RFC 1035
+	VirtualHost string `json:"virtualHost"`
 }

--- a/scripts/apiserver/resources.tmpl
+++ b/scripts/apiserver/resources.tmpl
@@ -42,7 +42,7 @@ type {{.res.kind}} struct {
 	{{range $field, $isNotEmpty := .res.fields}}
 		{{ $type := $field | strings.Title }}
 		{{ $varName := $.res.kind | strings.ReplaceAll "API" "Api" | strings.ReplaceAll "AWS" "Aws" }}
-		{{	$type }} {{if $isNotEmpty}} {{$varName}}{{$type}} {{else}} interface{} {{end}} `json:"{{$field | strings.ToLower}}"`
+        {{ $type}} {{if $isNotEmpty}} {{ $varName }}{{ $type }} {{else}} {{if eq $type "Owner"}} *apiv1.Owner {{else}} interface{} {{end}} {{end}} `json:"{{$field | strings.ToLower}}"`
 	{{end}}
 }
 


### PR DESCRIPTION
- Create Owner class and reference from ResourceInstance rather than using interface
- enhance codegen to replace Owner interface in apiserver files with apiv1.Owner (the new struct)
- regen apiserver files