### PR TITLE
APIGOV-21298 - Proxy support for gRPC watch and harvester connections

### DIFF
--- a/build/scripts/sonar.sh
+++ b/build/scripts/sonar.sh
@@ -15,7 +15,7 @@ sonar-scanner -X \
     -Dsonar.projectBaseDir=${WORKSPACE} \
     -Dsonar.sources=. \
     -Dsonar.tests=. \
-	-Dsonar.exclusions=**/mock/**,**/testdata/**,**/apiserver/clients/**,**/apiserver/models/**,**/api/v1/**,**/mock*.go,**/*.json,**/definitions.go,**/errors.go,**/error.go,**/proto/** \
+	-Dsonar.exclusions=**/mock/**,**/testdata/**,**/apiserver/clients/**,**/apiserver/models/**,**/api/v1/**,**/mock*.go,**/*.json,**/definitions.go,**/errors.go,**/error.go,**/proto/**,**/samples/** \
     -Dsonar.test.inclusions=**/*test*.go \
     -Dsonar.go.tests.reportPaths=goreport.json \
     -Dsonar.go.coverage.reportPaths=gocoverage.out \

--- a/errors.md
+++ b/errors.md
@@ -10,6 +10,8 @@
 | 1002 | timeout error checking for dependencies to respond, possibly network or settings                            | pkg/util/errors/ErrTimeoutServicesNotReady          |
 | 1003 | periodic health checker or status updater failed.  Services are not ready                                   | pkg/util/ErrPeriodicCheck                           |
 | 1004 | error starting periodic or immediate status update                                                          | pkg/util/ErrStartingAgentStatusUpdate               |
+| 1005 | error indicating failure in version check for upgrade                                                       | pkg/util/ErrStartingVersionChecker                  |
+| 1006 | error indicating failure to connect to Amplify Central over gRPC                                            | pkg/util/ErrGrpcConnection                          |
 |      | 1100-1299 - for apic package errors                                                                         |                                                     |
 | 1100 | general configuration error in CENTRAL                                                                      | pkg/apic/ErrCentralConfig                           |
 | 1101 | error attempting to query for ENVIRONMENT, check CENTRAL_ENVIRONMENT                                        | pkg/apic/ErrEnvironmentQuery                        |

--- a/pkg/agent/resource/manager.go
+++ b/pkg/agent/resource/manager.go
@@ -141,10 +141,8 @@ func applyResConfigToCentralConfig(cfg *config.CentralConfiguration, resCfgAddit
 func (a *agentResourceManager) onResourceChange() {
 	isChanged := (a.prevAgentResHash != 0)
 	agentResHash, _ := util.ComputeHash(a.agentResource)
-	if a.prevAgentResHash != 0 {
-		if a.prevAgentResHash == agentResHash {
-			isChanged = false
-		}
+	if a.prevAgentResHash != 0 && a.prevAgentResHash == agentResHash {
+		isChanged = false
 	}
 	a.prevAgentResHash = agentResHash
 	if isChanged {

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -95,7 +95,6 @@ func NewStreamer(
 ) (Streamer, error) {
 	apiServerHost := cfg.GetURL() + "/apis"
 	tenant := cfg.GetTenantID()
-	isInsecure := cfg.GetTLSConfig().IsInsecureSkipVerify()
 
 	rc := NewResourceClient(
 		apiServerHost,
@@ -128,10 +127,8 @@ func NewStreamer(
 	watchOpts := []wm.Option{
 		wm.WithLogger(logrus.NewEntry(log.Get())),
 		wm.WithSyncEvents(getAgentSequenceManager(wt.Name)),
-	}
-
-	if isInsecure {
-		watchOpts = append(watchOpts, wm.WithTLSConfig(nil))
+		wm.WithTLSConfig(cfg.GetTLSConfig().BuildTLSConfig()),
+		wm.WithProxy(cfg.GetProxyURL()),
 	}
 
 	return &streamer{

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -81,24 +81,47 @@ func NewClient(cfg config.TLSConfig, proxyURL string) Client {
 }
 
 // NewClientWithTimeout - creates a new HTTP client, with a timeout
-func NewClientWithTimeout(cfg config.TLSConfig, proxyURL string, timeout time.Duration) Client {
-	httpCli := http.DefaultClient
-	if cfg != nil {
-		url, err := url.Parse(proxyURL)
-		if err != nil {
-			log.Errorf("Error parsing proxyURL from config; creating a non-proxy client: %s", err.Error())
-		}
-		httpCli = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: cfg.BuildTLSConfig(),
-				Proxy:           util.GetProxyURL(url),
-			},
-		}
-	}
+func NewClientWithTimeout(tlsCfg config.TLSConfig, proxyURL string, timeout time.Duration) Client {
+	httpCli := createClient(tlsCfg, parseProxyURL(proxyURL))
 	httpCli.Timeout = timeout
 	return &httpClient{
 		timeout:    timeout,
 		httpClient: httpCli,
+	}
+}
+
+func parseProxyURL(proxyURL string) *url.URL {
+	if proxyURL != "" {
+		pURL, err := url.Parse(proxyURL)
+		if err == nil {
+			return pURL
+		}
+		log.Errorf("Error parsing proxyURL from config; creating a non-proxy client: %s", err.Error())
+	}
+	return nil
+}
+
+func createClient(tlsCfg config.TLSConfig, proxyURL *url.URL) *http.Client {
+	if tlsCfg != nil {
+		return createHTTPSClient(tlsCfg, proxyURL)
+	}
+	return createHTTPClient(proxyURL)
+}
+
+func createHTTPClient(proxyURL *url.URL) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: util.GetProxyURL(proxyURL),
+		},
+	}
+}
+
+func createHTTPSClient(tlsCfg config.TLSConfig, proxyURL *url.URL) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsCfg.BuildTLSConfig(),
+			Proxy:           util.GetProxyURL(proxyURL),
+		},
 	}
 }
 

--- a/pkg/watchmanager/harvesterclient.go
+++ b/pkg/watchmanager/harvesterclient.go
@@ -23,6 +23,7 @@ type harvesterConfig struct {
 	tenantID    string
 	tokenGetter TokenGetter
 	tlsCfg      *tls.Config
+	proxyURL    string
 	pageSize    int
 }
 
@@ -42,10 +43,9 @@ func newHarvesterClient(cfg *harvesterConfig) *harvesterClient {
 	tlsCfg := corecfg.NewTLSConfig().(*corecfg.TLSConfiguration)
 	tlsCfg.LoadFrom(cfg.tlsCfg)
 	return &harvesterClient{
-		url: cfg.protocol + "://" + cfg.host + ":" + strconv.Itoa(int(cfg.port)) + "/events",
-		cfg: cfg,
-		// TODO - connection via proxy
-		client: api.NewClient(tlsCfg, ""),
+		url:    cfg.protocol + "://" + cfg.host + ":" + strconv.Itoa(int(cfg.port)) + "/events",
+		cfg:    cfg,
+		client: api.NewClient(tlsCfg, cfg.proxyURL),
 	}
 }
 

--- a/pkg/watchmanager/proxy.go
+++ b/pkg/watchmanager/proxy.go
@@ -1,0 +1,81 @@
+package watchmanager
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+type proxyDialer interface {
+	dial(ctx context.Context, addr string) (net.Conn, error)
+}
+
+type grpcProxyDialer struct {
+	proxyAddress string
+	userName     string
+	password     string
+}
+
+func newGRPCProxyDialer(proxyURL *url.URL) proxyDialer {
+	dialer := &grpcProxyDialer{
+		proxyAddress: proxyURL.Host,
+	}
+
+	if user := proxyURL.User; user != nil {
+		dialer.userName = user.Username()
+		dialer.password, _ = user.Password()
+	}
+	return dialer
+}
+
+func (g *grpcProxyDialer) dial(ctx context.Context, addr string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", g.proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	err = g.proxyConnect(ctx, conn, addr)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func (g *grpcProxyDialer) proxyConnect(ctx context.Context, conn net.Conn, targetAddr string) error {
+	req := g.createConnectRequest(ctx, targetAddr)
+	if err := req.Write(conn); err != nil {
+		return err
+	}
+
+	r := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(r, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to connect proxy, status : %s", resp.Status)
+	}
+	return nil
+}
+
+func (g *grpcProxyDialer) createConnectRequest(ctx context.Context, targetAddress string) *http.Request {
+	req := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Host: targetAddress},
+	}
+
+	if g.userName != "" {
+		token := base64.StdEncoding.EncodeToString([]byte(g.userName + ":" + g.password))
+		req.Header = map[string][]string{
+			"Proxy-Authorization": {"Basic " + token},
+		}
+	}
+	return req.WithContext(ctx)
+}

--- a/pkg/watchmanager/proxy_test.go
+++ b/pkg/watchmanager/proxy_test.go
@@ -1,0 +1,61 @@
+package watchmanager
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProxyServer struct {
+	responseStatus int
+	proxyAuth      []string
+	server         *httptest.Server
+}
+
+func (m *mockProxyServer) handleReq(resp http.ResponseWriter, req *http.Request) {
+	m.proxyAuth = req.Header["Proxy-Authorization"]
+	resp.WriteHeader(m.responseStatus)
+}
+
+func newMockProxyServer() *mockProxyServer {
+	proxyServer := &mockProxyServer{}
+	proxyServer.server = httptest.NewServer(http.HandlerFunc(proxyServer.handleReq))
+	return proxyServer
+}
+
+func TestProxyDial(t *testing.T) {
+	proxyURL, _ := url.Parse("http://localhost:8888")
+	grpcProxyDialer := newGRPCProxyDialer(proxyURL)
+	conn, err := grpcProxyDialer.dial(context.Background(), "testtarget")
+	assert.Nil(t, conn)
+	assert.NotNil(t, err)
+
+	proxyServer := newMockProxyServer()
+	proxyURL, _ = url.Parse(proxyServer.server.URL)
+	grpcProxyDialer = newGRPCProxyDialer(proxyURL)
+	proxyServer.responseStatus = 200
+	conn, err = grpcProxyDialer.dial(context.Background(), "testtarget")
+	assert.NotNil(t, conn)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyServer.proxyAuth)
+
+	proxyServer.responseStatus = 407
+	conn, err = grpcProxyDialer.dial(context.Background(), "testtarget")
+	assert.Nil(t, conn)
+	assert.NotNil(t, err)
+	assert.Nil(t, proxyServer.proxyAuth)
+
+	proxyServer.responseStatus = 200
+	proxyAuthURL, _ := url.Parse("http://foo:bar@" + proxyURL.Host)
+	grpcProxyDialer = newGRPCProxyDialer(proxyAuthURL)
+	conn, err = grpcProxyDialer.dial(context.Background(), "testtarget")
+	assert.NotNil(t, conn)
+	assert.Nil(t, err)
+	assert.NotNil(t, proxyServer.proxyAuth)
+	assert.Equal(t, proxyServer.proxyAuth[0], "Basic "+base64.StdEncoding.EncodeToString([]byte("foo:bar")))
+}


### PR DESCRIPTION
- Added a custom dialer for gRPC connection to proxy.
- The dialer uses the configured proxy URL to establishes the connection and send CONNECT request to proxy
- Includes a fix to use insecure TLS connection to watch controller
- Includes a fix in API client to use proxy with no TLS configg