### PR TITLE
APIGOV-20279 - verify if email body is using {{.AuthTemplate}}

### DIFF
--- a/pkg/config/subscriptionconfig.go
+++ b/pkg/config/subscriptionconfig.go
@@ -440,7 +440,7 @@ func (s *SubscriptionConfiguration) validateSubscriptionConfig() error {
 
 	for variable, template := range templates {
 		emailTemplate.IsAPIKey = !(variable == oauthEnvVar) // apikey for all but oauth
-		_, err := emailtemplate.ValidateSubscriptionConfig(template, "", emailTemplate, false)
+		_, err := emailtemplate.ValidateSubscriptionConfigOnStartup(template, "", emailTemplate)
 		if err != nil {
 			templateErr := fmt.Errorf("%s template is not valid: %s", variable, err.Error())
 			log.Error(templateErr)

--- a/pkg/config/subscriptionconfig.go
+++ b/pkg/config/subscriptionconfig.go
@@ -440,7 +440,7 @@ func (s *SubscriptionConfiguration) validateSubscriptionConfig() error {
 
 	for variable, template := range templates {
 		emailTemplate.IsAPIKey = !(variable == oauthEnvVar) // apikey for all but oauth
-		_, err := emailtemplate.ValidateSubscriptionConfig(template, "", emailTemplate)
+		_, err := emailtemplate.ValidateSubscriptionConfig(template, "", emailTemplate, false)
 		if err != nil {
 			templateErr := fmt.Errorf("%s template is not valid: %s", variable, err.Error())
 			log.Error(templateErr)

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -223,8 +223,8 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 		IsAPIKey:        s.IsAPIKey,
 	}
 
-	// Shouldn't have to check error from ValidateSubscriptionConfig since startup passed the subscription validation check
-	emailBody, err := emailtemplate.ValidateSubscriptionConfig(template.Body, s.AuthTemplate, emailNotificationTemplate, true)
+	// Shouldn't have to check error from ValidateSubscriptionConfigOnNotification since startup passed the subscription validation check
+	emailBody, err := emailtemplate.ValidateSubscriptionConfigOnNotification(template.Body, s.AuthTemplate, emailNotificationTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -224,7 +224,7 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 	}
 
 	// Shouldn't have to check error from ValidateSubscriptionConfig since startup passed the subscription validation check
-	emailBody, err := emailtemplate.ValidateSubscriptionConfig(template.Body, s.AuthTemplate, emailNotificationTemplate)
+	emailBody, err := emailtemplate.ValidateSubscriptionConfig(template.Body, s.AuthTemplate, emailNotificationTemplate, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -51,9 +51,19 @@ type EmailNotificationTemplate struct {
 	IsAPIKey        bool   `json:"isAPIKey,omitempty"`
 }
 
-// ValidateSubscriptionConfig - validate body and auth template tags
+// ValidateSubscriptionConfig - validate body and auth template tags during startup (config)
+func ValidateSubscriptionConfigOnStartup(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate) (string, error) {
+	return validateEmailTags(body, authTemplate, emailNotificationTemplate, false)
+}
+
+// ValidateSubscriptionConfigOnNotification - validate body and auth template tags  during notification
+func ValidateSubscriptionConfigOnNotification(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate) (string, error) {
+	return validateEmailTags(body, authTemplate, emailNotificationTemplate, true)
+}
+
+// validateEmailTags - validate body and auth template tags
 // duringProcessing bool indicates whether this func is called during startup (config) or duringProcessing (subscription notification)
-func ValidateSubscriptionConfig(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate, duringProcessing bool) (string, error) {
+func validateEmailTags(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate, duringProcessing bool) (string, error) {
 	//DEPRECATED to be removed on major release - this check for '${"' will no longer be needed after "${tag} is invalid"
 
 	// Verify if customer is still using "${tag}" teamplate.  Warn them that it is going to be deprecated

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -51,7 +51,7 @@ type EmailNotificationTemplate struct {
 	IsAPIKey        bool   `json:"isAPIKey,omitempty"`
 }
 
-// ValidateSubscriptionConfig - validate body and auth template tags during startup (config)
+// ValidateSubscriptionConfigOnStartup - validate body and auth template tags during startup (config)
 func ValidateSubscriptionConfigOnStartup(body, authTemplate string, emailNotificationTemplate EmailNotificationTemplate) (string, error) {
 	return validateEmailTags(body, authTemplate, emailNotificationTemplate, false)
 }

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -74,7 +74,7 @@ func validateEmailTags(body, authTemplate string, emailNotificationTemplate Emai
 		body = updateTemplate(fmt.Sprintf("%s. </br>%s", body, authTemplate))
 	} // else customer is using the {{.Tag}} and therefore the body should already contain the authTemplate in the case of SUBSCRIBE
 
-	// Bypass this check if the validation is happening during startup (config).  We won't know the auth type during starup
+	// Bypass this check if the validation is happening during startup (config).  We won't know the auth type during starup.
 	if duringProcessing && strings.Contains(body, authTemplateTag) {
 		body = strings.Replace(body, authTemplateTag, authTemplate, -1)
 	}


### PR DESCRIPTION
Allow the customer to configure {{.AuthTemplate}} 
1.  this is an alternate solution for {{if}} / {{else}}
2.  this automatically pulls in the auth type. If it doesn't exist in the env_var, it will use the default.