### PR TITLE
APIGOV-21016 - updates for the jobs library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,4 +53,4 @@ replace (
 	github.com/tonistiigi/fifo => github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c
 )
 
-retract [v1.1.4, v1.1.6] // errored versions
+retract [v1.1.4, v1.1.9] // errored versions

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -60,8 +60,12 @@ func (su *agentStatusUpdate) Status() error {
 
 func (su *agentStatusUpdate) Execute() error {
 	// only one status update should execute at a time
+	log.Tracef("get status update lock %s", su.typeOfStatusUpdate)
 	updateStatusMutex.Lock()
-	defer updateStatusMutex.Unlock()
+	defer func() {
+		log.Tracef("return status update lock %s", su.typeOfStatusUpdate)
+		updateStatusMutex.Unlock()
+	}()
 
 	// error out if the agent name does not exist
 	err := runStatusUpdateCheck()

--- a/pkg/apic/subscriptionmanager.go
+++ b/pkg/apic/subscriptionmanager.go
@@ -37,6 +37,7 @@ type subscriptionManager struct {
 	apicClient          *ServiceClient
 	locklist            map[string]string // subscription items to skip because they are locked
 	locklistLock        *sync.RWMutex     // Use lock when making changes/reading the locklist map
+	jobID               string
 }
 
 // newSubscriptionManager - Creates a new subscription manager
@@ -51,7 +52,8 @@ func newSubscriptionManager(apicClient *ServiceClient) SubscriptionManager {
 	}
 
 	if apicClient.cfg.GetSubscriptionConfig().PollingEnabled() {
-		_, err := jobs.RegisterIntervalJobWithName(subscriptionMgr, apicClient.cfg.GetPollInterval(), "Subscription Manager")
+		var err error
+		subscriptionMgr.jobID, err = jobs.RegisterIntervalJobWithName(subscriptionMgr, apicClient.cfg.GetPollInterval(), "Subscription Manager")
 		if err != nil {
 			log.Errorf("Error registering interval job to poll for subscriptions: %s", err.Error())
 		}
@@ -240,6 +242,7 @@ func (sm *subscriptionManager) Stop() {
 		sm.publisher.Stop()
 		sm.receiverQuitChannel <- true
 		sm.isRunning = false
+		jobs.UnregisterJob(sm.jobID)
 	}
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -62,6 +62,7 @@ type agentRootCommand struct {
 	centralCfg        config.CentralConfig
 	agentCfg          interface{}
 	secretResolver    resolver.SecretResolver
+	initialized       bool
 }
 
 func init() {
@@ -89,6 +90,7 @@ func NewRootCmd(exeName, desc string, initConfigHandler InitConfigHandler, comma
 		initConfigHandler: initConfigHandler,
 		agentType:         agentType,
 		secretResolver:    resolver.NewSecretResolver(),
+		initialized:       false,
 	}
 
 	// use the description from the build if available
@@ -125,6 +127,7 @@ func NewCmd(rootCmd *cobra.Command, exeName, desc string, initConfigHandler Init
 		initConfigHandler: initConfigHandler,
 		agentType:         agentType,
 		secretResolver:    resolver.NewSecretResolver(),
+		initialized:       false,
 	}
 
 	// use the description from the build if available
@@ -275,10 +278,13 @@ func (c *agentRootCommand) initConfig() error {
 		}
 	}
 
-	// Start the initial and recurring version check jobs
-	startVersionCheckJobs(c.centralCfg)
-	// Init the healthcheck API
-	hc.HandleRequests()
+	if !c.initialized {
+		// Start the initial and recurring version check jobs
+		startVersionCheckJobs(c.centralCfg)
+		// Init the healthcheck API
+		hc.HandleRequests()
+	}
+	c.initialized = true
 	return nil
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/cmd/properties"
 	"github.com/Axway/agent-sdk/pkg/cmd/properties/resolver"
 	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/errors"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
@@ -259,6 +260,9 @@ func (c *agentRootCommand) initConfig() error {
 	if err != nil {
 		return err
 	}
+
+	jobs.UpdateDurations(c.statusCfg.GetHealthCheckInterval(), c.centralCfg.GetJobExecutionTimeout())
+
 	// Initialize Agent Config
 	c.agentCfg, err = c.initConfigHandler(c.centralCfg)
 	if err != nil {

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -127,6 +127,7 @@ type CentralConfig interface {
 	GetProxyURL() string
 	GetPollInterval() time.Duration
 	GetReportActivityFrequency() time.Duration
+	GetJobExecutionTimeout() time.Duration
 	GetClientTimeout() time.Duration
 	GetAPIServiceRevisionPattern() string
 	GetCatalogItemByIDURL(catalogItemID string) string
@@ -164,6 +165,7 @@ type CentralConfiguration struct {
 	ProxyURL                  string               `config:"proxyUrl"`
 	SubscriptionConfiguration SubscriptionConfig   `config:"subscriptions"`
 	UsageReporting            UsageReportingConfig `config:"usageReporting"`
+	JobExecutionTimeout       time.Duration        `config:"jobTimeout"`
 	environmentID             string
 	teamID                    string
 	isAxwayManaged            bool
@@ -186,6 +188,7 @@ func NewCentralConfig(agentType AgentType) CentralConfig {
 		VersionChecker:            true,
 		ReportActivityFrequency:   5 * time.Minute,
 		UsageReporting:            NewUsageReporting(),
+		JobExecutionTimeout:       5 * time.Minute,
 	}
 }
 
@@ -414,6 +417,11 @@ func (c *CentralConfiguration) GetReportActivityFrequency() time.Duration {
 	return c.ReportActivityFrequency
 }
 
+// GetJobExecutionTimeout - Returns the max time a job execution can run before considered failed
+func (c *CentralConfiguration) GetJobExecutionTimeout() time.Duration {
+	return c.JobExecutionTimeout
+}
+
 // GetClientTimeout - Returns the interval for http client timeouts
 func (c *CentralConfiguration) GetClientTimeout() time.Duration {
 	return c.ClientTimeout
@@ -476,6 +484,7 @@ const (
 	pathAppendEnvironmentToTitle  = "central.appendEnvironmentToTitle"
 	pathUpdateFromAPIServer       = "central.updateFromAPIServer"
 	pathVersionChecker            = "central.versionChecker"
+	pathJobTimeout                = "central.jobTimeout"
 )
 
 // ValidateCfg - Validates the config, implementing IConfigInterface
@@ -520,6 +529,15 @@ func (c *CentralConfiguration) validateConfig() {
 		c.validatePublishToEnvironmentModeConfig()
 		c.validateDiscoveryAgentConfig()
 	}
+	if c.GetReportActivityFrequency() <= 0 {
+		exception.Throw(ErrBadConfig.FormatError(pathReportActivityFrequency))
+	}
+	if c.GetClientTimeout() <= 0 {
+		exception.Throw(ErrBadConfig.FormatError(pathClientTimeout))
+	}
+	if c.GetJobExecutionTimeout() < 0 {
+		exception.Throw(ErrBadConfig.FormatError(pathJobTimeout))
+	}
 }
 
 func (c *CentralConfiguration) validateURL(urlString, configPath string, isURLRequired bool) {
@@ -536,12 +554,6 @@ func (c *CentralConfiguration) validateURL(urlString, configPath string, isURLRe
 func (c *CentralConfiguration) validateDiscoveryAgentConfig() {
 	if c.GetPollInterval() <= 0 {
 		exception.Throw(ErrBadConfig.FormatError(pathPollInterval))
-	}
-	if c.GetReportActivityFrequency() <= 0 {
-		exception.Throw(ErrBadConfig.FormatError(pathReportActivityFrequency))
-	}
-	if c.GetClientTimeout() <= 0 {
-		exception.Throw(ErrBadConfig.FormatError(pathClientTimeout))
 	}
 }
 
@@ -565,12 +577,6 @@ func (c *CentralConfiguration) validateTraceabilityAgentConfig() {
 	}
 	if c.GetEnvironmentName() == "" {
 		exception.Throw(ErrBadConfig.FormatError(pathEnvironment))
-	}
-	if c.GetReportActivityFrequency() <= 0 {
-		exception.Throw(ErrBadConfig.FormatError(pathReportActivityFrequency))
-	}
-	if c.GetClientTimeout() <= 0 {
-		exception.Throw(ErrBadConfig.FormatError(pathClientTimeout))
 	}
 }
 
@@ -611,6 +617,7 @@ func AddCentralConfigProperties(props properties.Properties, agentType AgentType
 	props.AddStringProperty(pathAPIServerVersion, "v1alpha1", "Version of the API Server")
 	props.AddBoolProperty(pathUpdateFromAPIServer, false, "Controls whether to call API Server if the API is not in the local cache")
 	props.AddBoolProperty(pathVersionChecker, true, "Controls whether the agent version checker will be enabled or not")
+	props.AddDurationProperty(pathJobTimeout, 5*time.Minute, "The max time a job execution can run before being considered as failed")
 
 	if supportsTraceability(agentType) {
 		props.AddStringProperty(pathEnvironmentID, "", "Offline Usage Reporting Only. The Environment ID the usage is associated with on Amplify Central")
@@ -646,6 +653,7 @@ func ParseCentralConfig(props properties.Properties, agentType AgentType) (Centr
 		TenantID:                  props.StringPropertyValue(pathTenantID),
 		PollInterval:              props.DurationPropertyValue(pathPollInterval),
 		ReportActivityFrequency:   props.DurationPropertyValue(pathReportActivityFrequency),
+		JobExecutionTimeout:       props.DurationPropertyValue(pathJobTimeout),
 		ClientTimeout:             props.DurationPropertyValue(pathClientTimeout),
 		APIServiceRevisionPattern: props.StringPropertyValue(pathAPIServiceRevisionPattern),
 		Environment:               props.StringPropertyValue(pathEnvironment),

--- a/pkg/config/logconfig.go
+++ b/pkg/config/logconfig.go
@@ -219,6 +219,9 @@ func overrideLogLevel(overrides []cfgfile.ConditionalOverride) []cfgfile.Conditi
 			aliasKeyPrefix := properties.GetAliasKeyPrefix()
 			output, _ := cfg.String(fmt.Sprintf("%s.%s", aliasKeyPrefix, pathLogOutput), 0)
 			if strings.ToLower(output) == "file" || strings.ToLower(output) == "both" {
+				if strings.ToLower(output) == "both" {
+					log.Warn("Traceability agent can only log to one output type, setting to file output")
+				}
 				return true
 			}
 			return false

--- a/pkg/jobs/README.md
+++ b/pkg/jobs/README.md
@@ -54,6 +54,15 @@ func (j *MyJob) Execute() error {
 
 ## Job types
 
+The section covers the following job types
+
+- [Single run jobs](#single-run-jobs)
+- [Retry jobs](#retry-jobs)
+- [Interval jobs](#interval-jobs)
+- [Detached interval jobs](#detached-interval-jobs)
+- [Scheduled jobs](#scheduled-jobs)
+- [Channel jobs](#channel-jobs)
+
 ### Single run jobs
 
 Single run jobs are used to run a specific task exactly once, regardless of pass or fail.
@@ -73,7 +82,7 @@ import (
 
 func main() {
   myJob := MyJob{}
-  jobID, err := jobs.RegisterSingleRunJob(myJob)
+  jobID, err := jobs.RegisterSingleRunJobWithName(myJob, "My Job")
   if err != nil {
     panic(err) // error registering the job
   }
@@ -101,7 +110,7 @@ import (
 func main() {
   myJob := MyJob{}
   retries := 3
-  jobID, err := jobs.RegisterRetryJob(myJob, retries)
+  jobID, err := jobs.RegisterRetryJobWithName(myJob, retries, "My Job")
   if err != nil {
     panic(err) // error registering the job
   }
@@ -129,13 +138,17 @@ import (
 func main() {
   myJob := MyJob{}
   interval := 30 * time.Second
-  jobID, err := jobs.RegisterIntervalJob(myJob, interval)
+  jobID, err := jobs.RegisterIntervalJobWithName(myJob, interval, "My Job")
   if err != nil {
     panic(err) // error registering the job
   }
   fmt.Println(GetJobStatus(jobID))
 }
 ```
+
+### Detached interval jobs
+
+Detached interval jobs are just like Interval jobs except they are not stopped with other jobs fail, they run independent of the job pool
 
 ### Scheduled jobs
 
@@ -195,7 +208,37 @@ import (
 func main() {
   myJob := MyJob{}
   runHalfPastHour := "0 30 * * * * *"
-  jobID, err := jobs.RegisterScheduledJob(myJob, runHalfPastHour)
+  jobID, err := jobs.RegisterScheduledJobWithName(myJob, runHalfPastHour, "My Job")
+  if err != nil {
+    panic(err) // error registering the job
+  }
+  fmt.Println(GetJobStatus(jobID))
+}
+```
+
+### Channel jobs
+
+Channel jobs are executed a single time via a go routine.  It is expected that the channel job runs forever.  
+
+To allow this job to be stopped and started the implementer will provide a channel that the jobs pool can use to tell the job to stop.
+
+#### Register Channel job
+
+Register the job and get its status
+
+```go
+package main
+
+import (
+  "fmt"
+
+  "github.com/Axway/agent-sdk/pkg/jobs"
+)
+
+func main() {
+  myJob := MyJob{}
+  stopChannel := make(chan interface{})
+  jobID, err := jobs.RegisterChannelJobWithName(myJob, stopChannel, "My Job")
   if err != nil {
     panic(err) // error registering the job
   }

--- a/pkg/jobs/backoff.go
+++ b/pkg/jobs/backoff.go
@@ -1,0 +1,38 @@
+package jobs
+
+import "time"
+
+func newBackoffTimeout(startingTimeout time.Duration, maxTimeout time.Duration, increaseFactor int) *backoff {
+	return &backoff{
+		base:    startingTimeout,
+		max:     maxTimeout,
+		current: startingTimeout,
+		factor:  increaseFactor,
+	}
+}
+
+type backoff struct {
+	base    time.Duration
+	max     time.Duration
+	current time.Duration
+	factor  int
+}
+
+func (b *backoff) increaseTimeout() {
+	b.current = b.current * time.Duration(b.factor)
+	if b.current > b.max {
+		b.current = b.max // use the max timeout
+	}
+}
+
+func (b *backoff) reset() {
+	b.current = b.base
+}
+
+func (b *backoff) sleep() {
+	time.Sleep(b.current)
+}
+
+func (b *backoff) getCurrentTimeout() time.Duration {
+	return b.current
+}

--- a/pkg/jobs/backoff_test.go
+++ b/pkg/jobs/backoff_test.go
@@ -1,0 +1,47 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffTimeout(t *testing.T) {
+	start := time.Millisecond
+	max := 10 * time.Millisecond
+	factor := 2
+	newBT := newBackoffTimeout(start, max, factor)
+
+	assert.Equal(t, start, newBT.base)
+	assert.Equal(t, max, newBT.max)
+	assert.Equal(t, factor, newBT.factor)
+	assert.Equal(t, start, newBT.getCurrentTimeout())
+
+	// increase the timeout, 2 milliseconds
+	newBT.increaseTimeout()
+	assert.Equal(t, start, newBT.base)
+	assert.Equal(t, max, newBT.max)
+	assert.Equal(t, factor, newBT.factor)
+	assert.Equal(t, start*2, newBT.getCurrentTimeout())
+
+	// increase the timeout again, 4 milliseconds
+	newBT.increaseTimeout()
+	assert.Equal(t, start*2*2, newBT.getCurrentTimeout())
+
+	// increase the timeout 2 more times, should be at max
+	newBT.increaseTimeout()
+	newBT.increaseTimeout()
+	assert.Equal(t, max, newBT.getCurrentTimeout())
+
+	// reset the timeout
+	newBT.reset()
+	assert.Equal(t, start, newBT.getCurrentTimeout())
+
+	// call sleep
+	newBT.sleep()
+	assert.Equal(t, start, newBT.base)
+	assert.Equal(t, max, newBT.max)
+	assert.Equal(t, factor, newBT.factor)
+	assert.Equal(t, start, newBT.getCurrentTimeout())
+}

--- a/pkg/jobs/baseJob.go
+++ b/pkg/jobs/baseJob.go
@@ -138,7 +138,7 @@ func (b *baseJob) updateStatus() JobStatus {
 	jobStatus := b.job.Status()   // get the current status
 	if jobStatus != nil {         // on error set the status to failed
 		b.failChan <- b.id
-		log.Errorf("job with ID %s failed: %s", b.id, jobStatus.Error())
+		log.Errorf("job %s (%s) failed: %s", b.name, b.id, jobStatus.Error())
 		newStatus = JobStatusFailed
 	}
 	b.statusLock.Lock()

--- a/pkg/jobs/baseJob.go
+++ b/pkg/jobs/baseJob.go
@@ -110,6 +110,14 @@ func (b *baseJob) GetID() string {
 	return b.id
 }
 
+//GetName - returns the name for this job, returns the ID if name is blank
+func (b *baseJob) GetName() string {
+	if b.name == "" {
+		return b.id
+	}
+	return b.name
+}
+
 //GetJob - returns the Job interface
 func (b *baseJob) GetJob() JobExecution {
 	return b

--- a/pkg/jobs/baseJob.go
+++ b/pkg/jobs/baseJob.go
@@ -144,9 +144,11 @@ func (b *baseJob) Ready() bool {
 
 //waitForReady - waits for the Ready func to return true
 func (b *baseJob) waitForReady() {
+	log.Debugf("Waiting for %s (%s) to be ready", b.name, b.id)
 	for !b.job.Ready() { // Wait for the job to be ready before starting
 		time.Sleep(time.Millisecond)
 	}
+	log.Debugf("%s (%s) is ready", b.name, b.id)
 }
 
 //start - waits for Ready to return true then calls the Execute function from the Job definition

--- a/pkg/jobs/basejob_test.go
+++ b/pkg/jobs/basejob_test.go
@@ -35,6 +35,7 @@ func TestSingleRunJob(t *testing.T) {
 	}
 
 	jobID, _ := RegisterSingleRunJob(job)
+	globalPool.jobs[jobID].(*baseJob).backoff = newBackoffTimeout(time.Millisecond, time.Millisecond, 1)
 
 	time.Sleep(10 * time.Millisecond)
 	status := GetJobStatus(jobID)

--- a/pkg/jobs/basejob_test.go
+++ b/pkg/jobs/basejob_test.go
@@ -47,4 +47,6 @@ func TestSingleRunJob(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	status = GetJobStatus(jobID)
 	assert.Equal(t, jobStatusToString[JobStatusFinished], status)
+
+	UnregisterJob(jobID)
 }

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -56,7 +56,12 @@ func (b *channelJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *channelJob) stop() {
 	b.stopLog()
-	log.Tracef("writing to %s stop channel", b.GetName())
-	b.stopChan <- true
-	log.Tracef("wrote to %s stop channel", b.GetName())
+	if b.isReady {
+		log.Tracef("writing to %s stop channel", b.GetName())
+		b.stopChan <- true
+		log.Tracef("wrote to %s stop channel", b.GetName())
+	} else {
+		b.stopReadyChan <- nil
+	}
+	b.isReady = false
 }

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -17,14 +17,7 @@ type channelJob struct {
 //newChannelJob - creates a channel run job
 func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := channelJob{
-		baseJob{
-			id:       newUUID(),
-			name:     name,
-			job:      newJob,
-			jobType:  JobTypeChannel,
-			status:   JobStatusInitializing,
-			failChan: failJobChan,
-		},
+		createBaseJob(newJob, failJobChan, name, JobTypeChannel),
 		channelJobProps{
 			signalStop: signalStop,
 			stopChan:   make(chan bool),

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -56,12 +56,12 @@ func (b *channelJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *channelJob) stop() {
 	b.stopLog()
-	if b.isReady {
+	if b.IsReady() {
 		log.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		log.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}
-	b.isReady = false
+	b.UnsetIsReady()
 }

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -51,13 +51,12 @@ func (b *channelJob) handleExecution() {
 func (b *channelJob) start() {
 	b.startLog()
 	b.waitForReady()
-	go b.handleExecution() // start a ingle execution in a go routine as it runs forever
+	go b.handleExecution() // start a single execution in a go routine as it runs forever
 
 	// Wait for a write on the stop channel
 	<-b.stopChan
 	b.signalStop <- nil // signal the execution to stop
 	b.SetStatus(JobStatusStopped)
-
 }
 
 //stop - write to the stop channel to stop the execution loop

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -37,7 +37,7 @@ func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJob
 
 func (b *channelJob) handleExecution() {
 	// Execute the job
-	b.executeCronJob()
+	b.executeJob()
 	if b.err != nil {
 		b.setExecutionError()
 		log.Error(b.err)
@@ -52,6 +52,7 @@ func (b *channelJob) start() {
 	b.startLog()
 	b.waitForReady()
 	go b.handleExecution() // start a single execution in a go routine as it runs forever
+	b.SetStatus(JobStatusRunning)
 
 	// Wait for a write on the stop channel
 	<-b.stopChan

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -1,0 +1,74 @@
+package jobs
+
+import (
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+type channelJobProps struct {
+	signalStop chan interface{}
+	stopChan   chan bool
+}
+
+type channelJob struct {
+	baseJob
+	channelJobProps
+}
+
+//newChannelJob - creates a channel run job
+func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJobChan chan string) (JobExecution, error) {
+	thisJob := channelJob{
+		baseJob{
+			id:       newUUID(),
+			name:     name,
+			job:      newJob,
+			jobType:  JobTypeInterval,
+			status:   JobStatusInitializing,
+			failChan: failJobChan,
+		},
+		channelJobProps{
+			signalStop: signalStop,
+			stopChan:   make(chan bool),
+		},
+	}
+
+	go thisJob.start()
+	return &thisJob, nil
+}
+
+func (b *channelJob) handleExecution() {
+	// Execute the job
+	b.executeCronJob()
+	if b.err != nil {
+		b.setExecutionError()
+		log.Error(b.err)
+		b.SetStatus(JobStatusStopped)
+		b.consecutiveFails++
+	}
+	b.consecutiveFails = 0
+}
+
+//start - calls the Execute function from the Job definition
+func (b *channelJob) start() {
+	b.startLog()
+	b.waitForReady()
+
+	for {
+		// Non-blocking channel read, if stopped then exit
+		select {
+		case <-b.stopChan:
+			b.SetStatus(JobStatusStopped)
+			b.signalStop <- nil
+			return
+		default:
+			b.handleExecution()
+		}
+	}
+}
+
+//stop - write to the stop channel to stop the execution loop
+func (b *channelJob) stop() {
+	b.stopLog()
+	log.Tracef("writing to %s stop channel", b.GetName())
+	b.stopChan <- true
+	log.Tracef("wrote to %s stop channel", b.GetName())
+}

--- a/pkg/jobs/channeljob_test.go
+++ b/pkg/jobs/channeljob_test.go
@@ -1,0 +1,71 @@
+package jobs
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type channelJobImpl struct {
+	Job
+	name        string
+	runTime     time.Duration
+	ready       bool
+	executions  int
+	failEvery   int
+	status      error
+	failTime    time.Duration
+	wasFailed   bool
+	wasRestored bool
+	stopChan    chan interface{}
+}
+
+func (j *channelJobImpl) Execute() error {
+	j.executions++
+	for {
+		select {
+		case <-j.stopChan:
+			return nil
+		default:
+			time.Sleep(j.runTime)
+			if j.failEvery > 0 && j.executions%j.failEvery == 0 {
+				j.status = fmt.Errorf("FAIL")
+				j.wasFailed = true
+			}
+		}
+	}
+}
+
+func (j *channelJobImpl) Status() error {
+	return j.status
+}
+
+func (j *channelJobImpl) Ready() bool {
+	return j.ready
+}
+
+func TestChannelJob(t *testing.T) {
+	job := &channelJobImpl{
+		name:     "ChannelJob",
+		runTime:  5 * time.Millisecond,
+		ready:    false,
+		stopChan: make(chan interface{}),
+	}
+
+	jobID, _ := RegisterChannelJob(job, job.stopChan)
+
+	status := GetJobStatus(jobID)
+	assert.Equal(t, jobStatusToString[JobStatusInitializing], status)
+	job.ready = true
+	time.Sleep(10 * time.Millisecond)
+	status = GetJobStatus(jobID)
+	assert.Equal(t, jobStatusToString[JobStatusRunning], status)
+	time.Sleep(50 * time.Millisecond) // Let the executions continue
+	globalPool.cronJobs[jobID].stop()
+	time.Sleep(10 * time.Millisecond)
+	status = GetJobStatus(jobID)
+	assert.Equal(t, jobStatusToString[JobStatusStopped], status)
+	assert.LessOrEqual(t, 1, job.executions)
+}

--- a/pkg/jobs/channeljob_test.go
+++ b/pkg/jobs/channeljob_test.go
@@ -66,6 +66,6 @@ func TestChannelJob(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	status = GetJobStatus(jobID)
 	assert.Equal(t, jobStatusToString[JobStatusRunning], status)
-	globalPool.cronJobs[jobID].stop()
+	UnregisterJob(jobID)
 	time.Sleep(10 * time.Millisecond)
 }

--- a/pkg/jobs/channeljob_test.go
+++ b/pkg/jobs/channeljob_test.go
@@ -46,6 +46,7 @@ func TestChannelJob(t *testing.T) {
 	}
 
 	jobID, _ := RegisterChannelJob(job, job.stopChan)
+	globalPool.jobs[jobID].(*channelJob).backoff = newBackoffTimeout(time.Millisecond, time.Millisecond, 1)
 
 	status := GetJobStatus(jobID)
 	assert.Equal(t, jobStatusToString[JobStatusInitializing], status)

--- a/pkg/jobs/definitions.go
+++ b/pkg/jobs/definitions.go
@@ -16,6 +16,7 @@ type Job interface {
 type JobExecution interface {
 	GetStatus() JobStatus
 	GetID() string
+	GetName() string
 	Ready() bool
 	GetJob() JobExecution
 	Lock()

--- a/pkg/jobs/definitions.go
+++ b/pkg/jobs/definitions.go
@@ -86,6 +86,7 @@ const (
 	JobTypeSingleRun        = "single run"
 	JobTypeRetry            = "retry"
 	JobTypeInterval         = "interval"
+	JobTypeChannel          = "channel"
 	JobTypeDetachedInterval = "detached interval"
 	JobTypeScheduled        = "scheduled"
 )

--- a/pkg/jobs/detachedintervaljob.go
+++ b/pkg/jobs/detachedintervaljob.go
@@ -7,14 +7,7 @@ import (
 //newDetachedIntervalJob - creates an interval run job, detached from other cron jobs
 func newDetachedIntervalJob(newJob Job, interval time.Duration, name string) (JobExecution, error) {
 	thisJob := intervalJob{
-		baseJob{
-			id:       newUUID(),
-			name:     name,
-			job:      newJob,
-			jobType:  JobTypeDetachedInterval,
-			status:   JobStatusInitializing,
-			failChan: nil,
-		},
+		createBaseJob(newJob, nil, name, JobTypeDetachedInterval),
 		intervalJobProps{
 			interval: interval,
 			stopChan: make(chan bool),

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -77,5 +77,7 @@ func (b *intervalJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *intervalJob) stop() {
 	b.stopLog()
+	log.Tracef("writing to %s stop channel", b.GetName())
 	b.stopChan <- true
+	log.Tracef("wrote to %s stop channel", b.GetName())
 }

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -70,12 +70,12 @@ func (b *intervalJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *intervalJob) stop() {
 	b.stopLog()
-	if b.isReady {
+	if b.IsReady() {
 		log.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		log.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}
-	b.isReady = false
+	b.UnsetIsReady()
 }

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -19,14 +19,7 @@ type intervalJob struct {
 //newIntervalJob - creates an interval run job
 func newIntervalJob(newJob Job, interval time.Duration, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := intervalJob{
-		baseJob{
-			id:       newUUID(),
-			name:     name,
-			job:      newJob,
-			jobType:  JobTypeInterval,
-			status:   JobStatusInitializing,
-			failChan: failJobChan,
-		},
+		createBaseJob(newJob, failJobChan, name, JobTypeInterval),
 		intervalJobProps{
 			interval: interval,
 			stopChan: make(chan bool),

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -70,7 +70,12 @@ func (b *intervalJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *intervalJob) stop() {
 	b.stopLog()
-	log.Tracef("writing to %s stop channel", b.GetName())
-	b.stopChan <- true
-	log.Tracef("wrote to %s stop channel", b.GetName())
+	if b.isReady {
+		log.Tracef("writing to %s stop channel", b.GetName())
+		b.stopChan <- true
+		log.Tracef("wrote to %s stop channel", b.GetName())
+	} else {
+		b.stopReadyChan <- nil
+	}
+	b.isReady = false
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -4,9 +4,17 @@ import "time"
 
 //globalPool - the default job pool
 var globalPool *Pool
+var executionTimeLimit time.Duration
 
 func init() {
 	globalPool = newPool()
+	executionTimeLimit = 5 * time.Minute
+}
+
+// UpdateDurations - updates settings int he jobs library
+func UpdateDurations(retryInterval time.Duration, executionTimeout time.Duration) {
+	executionTimeLimit = executionTimeout
+	globalPool.backoff = newBackoffTimeout(retryInterval, 10*time.Minute, 2)
 }
 
 //RegisterSingleRunJob - Runs a single run job in the globalPool

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -29,6 +29,16 @@ func RegisterIntervalJobWithName(newJob Job, interval time.Duration, name string
 	return globalPool.RegisterIntervalJobWithName(newJob, interval, name)
 }
 
+//RegisterChannelJob - Runs a job with a specific interval between each run in the globalPool
+func RegisterChannelJob(newJob Job, stopChan chan interface{}) (string, error) {
+	return globalPool.RegisterChannelJob(newJob, stopChan)
+}
+
+//RegisterChannelJobWithName - Runs a job with a specific interval between each run in the globalPool
+func RegisterChannelJobWithName(newJob Job, stopChan chan interface{}, name string) (string, error) {
+	return globalPool.RegisterChannelJobWithName(newJob, stopChan, name)
+}
+
 //RegisterDetachedIntervalJob - Runs a job with a specific interval between each run in the globalPool, detached from other jobs to always run
 func RegisterDetachedIntervalJob(newJob Job, interval time.Duration) (string, error) {
 	return globalPool.RegisterDetachedIntervalJob(newJob, interval)

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -140,6 +140,20 @@ func (p *Pool) RegisterIntervalJobWithName(newJob Job, interval time.Duration, n
 	return p.recordCronJob(job), nil
 }
 
+//RegisterChannelJob - Runs a job with a specific interval between each run
+func (p *Pool) RegisterChannelJob(newJob Job, stopChan chan interface{}) (string, error) {
+	return p.RegisterChannelJobWithName(newJob, stopChan, "")
+}
+
+//RegisterChannelJobWithName - Runs a job with a specific interval between each run
+func (p *Pool) RegisterChannelJobWithName(newJob Job, stopChan chan interface{}, name string) (string, error) {
+	job, err := newChannelJob(newJob, stopChan, name, p.failJobChan)
+	if err != nil {
+		return "", err
+	}
+	return p.recordCronJob(job), nil
+}
+
 //RegisterDetachedIntervalJob - Runs a job with a specific interval between each run, detached from other jobs
 func (p *Pool) RegisterDetachedIntervalJob(newJob Job, interval time.Duration) (string, error) {
 	return p.RegisterDetachedIntervalJobWithName(newJob, interval, "")

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -257,10 +257,12 @@ func (p *Pool) stopAll() {
 	}
 	p.cronJobsMapLock.Unlock()
 	for _, job := range mapCopy {
+		log.Tracef("starting to stop job %s", job.GetName())
 		job.stop()
 		if job.getConsecutiveFails() > maxErrors {
 			maxErrors = job.getConsecutiveFails()
 		}
+		log.Tracef("finished stopping job %s", job.GetName())
 	}
 	for i := 1; i < maxErrors; i++ {
 		p.backoffTimeout()

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -62,7 +62,7 @@ func (p *Pool) recordCronJob(job JobExecution) string {
 	p.cronJobsMapLock.Lock()
 	defer p.cronJobsMapLock.Unlock()
 	p.cronJobs[job.GetID()] = job
-	log.Tracef("added new cron job, now running %s cron jobs", len(p.cronJobs))
+	log.Tracef("added new cron job, now running %v cron jobs", len(p.cronJobs))
 	return p.recordJob(job)
 }
 
@@ -71,7 +71,7 @@ func (p *Pool) recordDetachedCronJob(job JobExecution) string {
 	p.detachedCronJobsMapLock.Lock()
 	defer p.detachedCronJobsMapLock.Unlock()
 	p.detachedCronJobs[job.GetID()] = job
-	log.Tracef("added new cron job, now running %s detached cron jobs", len(p.detachedCronJobs))
+	log.Tracef("added new cron job, now running %v detached cron jobs", len(p.detachedCronJobs))
 	return p.recordJob(job)
 }
 

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -302,7 +302,7 @@ func (p *Pool) watchJobs() {
 		if p.GetStatus() == PoolStatusRunning.String() {
 			// The pool is running, wait for any signal that a job went down
 			<-p.stopJobsChan
-			log.Debugf("Job with id %v failed, stop all jobs", p.failedJob)
+			log.Debugf("Job %s (%v) failed, stop all jobs", p.cronJobs[p.failedJob].GetName(), p.failedJob)
 			p.stopAll()
 		} else {
 			if p.failedJob != "" {

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -29,11 +29,6 @@ type Pool struct {
 }
 
 func newPool() *Pool {
-	interval := defaultRetryInterval
-	if GetStatusConfig() != nil {
-		interval = GetStatusConfig().GetHealthCheckInterval()
-	}
-
 	newPool := Pool{
 		jobs:             make(map[string]JobExecution),
 		cronJobs:         make(map[string]JobExecution),
@@ -41,7 +36,7 @@ func newPool() *Pool {
 		failedJob:        "",
 		failJobChan:      make(chan string),
 		stopJobsChan:     make(chan bool),
-		backoff:          newBackoffTimeout(interval, 10*time.Minute, 2),
+		backoff:          newBackoffTimeout(defaultRetryInterval, 10*time.Minute, 2),
 	}
 	newPool.SetStatus(PoolStatusInitializing)
 
@@ -51,16 +46,6 @@ func newPool() *Pool {
 	go newPool.watchJobs()
 
 	return &newPool
-}
-
-// SetStatusConfig - Set the status config globally
-func SetStatusConfig(statusCfg corecfg.StatusConfig) {
-	statusConfig = statusCfg
-}
-
-// GetStatusConfig - Set the status config globally
-func GetStatusConfig() corecfg.StatusConfig {
-	return statusConfig
 }
 
 //recordJob - Adds a job to the jobs map

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -52,6 +52,7 @@ func newPool() *Pool {
 func (p *Pool) recordJob(job JobExecution) string {
 	p.jobsMapLock.Lock()
 	defer p.jobsMapLock.Unlock()
+	log.Tracef("registered job %s (%s)", job.GetName(), job.GetID())
 	p.jobs[job.GetID()] = job
 	return job.GetID()
 }
@@ -61,6 +62,7 @@ func (p *Pool) recordCronJob(job JobExecution) string {
 	p.cronJobsMapLock.Lock()
 	defer p.cronJobsMapLock.Unlock()
 	p.cronJobs[job.GetID()] = job
+	log.Tracef("added new cron job, now running %s cron jobs", len(p.cronJobs))
 	return p.recordJob(job)
 }
 
@@ -69,6 +71,7 @@ func (p *Pool) recordDetachedCronJob(job JobExecution) string {
 	p.detachedCronJobsMapLock.Lock()
 	defer p.detachedCronJobsMapLock.Unlock()
 	p.detachedCronJobs[job.GetID()] = job
+	log.Tracef("added new cron job, now running %s detached cron jobs", len(p.detachedCronJobs))
 	return p.recordJob(job)
 }
 

--- a/pkg/jobs/pool_test.go
+++ b/pkg/jobs/pool_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestPoolCoordination(t *testing.T) {
 	testPool := newPool() // create a new pool for this test to not interfere with other tests
+	testPool.backoff = newBackoffTimeout(time.Millisecond, time.Millisecond, 1)
 	testPool.retryInterval = time.Second
 	failJob := &intervalJobImpl{
 		name:      "FailedIntervalJob",
@@ -72,7 +73,7 @@ func TestPoolCoordination(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	time.Sleep(time.Second) // give enough time for scheduled job to run at least once more
+	time.Sleep(2 * time.Second) // give enough time for scheduled job to run at least once more
 
 	assert.GreaterOrEqual(t, sJob.executions, 1, "The scheduled job did not run at least once after failure")
 	assert.GreaterOrEqual(t, iJob.executions, 1, "The interval job did not run at least once after failure")

--- a/pkg/jobs/retryjob.go
+++ b/pkg/jobs/retryjob.go
@@ -16,14 +16,7 @@ type retryJob struct {
 //newBaseJob - creates a single run job and sets up the structure for different job types
 func newRetryJob(newJob Job, retries int, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := retryJob{
-		baseJob{
-			id:       newUUID(),
-			name:     name,
-			job:      newJob,
-			jobType:  JobTypeRetry,
-			status:   JobStatusInitializing,
-			failChan: failJobChan,
-		},
+		createBaseJob(newJob, failJobChan, name, JobTypeRetry),
 		retryJobProps{
 			retries: retries,
 		},

--- a/pkg/jobs/retryjob_test.go
+++ b/pkg/jobs/retryjob_test.go
@@ -42,6 +42,7 @@ func TestRetryJob(t *testing.T) {
 	}
 
 	jobID, _ := RegisterRetryJob(job, 3)
+	globalPool.jobs[jobID].(*retryJob).backoff = newBackoffTimeout(time.Millisecond, time.Millisecond, 1)
 
 	time.Sleep(10 * time.Millisecond)
 	status := GetJobStatus(jobID)

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -74,12 +74,12 @@ func (b *scheduleJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *scheduleJob) stop() {
 	b.stopLog()
-	if b.isReady {
+	if b.IsReady() {
 		log.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		log.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}
-	b.isReady = false
+	b.UnsetIsReady()
 }

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorhill/cronexpr"
 
 	"github.com/Axway/agent-sdk/pkg/util/errors"
+	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
 type scheduleJobProps struct {
@@ -80,5 +81,7 @@ func (b *scheduleJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *scheduleJob) stop() {
 	b.stopLog()
+	log.Tracef("writing to %s stop channel", b.GetName())
 	b.stopChan <- true
+	log.Tracef("wrote to %s stop channel", b.GetName())
 }

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -74,7 +74,12 @@ func (b *scheduleJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *scheduleJob) stop() {
 	b.stopLog()
-	log.Tracef("writing to %s stop channel", b.GetName())
-	b.stopChan <- true
-	log.Tracef("wrote to %s stop channel", b.GetName())
+	if b.isReady {
+		log.Tracef("writing to %s stop channel", b.GetName())
+		b.stopChan <- true
+		log.Tracef("wrote to %s stop channel", b.GetName())
+	} else {
+		b.stopReadyChan <- nil
+	}
+	b.isReady = false
 }

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -28,14 +28,7 @@ func newScheduledJob(newJob Job, schedule, name string, failJobChan chan string)
 	}
 
 	thisJob := scheduleJob{
-		baseJob{
-			id:       newUUID(),
-			name:     name,
-			job:      newJob,
-			jobType:  JobTypeScheduled,
-			status:   JobStatusInitializing,
-			failChan: failJobChan,
-		},
+		createBaseJob(newJob, failJobChan, name, JobTypeScheduled),
 		scheduleJobProps{
 			cronExp:  exp,
 			schedule: schedule,


### PR DESCRIPTION
- added a channel job type, only excepts a stop channel
- added a timeout for a job execution, still needs a configuration for this
- fixed issue of creating status update jobs when no agent name provided
- added backoff timer for calling the job ready function 
- attribute on job to know when it is ready
- on stop call kill the ready loop or the running loop
- only initialize one version checker job