### PR TITLE
APIGOV-21244 - updates for spec parsing and subscription notifications

### DIFF
--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -115,6 +115,9 @@ func (c *ServiceClient) buildUnstructuredDataProperties(serviceBody *ServiceBody
 }
 
 func (c *ServiceClient) enableSubscription(serviceBody *ServiceBody) bool {
+	if len(serviceBody.authPolicies) > 0 {
+		serviceBody.AuthPolicy = serviceBody.authPolicies[0] // use the first auth policy
+	}
 	enableSubscription := serviceBody.AuthPolicy != Passthrough
 	// if there isn't a registered subscription schema, do not enable subscriptions,
 	// or if the status is not PUBLISHED, do not enable subscriptions

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -306,7 +306,7 @@ func (c *ServiceClient) getConsumerInstancesByExternalAPIID(externalAPIID string
 	log.Tracef("Get consumer instance by external api id: %s", externalAPIID)
 
 	params := map[string]string{
-		"query": fmt.Sprintf("attributes."+AttrExternalAPIID+"==%s", externalAPIID),
+		"query": fmt.Sprintf("attributes."+AttrExternalAPIID+"==\"%s\"", externalAPIID),
 	}
 	request := coreapi.Request{
 		Method:      coreapi.GET,

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -90,42 +90,6 @@ type EndpointDefinition struct {
 	BasePath string
 }
 
-//ServiceBody -
-type ServiceBody struct {
-	NameToPush         string `json:",omitempty"`
-	APIName            string `json:",omitempty"`
-	RestAPIID          string `json:",omitempty"`
-	PrimaryKey         string `json:",omitempty"`
-	URL                string `json:",omitempty"`
-	Stage              string `json:",omitempty"`
-	StageDescriptor    string `json:",omitempty"`
-	Description        string `json:",omitempty"`
-	Version            string `json:",omitempty"`
-	AuthPolicy         string `json:",omitempty"`
-	SpecDefinition     []byte `json:",omitempty"`
-	Documentation      []byte `json:",omitempty"`
-	Tags               map[string]interface{}
-	AgentMode          corecfg.AgentMode `json:",omitempty"`
-	Image              string
-	ImageContentType   string
-	CreatedBy          string
-	ResourceType       string
-	AltRevisionPrefix  string
-	SubscriptionName   string
-	APIUpdateSeverity  string `json:",omitempty"`
-	State              string
-	Status             string
-	ServiceAttributes  map[string]string
-	RevisionAttributes map[string]string
-	InstanceAttributes map[string]string
-	serviceContext     serviceContext
-	Endpoints          []EndpointDefinition
-	UnstructuredProps  *UnstructuredProperties
-	TeamName           string
-	categoryTitles     []string //Titles will be set via the service body builder
-	categoryNames      []string //Names will be determined based the Title
-}
-
 // APIError - api response error
 type APIError struct {
 	Status int    `json:"status,omitempty"`

--- a/pkg/apic/service_test.go
+++ b/pkg/apic/service_test.go
@@ -10,33 +10,27 @@ import (
 
 var methods = [5]string{"get", "post", "put", "patch", "delete"} // RestAPI methods
 
-const (
-	apikey      = "verify-api-key"
-	passthrough = "pass-through"
-	oauth       = "verify-oauth-token"
-)
-
 func determineAuthPolicyFromSwagger(swagger *[]byte) string {
 	// Traverse the swagger looking for any route that has security set
 	// return the security of the first route, if none- found return passthrough
-	var authPolicy = passthrough
+	var authPolicy = Passthrough
 
 	gjson.GetBytes(*swagger, "paths").ForEach(func(_, pathObj gjson.Result) bool {
 		for _, method := range methods {
 			if pathObj.Get(fmt.Sprint(method, ".security.#.api_key")).Exists() {
-				authPolicy = apikey
+				authPolicy = Apikey
 				return false
 			}
 			if pathObj.Get(fmt.Sprint(method, ".securityDefinitions.OAuthImplicit")).Exists() {
-				authPolicy = oauth
+				authPolicy = Oauth
 				return false
 			}
 		}
-		return authPolicy == passthrough // Return from path loop anonymous func, true = go to next item
+		return authPolicy == Passthrough // Return from path loop anonymous func, true = go to next item
 	})
 
 	if gjson.GetBytes(*swagger, "securityDefinitions.OAuthImplicit").Exists() {
-		authPolicy = oauth
+		authPolicy = Oauth
 	}
 
 	return authPolicy

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -4,6 +4,7 @@ import (
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 )
 
+//APIKeyInfo -
 type APIKeyInfo struct {
 	Name     string
 	Location string

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -1,0 +1,58 @@
+package apic
+
+import (
+	corecfg "github.com/Axway/agent-sdk/pkg/config"
+)
+
+type APIKeyInfo struct {
+	Name     string
+	Location string
+}
+
+//ServiceBody -
+type ServiceBody struct {
+	NameToPush         string
+	APIName            string
+	RestAPIID          string
+	PrimaryKey         string
+	URL                string
+	Stage              string
+	StageDescriptor    string
+	Description        string
+	Version            string
+	AuthPolicy         string
+	authPolicies       []string
+	apiKeyInfo         []APIKeyInfo
+	SpecDefinition     []byte
+	Documentation      []byte
+	Tags               map[string]interface{}
+	AgentMode          corecfg.AgentMode
+	Image              string
+	ImageContentType   string
+	CreatedBy          string
+	ResourceType       string
+	AltRevisionPrefix  string
+	SubscriptionName   string
+	APIUpdateSeverity  string
+	State              string
+	Status             string
+	ServiceAttributes  map[string]string
+	RevisionAttributes map[string]string
+	InstanceAttributes map[string]string
+	serviceContext     serviceContext
+	Endpoints          []EndpointDefinition
+	UnstructuredProps  *UnstructuredProperties
+	TeamName           string
+	categoryTitles     []string //Titles will be set via the service body builder
+	categoryNames      []string //Names will be determined based the Title
+}
+
+//GetAuthPolicies - returns the array of all auth policies in the ServiceBody
+func (s *ServiceBody) GetAuthPolicies() []string {
+	return s.authPolicies
+}
+
+//GetAPIKeyInfo - returns the array of locations and argument names for the api key
+func (s *ServiceBody) GetAPIKeyInfo() []APIKeyInfo {
+	return s.apiKeyInfo
+}

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -60,6 +60,7 @@ func NewServiceBodyBuilder() ServiceBuilder {
 	return &serviceBodyBuilder{
 		serviceBody: ServiceBody{
 			AuthPolicy:         Passthrough,
+			authPolicies:       make([]string, 0),
 			CreatedBy:          config.AgentTypeName,
 			State:              PublishedStatus,
 			Status:             PublishedStatus,
@@ -266,5 +267,17 @@ func (b *serviceBodyBuilder) Build() (ServiceBody, error) {
 		}
 		b.serviceBody.Endpoints = endPoints
 	}
+
+	var i interface{} = specProcessor
+	if val, ok := i.(oasSpecProcessor); ok {
+		// get the auth policy from the spec
+		b.serviceBody.authPolicies, b.serviceBody.apiKeyInfo = val.getAuthInfo()
+
+		// use the first auth policy in the list as the AuthPolicy for determining if subscriptions are enabled
+		if len(b.serviceBody.authPolicies) > 0 {
+			b.serviceBody.AuthPolicy = b.serviceBody.authPolicies[0]
+		}
+	}
+
 	return b.serviceBody, nil
 }

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -11,8 +11,8 @@ import (
 var validOA2Schemes = map[string]bool{"http": true, "https": true, "ws": true, "wss": true}
 
 const (
-	apiKey = "apiKey"
-	oauth  = "oauth2"
+	oasSecurityAPIKey = "apiKey"
+	oasSecurityOauth  = "oauth2"
 )
 
 // oas2SpecProcessor parses and validates an OAS2 spec, and exposes methods to modify the content of the spec.
@@ -68,13 +68,13 @@ func (p *oas2SpecProcessor) getAuthInfo() ([]string, []APIKeyInfo) {
 	keyInfo := []APIKeyInfo{}
 	for _, scheme := range p.spec.SecurityDefinitions {
 		switch scheme.Type {
-		case apiKey:
+		case oasSecurityAPIKey:
 			authPolicies = append(authPolicies, Apikey)
 			keyInfo = append(keyInfo, APIKeyInfo{
 				Location: scheme.In,
 				Name:     scheme.Name,
 			})
-		case oauth:
+		case oasSecurityOauth:
 			authPolicies = append(authPolicies, Oauth)
 		}
 	}

--- a/pkg/apic/specoas2processor.go
+++ b/pkg/apic/specoas2processor.go
@@ -10,6 +10,11 @@ import (
 
 var validOA2Schemes = map[string]bool{"http": true, "https": true, "ws": true, "wss": true}
 
+const (
+	apiKey = "apiKey"
+	oauth  = "oauth2"
+)
+
 // oas2SpecProcessor parses and validates an OAS2 spec, and exposes methods to modify the content of the spec.
 type oas2SpecProcessor struct {
 	spec *oas2Swagger
@@ -56,6 +61,24 @@ func (p *oas2SpecProcessor) getEndpoints() ([]EndpointDefinition, error) {
 		endPoints = append(endPoints, endPoint)
 	}
 	return endPoints, nil
+}
+
+func (p *oas2SpecProcessor) getAuthInfo() ([]string, []APIKeyInfo) {
+	authPolicies := []string{}
+	keyInfo := []APIKeyInfo{}
+	for _, scheme := range p.spec.SecurityDefinitions {
+		switch scheme.Type {
+		case apiKey:
+			authPolicies = append(authPolicies, Apikey)
+			keyInfo = append(keyInfo, APIKeyInfo{
+				Location: scheme.In,
+				Name:     scheme.Name,
+			})
+		case oauth:
+			authPolicies = append(authPolicies, Oauth)
+		}
+	}
+	return authPolicies, keyInfo
 }
 
 func createEndpointDefinition(scheme, host string, port int, basePath string) EndpointDefinition {

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -147,13 +147,13 @@ func (p *oas3SpecProcessor) getAuthPolicies() ([]string, []APIKeyInfo) {
 	keyInfo := []APIKeyInfo{}
 	for _, scheme := range p.spec.Components.SecuritySchemes {
 		switch scheme.Value.Type {
-		case apiKey:
+		case oasSecurityApiKey:
 			authPolicies = append(authPolicies, Apikey)
 			keyInfo = append(keyInfo, APIKeyInfo{
 				Location: scheme.Value.In,
 				Name:     scheme.Value.Name,
 			})
-		case oauth:
+		case oasSecurityOauth:
 			authPolicies = append(authPolicies, Oauth)
 		}
 	}

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -147,7 +147,7 @@ func (p *oas3SpecProcessor) getAuthPolicies() ([]string, []APIKeyInfo) {
 	keyInfo := []APIKeyInfo{}
 	for _, scheme := range p.spec.Components.SecuritySchemes {
 		switch scheme.Value.Type {
-		case oasSecurityApiKey:
+		case oasSecurityAPIKey:
 			authPolicies = append(authPolicies, Apikey)
 			keyInfo = append(keyInfo, APIKeyInfo{
 				Location: scheme.Value.In,

--- a/pkg/apic/specoas3processor.go
+++ b/pkg/apic/specoas3processor.go
@@ -141,3 +141,21 @@ func (p *oas3SpecProcessor) parseURLsIntoEndpoints(defaultURL string, allURLs []
 
 	return endPoints, nil
 }
+
+func (p *oas3SpecProcessor) getAuthPolicies() ([]string, []APIKeyInfo) {
+	authPolicies := []string{}
+	keyInfo := []APIKeyInfo{}
+	for _, scheme := range p.spec.Components.SecuritySchemes {
+		switch scheme.Value.Type {
+		case apiKey:
+			authPolicies = append(authPolicies, Apikey)
+			keyInfo = append(keyInfo, APIKeyInfo{
+				Location: scheme.Value.In,
+				Name:     scheme.Value.Name,
+			})
+		case oauth:
+			authPolicies = append(authPolicies, Oauth)
+		}
+	}
+	return authPolicies, keyInfo
+}

--- a/pkg/apic/specparser.go
+++ b/pkg/apic/specparser.go
@@ -18,6 +18,10 @@ type specProcessor interface {
 	getResourceType() string
 }
 
+type oasSpecProcessor interface {
+	getAuthInfo() ([]string, []APIKeyInfo)
+}
+
 type specResourceParser struct {
 	resourceSpecType string
 	resourceSpec     []byte

--- a/pkg/notify/subscriptionnotification.go
+++ b/pkg/notify/subscriptionnotification.go
@@ -31,11 +31,12 @@ type SubscriptionNotification struct {
 	Email           string                 `json:"email,omitempty"`
 	Message         string                 `json:"message,omitempty"`
 	Key             string                 `json:"key,omitempty"`
-	KeyHeaderName   string                 `json:"keyHeaderName,omitempty"`
 	ClientID        string                 `json:"clientID,omitempty"`
 	ClientSecret    string                 `json:"clientSecret,omitempty"`
 	AuthTemplate    string                 `json:"authtemplate,omitempty"`
 	IsAPIKey        bool                   `json:"isAPIKey,omitempty"`
+	KeyName         string
+	KeyLocation     string
 	apiClient       coreapi.Client
 }
 
@@ -65,9 +66,16 @@ func (s *SubscriptionNotification) SetCatalogItemInfo(catalogID, catalogName, ca
 }
 
 // SetAPIKeyInfo - Set the key and header
-func (s *SubscriptionNotification) SetAPIKeyInfo(key, keyHeaderName string) {
+func (s *SubscriptionNotification) SetAPIKeyInfo(key, keyName string) {
 	s.Key = key
-	s.KeyHeaderName = keyHeaderName
+	s.KeyName = keyName
+}
+
+// SetAPIKeyInfoAndLocation - Set the key, name, and location
+func (s *SubscriptionNotification) SetAPIKeyInfoAndLocation(key, keyName, keyLocation string) {
+	s.Key = key
+	s.KeyName = keyName
+	s.KeyLocation = keyLocation
 }
 
 // SetOauthInfo - Set the id and secret info
@@ -216,7 +224,9 @@ func (s *SubscriptionNotification) BuildSMTPMessage(template *corecfg.EmailTempl
 		Email:           s.Email,
 		Message:         s.Message,
 		Key:             s.Key,
-		KeyHeaderName:   s.KeyHeaderName,
+		KeyHeaderName:   s.KeyName,
+		KeyName:         s.KeyName,
+		KeyLocation:     s.KeyLocation,
 		ClientID:        s.ClientID,
 		ClientSecret:    s.ClientSecret,
 		AuthTemplate:    s.AuthTemplate,

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -38,17 +38,19 @@ var subNotifTemplateMap = map[string]string{
 
 // EmailNotificationTemplate - (go) template for email notification
 type EmailNotificationTemplate struct {
-	CatalogItemID   string `json:"catalogItemId"`
-	CatalogItemURL  string `json:"catalogItemUrl"`
-	CatalogItemName string `json:"catalogItemName"`
-	Email           string `json:"email,omitempty"`
-	Message         string `json:"message,omitempty"`
-	Key             string `json:"key,omitempty"`
-	KeyHeaderName   string `json:"keyHeaderName,omitempty"`
-	ClientID        string `json:"clientID,omitempty"`
-	ClientSecret    string `json:"clientSecret,omitempty"`
-	AuthTemplate    string `json:"authtemplate,omitempty"`
-	IsAPIKey        bool   `json:"isAPIKey,omitempty"`
+	CatalogItemID   string
+	CatalogItemURL  string
+	CatalogItemName string
+	Email           string
+	Message         string
+	Key             string
+	KeyHeaderName   string
+	KeyName         string
+	KeyLocation     string
+	ClientID        string
+	ClientSecret    string
+	AuthTemplate    string
+	IsAPIKey        bool
 }
 
 // ValidateSubscriptionConfigOnStartup - validate body and auth template tags during startup (config)

--- a/pkg/notify/template/emailtemplate.go
+++ b/pkg/notify/template/emailtemplate.go
@@ -38,19 +38,19 @@ var subNotifTemplateMap = map[string]string{
 
 // EmailNotificationTemplate - (go) template for email notification
 type EmailNotificationTemplate struct {
-	CatalogItemID   string
-	CatalogItemURL  string
-	CatalogItemName string
-	Email           string
-	Message         string
-	Key             string
-	KeyHeaderName   string
-	KeyName         string
-	KeyLocation     string
-	ClientID        string
-	ClientSecret    string
-	AuthTemplate    string
-	IsAPIKey        bool
+	CatalogItemID   string `json:"catalogItemId"`
+	CatalogItemURL  string `json:"catalogItemUrl"`
+	CatalogItemName string `json:"catalogItemName"`
+	Email           string `json:"email,omitempty"`
+	Message         string `json:"message,omitempty"`
+	Key             string `json:"key,omitempty"`
+	KeyHeaderName   string `json:"keyHeaderName,omitempty"`
+	KeyName         string `json:"keyName,omitempty"`
+	KeyLocation     string `json:"keyLocation,omitempty"`
+	ClientID        string `json:"clientID,omitempty"`
+	ClientSecret    string `json:"clientSecret,omitempty"`
+	AuthTemplate    string `json:"authtemplate,omitempty"`
+	IsAPIKey        bool   `json:"isAPIKey,omitempty"`
 }
 
 // ValidateSubscriptionConfigOnStartup - validate body and auth template tags during startup (config)


### PR DESCRIPTION
- add auth policy and key info parsing to oas2 and oas3 spec parser
- add key location for api key auth in notification message
- add getters to retrieve the auth info or key info from the service body