### PR TITLE
APIGOV-19801 - change some debug logs to trace

### DIFF
--- a/docs/utilities/index.md
+++ b/docs/utilities/index.md
@@ -186,6 +186,8 @@ log.Infof("Log entry with format, %s", "additional log ~~message")
 
 log.Debugf("No changes detected in the API %s", *azAPI.Name)
 
+log.Trace("I got here in the code")
+
 log.Errorf("Error in processing : %s", err.Error())
 
 log.Warnf("Config not found: %s", missingItem)

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -36,7 +36,7 @@ func (su *agentStatusUpdate) Ready() bool {
 		return false
 	}
 
-	log.Debug("Periodic status update is ready")
+	log.Trace("Periodic status update is ready")
 	su.currentActivityTime = time.Now()
 	su.previousActivityTime = su.currentActivityTime
 	return true

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -238,6 +238,6 @@ func (c *ServiceClient) updateAPIServiceRevisionTitle(serviceBody *ServiceBody) 
 		return defaultAPISvcRevTitle
 	}
 
-	log.Debugf("Returning apiservicerevision title : %s", apiSvcRevTitle.String())
+	log.Tracef("Returning apiservicerevision title : %s", apiSvcRevTitle.String())
 	return apiSvcRevTitle.String()
 }

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -359,7 +359,7 @@ func (c *ServiceClient) getPlatformUserInfo(id string) (*PlatformUserInfo, error
 	}
 
 	platformURL := fmt.Sprintf("%s/api/v1/user/%s", c.cfg.GetPlatformURL(), id)
-	log.Debugf("Platform URL being used to get user information %s", platformURL)
+	log.Tracef("Platform URL being used to get user information %s", platformURL)
 
 	platformUserBytes, reqErr := c.sendServerRequest(platformURL, headers, make(map[string]string, 0))
 	if reqErr != nil {
@@ -387,7 +387,7 @@ func (c *ServiceClient) GetUserEmailAddress(id string) (string, error) {
 	}
 
 	email := platformUserInfo.Result.Email
-	log.Debugf("Platform user email %s", email)
+	log.Tracef("Platform user email %s", email)
 
 	return email, nil
 }
@@ -402,7 +402,7 @@ func (c *ServiceClient) GetUserName(id string) (string, error) {
 
 	userName := fmt.Sprintf("%s %s", platformUserInfo.Result.Firstname, platformUserInfo.Result.Lastname)
 
-	log.Debugf("Platform user %s", userName)
+	log.Tracef("Platform user %s", userName)
 
 	return userName, nil
 }

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -280,7 +280,7 @@ func (c *ServiceClient) getConsumerInstancesByExternalAPIID(externalAPIID string
 		return nil, err
 	}
 
-	log.Debugf("Get consumer instance by external api id: %s", externalAPIID)
+	log.Tracef("Get consumer instance by external api id: %s", externalAPIID)
 
 	params := map[string]string{
 		"query": fmt.Sprintf("attributes."+AttrExternalAPIID+"==%s", externalAPIID),
@@ -321,7 +321,7 @@ func (c *ServiceClient) getConsumerInstanceByID(instanceID string) (*v1alpha1.Co
 		return nil, err
 	}
 
-	log.Debugf("Get consumer instance by id: %s", instanceID)
+	log.Tracef("Get consumer instance by id: %s", instanceID)
 
 	params := map[string]string{
 		"query": fmt.Sprintf("metadata.id==%s", instanceID),
@@ -359,7 +359,7 @@ func (c *ServiceClient) getConsumerInstanceByName(consumerInstanceName string) (
 		return nil, err
 	}
 
-	log.Debugf("Get consumer instance by name: %s", consumerInstanceName)
+	log.Tracef("Get consumer instance by name: %s", consumerInstanceName)
 
 	params := map[string]string{
 		"query": fmt.Sprintf("name==%s", consumerInstanceName),

--- a/pkg/apic/resourcePagination.go
+++ b/pkg/apic/resourcePagination.go
@@ -91,7 +91,7 @@ func (c *ServiceClient) GetAPIV1ResourceInstancesWithPageSize(queryParams map[st
 		if len(resourceInstancePage) < queryPageSize {
 			morePages = false
 		} else {
-			log.Debug("More resource instance pages exist.  Continue retrieval of resource instances.")
+			log.Trace("More resource instance pages exist.  Continue retrieval of resource instances.")
 		}
 
 		page++

--- a/pkg/apic/subscriptionmanager.go
+++ b/pkg/apic/subscriptionmanager.go
@@ -153,7 +153,7 @@ func (sm *subscriptionManager) preprocessSubscriptionForConsumerInstance(subscri
 			resource, _ := consumerInstance.AsInstance()
 			sm.setSubscriptionInfo(subscription, resource)
 		} else {
-			log.Debug("Preprocess subscription for environment mode only")
+			log.Trace("Preprocess subscription for environment mode only")
 			sm.preprocessSubscriptionForAPIServiceInstance(subscription, consumerInstance)
 		}
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -191,7 +191,7 @@ func (c *agentRootCommand) initialize(cmd *cobra.Command, args []string) error {
 
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
-		log.Debugf("Config file changed : %s", e.Name)
+		log.Tracef("Config file changed : %s", e.Name)
 		c.onConfigChange()
 	})
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -191,7 +191,7 @@ func (c *agentRootCommand) initialize(cmd *cobra.Command, args []string) error {
 
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
-		log.Tracef("Config file changed : %s", e.Name)
+		log.Debugf("Config file changed : %s", e.Name)
 		c.onConfigChange()
 	})
 

--- a/pkg/config/subscriptionconfig.go
+++ b/pkg/config/subscriptionconfig.go
@@ -370,7 +370,7 @@ func (s *SubscriptionConfiguration) GetSubscriptionApprovalWebhookConfig() Webho
 func (s *SubscriptionConfiguration) ValidateCfg() error {
 	if s.Notifications.Webhook.GetURL() != "" {
 		s.SetNotificationType(NotifyWebhook)
-		log.Debug("Webhook notification set")
+		log.Trace("Webhook notification set")
 		err := s.validateWebhook()
 		if err != nil {
 			return err
@@ -378,7 +378,7 @@ func (s *SubscriptionConfiguration) ValidateCfg() error {
 	}
 	if s.Notifications.SMTP.Host != "" {
 		s.SetNotificationType(NotifySMTP)
-		log.Debug("SMTP notification set")
+		log.Trace("SMTP notification set")
 		err := s.validateSubscriptionConfig()
 		if err != nil {
 			return err
@@ -393,7 +393,7 @@ func (s *SubscriptionConfiguration) ValidateCfg() error {
 		return ErrBadConfig.FormatError(pathSubscriptionsApprovalMode)
 	}
 
-	log.Debugf("Approval mode set: %s", s.GetSubscriptionApprovalMode())
+	log.Tracef("Approval mode set: %s", s.GetSubscriptionApprovalMode())
 
 	// only validate the webhook approval config settings if the approval mode is for webhook
 	if s.GetSubscriptionApprovalMode() == WebhookApproval {

--- a/pkg/config/webhookconfig.go
+++ b/pkg/config/webhookconfig.go
@@ -75,7 +75,7 @@ func (c *WebhookConfiguration) ValidateConfig() error {
 				c.webhookHeaders[hvArray[0]] = hvArray[1]
 			}
 		}
-		log.Debug("Subscription approval webhook configuration set")
+		log.Trace("Subscription approval webhook configuration set")
 	}
 
 	return nil

--- a/pkg/util/healthcheck/healthchecker.go
+++ b/pkg/util/healthcheck/healthchecker.go
@@ -89,7 +89,7 @@ func WaitForReady() error {
 		// Got a tick, we should RunChecks
 		case <-tick:
 			if RunChecks() == OK {
-				log.Debug("Services are Ready")
+				log.Trace("Services are Ready")
 				return nil
 			}
 		}
@@ -128,7 +128,7 @@ func executeCheck(check *statusCheck) {
 	// Run the check
 	check.Status = check.checker(check.Name)
 	if check.Status.Result == OK {
-		log.Debugf("%s - %s", check.Name, check.Status.Result)
+		log.Tracef("%s - %s", check.Name, check.Status.Result)
 	} else {
 		log.Errorf("%s - %s (%s)", check.Name, check.Status.Result, check.Status.Details)
 	}


### PR DESCRIPTION
Based on the ambiguity of debug vs trace and what customers want or need to see, this is about the extent I want to go for right now. Just move some of the messages that are clearly pretty low-level. If there are no objections and this is approved, I will take a similar approach to the agents. If you feel that it's gone overboard, let me know also.