### PR TITLE
APIGOV-20614 - create an traceability api (path) exceptions list

### DIFF
--- a/pkg/traceability/config.go
+++ b/pkg/traceability/config.go
@@ -17,23 +17,24 @@ import (
 
 // Config -
 type Config struct {
-	Index            string            `config:"index"`
-	LoadBalance      bool              `config:"loadbalance"`
-	BulkMaxSize      int               `config:"bulk_max_size"`
-	SlowStart        bool              `config:"slow_start"`
-	Timeout          time.Duration     `config:"client_timeout"    validate:"min=0"`
-	TTL              time.Duration     `config:"ttl"               validate:"min=0"`
-	Pipelining       int               `config:"pipelining"        validate:"min=0"`
-	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
-	MaxRetries       int               `config:"max_retries"       validate:"min=-1"`
-	TLS              *tlscommon.Config `config:"ssl"`
-	Proxy            ProxyConfig       `config:",inline"`
-	Backoff          Backoff           `config:"backoff"`
-	EscapeHTML       bool              `config:"escape_html"`
-	Protocol         string            `config:"protocol"`
-	Hosts            []string          `config:"hosts"`
-	Redaction        redaction.Config  `config:"redaction" yaml:"redaction"`
-	Sampling         sampling.Sampling `config:"sampling" yaml:"sampling"`
+	Index             string            `config:"index"`
+	LoadBalance       bool              `config:"loadbalance"`
+	BulkMaxSize       int               `config:"bulk_max_size"`
+	SlowStart         bool              `config:"slow_start"`
+	Timeout           time.Duration     `config:"client_timeout"    validate:"min=0"`
+	TTL               time.Duration     `config:"ttl"               validate:"min=0"`
+	Pipelining        int               `config:"pipelining"        validate:"min=0"`
+	CompressionLevel  int               `config:"compression_level" validate:"min=0, max=9"`
+	MaxRetries        int               `config:"max_retries"       validate:"min=-1"`
+	TLS               *tlscommon.Config `config:"ssl"`
+	Proxy             ProxyConfig       `config:",inline"`
+	Backoff           Backoff           `config:"backoff"`
+	EscapeHTML        bool              `config:"escape_html"`
+	Protocol          string            `config:"protocol"`
+	Hosts             []string          `config:"hosts"`
+	Redaction         redaction.Config  `config:"redaction" yaml:"redaction"`
+	Sampling          sampling.Sampling `config:"sampling" yaml:"sampling"`
+	APIExceptionsList string            `config:"apiExceptionsList"`
 }
 
 // ProxyConfig holds the configuration information required to proxy
@@ -133,4 +134,12 @@ func GetMaxRetries() int {
 		return 3
 	}
 	return outputConfig.MaxRetries
+}
+
+// GetAPIExceptionsList - Returns traceability APIs exception list (api paths)
+func GetAPIExceptionsList() string {
+	if outputConfig == nil {
+		return ""
+	}
+	return outputConfig.APIExceptionsList
 }

--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -46,7 +46,7 @@ var GetClient = getClient
 func getClient() (*Client, error) {
 	switch clients := len(traceabilityClients); clients {
 	case 0:
-		return nil, fmt.Errorf("No traceability clients, can't publish metrics")
+		return nil, fmt.Errorf("no traceability clients, can't publish metrics")
 	case 1:
 		return traceabilityClients[0], nil
 	default:

--- a/pkg/transaction/definitions.go
+++ b/pkg/transaction/definitions.go
@@ -158,5 +158,5 @@ type Protocol struct {
 	ResponsePayload        string `json:"responsePayload,omitempty"`
 	WafStatus              int    `json:"wafStatus,omitempty"`
 	Timing                 string `json:"timing,omitempty"`
-	URIRaw                 string `json:"uriRaw,omitempty"`
+	uriRaw                 string
 }

--- a/pkg/transaction/definitions.go
+++ b/pkg/transaction/definitions.go
@@ -158,4 +158,5 @@ type Protocol struct {
 	ResponsePayload        string `json:"responsePayload,omitempty"`
 	WafStatus              int    `json:"wafStatus,omitempty"`
 	Timing                 string `json:"timing,omitempty"`
+	URIRaw                 string `json:"uriRaw,omitempty"`
 }

--- a/pkg/transaction/eventgenerator.go
+++ b/pkg/transaction/eventgenerator.go
@@ -119,7 +119,8 @@ func (e *Generator) CreateEvents(summaryEvent LogEvent, detailEvents []LogEvent,
 	events := make([]beat.Event, 0)
 
 	// See if the uri is in the api exceptions list
-	if len(detailEvents) > 0 && e.isInAPIExceptionsList(detailEvents) {
+	if e.isInAPIExceptionsList(detailEvents) {
+		log.Debug("Found api path in traceability api exceptions list.  Ignore transaction event")
 		return events, nil
 	}
 
@@ -181,6 +182,11 @@ func (e *Generator) createSamplingTransactionDetails(summaryEvent LogEvent) samp
 // Validate APIs in the traceability exceptions list
 func (e *Generator) isInAPIExceptionsList(logEvents []LogEvent) bool {
 
+	// Sanity check.
+	if len(logEvents) == 0 {
+		return false
+	}
+
 	// Check first leg for URI.  Use the raw value before redaction happens
 	uriRaw := ""
 
@@ -198,11 +204,11 @@ func (e *Generator) isInAPIExceptionsList(logEvents []LogEvent) bool {
 	// If the api path exists in the exceptions list, return true and ignore event
 	for _, value := range exceptions {
 		if value == uriRaw {
-			log.Debugf("Found api path %s in traceability api exceptions list.  Ignore transaction event", uriRaw)
 			return true
 		}
 	}
 
+	// api path not found in exceptions list
 	return false
 }
 

--- a/pkg/transaction/eventgenerator.go
+++ b/pkg/transaction/eventgenerator.go
@@ -191,7 +191,7 @@ func (e *Generator) isInAPIExceptionsList(logEvents []LogEvent) bool {
 	uriRaw := ""
 
 	if httpEvent, ok := logEvents[0].TransactionEvent.Protocol.(*Protocol); ok {
-		uriRaw = httpEvent.URIRaw
+		uriRaw = httpEvent.uriRaw
 	}
 
 	// Get the api exceptions list

--- a/pkg/transaction/httpprotocolbuilder.go
+++ b/pkg/transaction/httpprotocolbuilder.go
@@ -71,7 +71,7 @@ func (b *httpProtocolBuilder) SetURI(uri string) HTTPProtocolBuilder {
 	if b.err != nil {
 		return b
 	}
-	b.httpProtocol.URIRaw = uri
+	b.httpProtocol.uriRaw = uri
 	b.httpProtocol.URI, b.err = redaction.URIRedaction(uri)
 	return b
 }

--- a/pkg/transaction/httpprotocolbuilder.go
+++ b/pkg/transaction/httpprotocolbuilder.go
@@ -71,7 +71,7 @@ func (b *httpProtocolBuilder) SetURI(uri string) HTTPProtocolBuilder {
 	if b.err != nil {
 		return b
 	}
-
+	b.httpProtocol.URIRaw = uri
 	b.httpProtocol.URI, b.err = redaction.URIRedaction(uri)
 	return b
 }
@@ -101,7 +101,7 @@ func (b *httpProtocolBuilder) AddArg(key string, value []string) HTTPProtocolBui
 		return b
 	}
 	if _, ok := b.argsMap[key]; ok {
-		b.err = fmt.Errorf("Arg with key %s has already been added", key)
+		b.err = fmt.Errorf("arg with key %s has already been added", key)
 	} else {
 		b.argsMap[key] = value
 	}
@@ -233,7 +233,7 @@ func (b *httpProtocolBuilder) AddRequestHeader(key string, value string) HTTPPro
 		return b
 	}
 	if _, ok := b.requestHeaders[key]; ok {
-		b.err = fmt.Errorf("Response Header with key %s has already been added", key)
+		b.err = fmt.Errorf("response Header with key %s has already been added", key)
 	} else {
 		b.requestHeaders[key] = value
 	}
@@ -253,7 +253,7 @@ func (b *httpProtocolBuilder) AddResponseHeader(key string, value string) HTTPPr
 		return b
 	}
 	if _, ok := b.responseHeaders[key]; ok {
-		b.err = fmt.Errorf("Response Header with key %s has already been added", key)
+		b.err = fmt.Errorf("response Header with key %s has already been added", key)
 	} else {
 		b.responseHeaders[key] = value
 	}
@@ -294,7 +294,7 @@ func (b *httpProtocolBuilder) AddIndexedRequestHeader(key string, value string) 
 		return b
 	}
 	if _, ok := b.indexedRequestHeaders[key]; ok {
-		b.err = fmt.Errorf("Indexed Response Header with key %s has already been added", key)
+		b.err = fmt.Errorf("indexed Response Header with key %s has already been added", key)
 	} else {
 		b.indexedRequestHeaders[key] = value
 	}
@@ -314,7 +314,7 @@ func (b *httpProtocolBuilder) AddIndexedResponseHeader(key string, value string)
 		return b
 	}
 	if _, ok := b.indexedResponseHeaders[key]; ok {
-		b.err = fmt.Errorf("Indexed Response Header with key %s has already been added", key)
+		b.err = fmt.Errorf("indexed Response Header with key %s has already been added", key)
 	} else {
 		b.indexedResponseHeaders[key] = value
 	}
@@ -349,23 +349,23 @@ func (b *httpProtocolBuilder) Build() (TransportProtocol, error) {
 	}
 
 	if b.httpProtocol.RequestHeaders == "" || b.httpProtocol.ResponseHeaders == "" {
-		return nil, errors.New("Request or Response Headers not set in HTTP protocol details")
+		return nil, errors.New("request or Response Headers not set in HTTP protocol details")
 	}
 
 	if b.httpProtocol.URI == "" {
-		return nil, errors.New("URI property not set in HTTP protocol details")
+		return nil, errors.New("uri property not set in HTTP protocol details")
 	}
 
 	if b.httpProtocol.Method == "" {
-		return nil, errors.New("Method property not set in HTTP protocol details")
+		return nil, errors.New("method property not set in HTTP protocol details")
 	}
 
 	if b.httpProtocol.Host == "" {
-		return nil, errors.New("Host property not set in HTTP protocol details")
+		return nil, errors.New("host property not set in HTTP protocol details")
 	}
 
 	if b.httpProtocol.Status < 100 || b.httpProtocol.Status > 600 {
-		return nil, errors.New("Invalid status code set in HTTP protocol details")
+		return nil, errors.New("invalid status code set in HTTP protocol details")
 	}
 	return b.httpProtocol, nil
 }

--- a/pkg/transaction/httpprotocolbuilder_test.go
+++ b/pkg/transaction/httpprotocolbuilder_test.go
@@ -41,21 +41,21 @@ func TestHTTPProtocolBuilder(t *testing.T) {
 	httpProtocol, err = httpProtocolBuilder.Build()
 	assert.Nil(t, httpProtocol)
 	assert.NotNil(t, err)
-	assert.Equal(t, "URI property not set in HTTP protocol details", err.Error())
+	assert.Equal(t, "uri property not set in HTTP protocol details", err.Error())
 
 	httpProtocol, err = httpProtocolBuilder.
 		SetURI("/test").
 		Build()
 	assert.Nil(t, httpProtocol)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Method property not set in HTTP protocol details", err.Error())
+	assert.Equal(t, "method property not set in HTTP protocol details", err.Error())
 	httpProtocol, err = httpProtocolBuilder.
 		SetURI("/test").
 		SetMethod("GET").
 		Build()
 	assert.Nil(t, httpProtocol)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Host property not set in HTTP protocol details", err.Error())
+	assert.Equal(t, "host property not set in HTTP protocol details", err.Error())
 
 	httpProtocol, err = httpProtocolBuilder.
 		SetURI("/test").
@@ -65,7 +65,7 @@ func TestHTTPProtocolBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, httpProtocol)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Invalid status code set in HTTP protocol details", err.Error())
+	assert.Equal(t, "invalid status code set in HTTP protocol details", err.Error())
 
 	httpProtocol, err = httpProtocolBuilder.
 		SetURI("/test").

--- a/pkg/transaction/logeventbuilder.go
+++ b/pkg/transaction/logeventbuilder.go
@@ -290,7 +290,7 @@ func (b *transactionEventBuilder) SetProtocolDetail(protocolDetail interface{}) 
 	if ok {
 		b.logEvent.TransactionEvent.Protocol = protocolDetail
 	} else {
-		b.err = errors.New("Unsupported protocol type")
+		b.err = errors.New("unsupported protocol type")
 	}
 	return b
 }
@@ -319,23 +319,23 @@ func (b *transactionEventBuilder) validateLogEvent() error {
 	}
 
 	if b.logEvent.TenantID == "" {
-		return errors.New("Tenant ID property not set in transaction event")
+		return errors.New("tenant ID property not set in transaction event")
 	}
 
 	if b.logEvent.EnvironmentID == "" {
-		return errors.New("Environment ID property are not set in transaction event")
+		return errors.New("environment ID property are not set in transaction event")
 	}
 
 	if b.logEvent.TransactionEvent.ID == "" {
-		return errors.New("ID property not set in transaction event")
+		return errors.New("id property not set in transaction event")
 	}
 
 	if b.logEvent.TransactionEvent.Direction == "" {
-		return errors.New("Direction property not set in transaction event")
+		return errors.New("direction property not set in transaction event")
 	}
 
 	if b.logEvent.TransactionEvent.Status == "" {
-		return errors.New("Status property not set in transaction event")
+		return errors.New("status property not set in transaction event")
 	}
 
 	if b.logEvent.TransactionEvent.Protocol == nil {
@@ -543,23 +543,23 @@ func (b *transactionSummaryBuilder) validateLogEvent() error {
 	}
 
 	if b.logEvent.TenantID == "" {
-		return errors.New("Tenant ID property not set in transaction summary event")
+		return errors.New("tenant ID property not set in transaction summary event")
 	}
 
 	if b.logEvent.EnvironmentID == "" {
-		return errors.New("Environment ID property are not set in transaction summary event")
+		return errors.New("environment ID property are not set in transaction summary event")
 	}
 
 	if b.logEvent.TransactionSummary.Status == "" {
-		return errors.New("Status property not set in transaction summary event")
+		return errors.New("status property not set in transaction summary event")
 	}
 
 	if b.logEvent.TransactionSummary.EntryPoint == nil {
-		return errors.New("Transaction entry point details are not set in transaction summary event")
+		return errors.New("transaction entry point details are not set in transaction summary event")
 	}
 
 	if b.logEvent.TransactionSummary.Product != nil && b.logEvent.TransactionSummary.Product.ID == "" {
-		return errors.New("Product ID property not set in transaction summary event")
+		return errors.New("product ID property not set in transaction summary event")
 	}
 	return nil
 }

--- a/pkg/transaction/logeventbuilder.go
+++ b/pkg/transaction/logeventbuilder.go
@@ -18,7 +18,7 @@ func (s TxEventStatus) IsValid() error {
 	case TxEventStatusPass, TxEventStatusFail:
 		return nil
 	}
-	return errors.New("Invalid transaction event status")
+	return errors.New("invalid transaction event status")
 }
 
 // IsValid - Validator for TxSummaryStatus
@@ -27,7 +27,7 @@ func (s TxSummaryStatus) IsValid() error {
 	case TxSummaryStatusSuccess, TxSummaryStatusFailure, TxSummaryStatusException, TxSummaryStatusUnknown:
 		return nil
 	}
-	return errors.New("Invalid transaction summary status")
+	return errors.New("invalid transaction summary status")
 }
 
 // EventBuilder - Interface to build the log event of type transaction event
@@ -339,7 +339,7 @@ func (b *transactionEventBuilder) validateLogEvent() error {
 	}
 
 	if b.logEvent.TransactionEvent.Protocol == nil {
-		return errors.New("Protocol details not set in transaction event")
+		return errors.New("protocol details not set in transaction event")
 	}
 	return nil
 }

--- a/pkg/transaction/logeventbuilder_test.go
+++ b/pkg/transaction/logeventbuilder_test.go
@@ -27,7 +27,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "ID property not set in transaction event", err.Error())
+	assert.Equal(t, "id property not set in transaction event", err.Error())
 
 	logEvent, err = NewTransactionEventBuilder().
 		SetTransactionID("11111").
@@ -36,7 +36,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Direction property not set in transaction event", err.Error())
+	assert.Equal(t, "direction property not set in transaction event", err.Error())
 
 	logEvent, err = NewTransactionEventBuilder().
 		SetTransactionID("11111").
@@ -46,7 +46,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Status property not set in transaction event", err.Error())
+	assert.Equal(t, "status property not set in transaction event", err.Error())
 
 	logEvent, err = NewTransactionEventBuilder().
 		SetTransactionID("11111").
@@ -57,7 +57,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Invalid transaction event status", err.Error())
+	assert.Equal(t, "invalid transaction event status", err.Error())
 
 	logEvent, err = NewTransactionEventBuilder().
 		SetTransactionID("11111").
@@ -72,7 +72,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Protocol details not set in transaction event", err.Error())
+	assert.Equal(t, "protocol details not set in transaction event", err.Error())
 
 	logEvent, err = NewTransactionEventBuilder().
 		SetTransactionID("11111").
@@ -89,7 +89,7 @@ func TestTransactionEventBuilder(t *testing.T) {
 
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Unsupported protocol type", err.Error())
+	assert.Equal(t, "unsupported protocol type", err.Error())
 
 	httpProtocol, _ := createHTTPProtocol("/testuri", "GET", "{}", "{}", 200, 10, 10)
 	logEvent, err = NewTransactionEventBuilder().
@@ -222,7 +222,7 @@ func TestSummaryBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Status property not set in transaction summary event", err.Error())
+	assert.Equal(t, "status property not set in transaction summary event", err.Error())
 
 	logEvent, err = NewTransactionSummaryBuilder().
 		SetDuration(10).
@@ -230,7 +230,7 @@ func TestSummaryBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Invalid transaction summary status", err.Error())
+	assert.Equal(t, "invalid transaction summary status", err.Error())
 
 	logEvent, err = NewTransactionSummaryBuilder().
 		SetDuration(10).
@@ -238,7 +238,7 @@ func TestSummaryBuilder(t *testing.T) {
 		Build()
 	assert.Nil(t, logEvent)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Transaction entry point details are not set in transaction summary event", err.Error())
+	assert.Equal(t, "transaction entry point details are not set in transaction summary event", err.Error())
 
 	// Test with explicitly setting properties that are set thru agent config by default
 	logEvent, err = NewTransactionSummaryBuilder().


### PR DESCRIPTION
1. new traceability configuration - apiExceptionsList: ${TRACEABILITY_EXCEPTION_LIST:"stringPath1, stringPath2, etc"}
2. Before redaction on URI, check to see if api path matches with entries in apiExceptionsList
3. If we find a match, do not send the event through
4. Should not affect go right path
5. Create debug logs to show what api path sdk found to ignore
6. Fix lint warning about upper case error verbiage(s)