### PR TITLE
APIGOV-21351 - Support for registering event handlers

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -61,12 +61,12 @@ type agentData struct {
 	deleteServiceValidator     DeleteServiceValidator
 	configChangeHandler        ConfigChangeHandler
 	agentResourceChangeHandler ConfigChangeHandler
-	proxyResourceHandler       handler.ProxyHandler
+	proxyResourceHandler       *handler.StreamWatchProxyHandler
 	isInitialized              bool
 }
 
 var agent = agentData{
-	proxyResourceHandler: handler.NewProxyHandler(),
+	proxyResourceHandler: handler.NewStreamWatchProxyHandler(),
 }
 
 // Initialize - Initializes the agent
@@ -357,13 +357,12 @@ func startDiscoveryCache(instanceCacheLock *sync.Mutex) {
 }
 
 func startStreamMode(agent agentData) error {
-	proxyHandler := agent.proxyResourceHandler.(handler.Handler)
 	handlers := []handler.Handler{
 		handler.NewAPISvcHandler(agent.apiMap),
 		handler.NewInstanceHandler(agent.instanceMap),
 		handler.NewCategoryHandler(agent.categoryMap),
 		handler.NewAgentResourceHandler(agent.agentResourceManager),
-		proxyHandler,
+		agent.proxyResourceHandler,
 	}
 
 	cs, err := stream.NewStreamer(

--- a/pkg/agent/handler/handlers.go
+++ b/pkg/agent/handler/handlers.go
@@ -21,7 +21,7 @@ const (
 
 // Handler interface used by the EventListener to process events.
 type Handler interface {
-	// Handle receives the type of the event (add, update, delete), and the ResourceClient on API Server, if it exists.
+	// Handle receives the type of the event (add, update, delete), and the API Server resource, if it exists.
 	Handle(action proto.Event_Type, resource *v1.ResourceInstance) error
 }
 
@@ -148,7 +148,7 @@ func (h *agentResourceHandler) Handle(action proto.Event_Type, resource *v1.Reso
 type ProxyHandler interface {
 	// RegisterTargetHandler adds the target handler
 	RegisterTargetHandler(name string, resourceHandler Handler)
-	// UnRegisterTargetHandler removes the specified handler
+	// UnregisterTargetHandler removes the specified handler
 	UnregisterTargetHandler(name string)
 }
 
@@ -157,21 +157,24 @@ type StreamWatchProxyHandler struct {
 	targetResourceHandlerMap map[string]Handler
 }
 
-// NewProxyHandler - creates a Handler to proxy target resource handler
+// NewStreamWatchProxyHandler - creates a Handler to proxy target resource handler
 func NewStreamWatchProxyHandler() *StreamWatchProxyHandler {
 	return &StreamWatchProxyHandler{
 		targetResourceHandlerMap: make(map[string]Handler),
 	}
 }
 
+// RegisterTargetHandler adds the target handler
 func (h *StreamWatchProxyHandler) RegisterTargetHandler(name string, resourceHandler Handler) {
 	h.targetResourceHandlerMap[name] = resourceHandler
 }
 
+// UnregisterTargetHandler removes the specified handler
 func (h *StreamWatchProxyHandler) UnregisterTargetHandler(name string) {
 	delete(h.targetResourceHandlerMap, name)
 }
 
+// Handle receives the type of the event (add, update, delete) and updated API Server resource
 func (h *StreamWatchProxyHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
 	if h.targetResourceHandlerMap != nil {
 		for _, handler := range h.targetResourceHandlerMap {

--- a/pkg/agent/handler/handlers.go
+++ b/pkg/agent/handler/handlers.go
@@ -152,26 +152,27 @@ type ProxyHandler interface {
 	UnregisterTargetHandler(name string)
 }
 
-type proxyHandler struct {
+// StreamWatchProxyHandler - proxy handler for stream watch
+type StreamWatchProxyHandler struct {
 	targetResourceHandlerMap map[string]Handler
 }
 
 // NewProxyHandler - creates a Handler to proxy target resource handler
-func NewProxyHandler() ProxyHandler {
-	return &proxyHandler{
+func NewStreamWatchProxyHandler() *StreamWatchProxyHandler {
+	return &StreamWatchProxyHandler{
 		targetResourceHandlerMap: make(map[string]Handler),
 	}
 }
 
-func (h *proxyHandler) RegisterTargetHandler(name string, resourceHandler Handler) {
+func (h *StreamWatchProxyHandler) RegisterTargetHandler(name string, resourceHandler Handler) {
 	h.targetResourceHandlerMap[name] = resourceHandler
 }
 
-func (h *proxyHandler) UnregisterTargetHandler(name string) {
+func (h *StreamWatchProxyHandler) UnregisterTargetHandler(name string) {
 	delete(h.targetResourceHandlerMap, name)
 }
 
-func (h *proxyHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (h *StreamWatchProxyHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
 	if h.targetResourceHandlerMap != nil {
 		for _, handler := range h.targetResourceHandlerMap {
 			err := handler.Handle(action, resource)

--- a/pkg/agent/handler/handlers.go
+++ b/pkg/agent/handler/handlers.go
@@ -21,8 +21,8 @@ const (
 
 // Handler interface used by the EventListener to process events.
 type Handler interface {
-	// Handle receives the type of the event (add, update, delete), and the API Server resource, if it exists.
-	Handle(action proto.Event_Type, resource *v1.ResourceInstance) error
+	// Handle receives the type of the event (add, update, delete), event metadata and the API Server resource, if it exists.
+	Handle(action proto.Event_Type, eventMetadata *proto.EventMeta, resource *v1.ResourceInstance) error
 }
 
 type apiSvcHandler struct {
@@ -36,7 +36,7 @@ func NewAPISvcHandler(cache cache.Cache) Handler {
 	}
 }
 
-func (h *apiSvcHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (h *apiSvcHandler) Handle(action proto.Event_Type, _ *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if resource.Kind != apiService {
 		return nil
 	}
@@ -74,7 +74,7 @@ func NewInstanceHandler(cache cache.Cache) Handler {
 	}
 }
 
-func (h *instanceHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (h *instanceHandler) Handle(action proto.Event_Type, _ *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if resource.Kind != apiServiceInstance {
 		return nil
 	}
@@ -102,7 +102,7 @@ func NewCategoryHandler(cache cache.Cache) Handler {
 	}
 }
 
-func (c *categoryHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (c *categoryHandler) Handle(action proto.Event_Type, _ *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if resource.Kind != category {
 		return nil
 	}
@@ -129,7 +129,7 @@ func NewAgentResourceHandler(agentResourceManager resource.Manager) Handler {
 	}
 }
 
-func (h *agentResourceHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (h *agentResourceHandler) Handle(action proto.Event_Type, _ *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if h.agentResourceManager != nil && action == proto.Event_UPDATED {
 		kind := resource.Kind
 		switch kind {
@@ -174,11 +174,11 @@ func (h *StreamWatchProxyHandler) UnregisterTargetHandler(name string) {
 	delete(h.targetResourceHandlerMap, name)
 }
 
-// Handle receives the type of the event (add, update, delete) and updated API Server resource
-func (h *StreamWatchProxyHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+// Handle receives the type of the event (add, update, delete), event metadata and updated API Server resource
+func (h *StreamWatchProxyHandler) Handle(action proto.Event_Type, eventMetadata *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if h.targetResourceHandlerMap != nil {
 		for _, handler := range h.targetResourceHandlerMap {
-			err := handler.Handle(action, resource)
+			err := handler.Handle(action, eventMetadata, resource)
 			if err != nil {
 				return err
 			}

--- a/pkg/agent/handler/handlers_test.go
+++ b/pkg/agent/handler/handlers_test.go
@@ -112,7 +112,7 @@ func TestNewAPISvcHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := NewAPISvcHandler(&cache.MockCache{})
 
-			err := handler.Handle(tc.action, tc.resource)
+			err := handler.Handle(tc.action, nil, tc.resource)
 			if tc.hasError {
 				assert.NotNil(t, err)
 			} else {
@@ -200,7 +200,7 @@ func TestNewCategoryHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := NewCategoryHandler(&cache.MockCache{})
 
-			err := handler.Handle(tc.action, tc.resource)
+			err := handler.Handle(tc.action, nil, tc.resource)
 			if tc.hasError {
 				assert.NotNil(t, err)
 			} else {
@@ -300,7 +300,7 @@ func TestNewInstanceHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := NewInstanceHandler(&cache.MockCache{})
 
-			err := handler.Handle(tc.action, tc.resource)
+			err := handler.Handle(tc.action, nil, tc.resource)
 			if tc.hasError {
 				assert.NotNil(t, err)
 			} else {
@@ -402,7 +402,7 @@ func TestAgentResourceHandler(t *testing.T) {
 
 			handler := NewAgentResourceHandler(resourceManager)
 
-			err := handler.Handle(tc.action, tc.resource)
+			err := handler.Handle(tc.action, nil, tc.resource)
 			if tc.hasError {
 				assert.Nil(t, err)
 				assert.Nil(t, resourceManager.resource)
@@ -421,7 +421,7 @@ type customHandler struct {
 	ri     *v1.ResourceInstance
 }
 
-func (c *customHandler) Handle(action proto.Event_Type, resource *v1.ResourceInstance) error {
+func (c *customHandler) Handle(action proto.Event_Type, eventMetadata *proto.EventMeta, resource *v1.ResourceInstance) error {
 	if c.err != nil {
 		return c.err
 	}
@@ -439,18 +439,18 @@ func TestProxyHandler(t *testing.T) {
 	}
 	handler := &customHandler{}
 	proxy := NewStreamWatchProxyHandler()
-	proxy.Handle(proto.Event_UPDATED, testRes)
+	proxy.Handle(proto.Event_UPDATED, nil, testRes)
 	assert.Nil(t, handler.ri)
 
 	proxy.RegisterTargetHandler("custom", handler)
-	proxy.Handle(proto.Event_UPDATED, testRes)
+	proxy.Handle(proto.Event_UPDATED, nil, testRes)
 	assert.Equal(t, testRes, handler.ri)
 	assert.Equal(t, proto.Event_UPDATED, handler.action)
 	handler.ri = nil
 
 	handler2 := &customHandler{}
 	proxy.RegisterTargetHandler("custom2", handler2)
-	proxy.Handle(proto.Event_UPDATED, testRes)
+	proxy.Handle(proto.Event_UPDATED, nil, testRes)
 	assert.Equal(t, testRes, handler.ri)
 	assert.Equal(t, proto.Event_UPDATED, handler.action)
 	assert.Equal(t, testRes, handler2.ri)
@@ -459,7 +459,7 @@ func TestProxyHandler(t *testing.T) {
 	handler.ri = nil
 	handler2.ri = nil
 	handler.err = errors.New("test")
-	err := proxy.Handle(proto.Event_UPDATED, testRes)
+	err := proxy.Handle(proto.Event_UPDATED, nil, testRes)
 	assert.NotNil(t, err)
 	assert.Equal(t, err, handler.err)
 	assert.Nil(t, handler.ri)
@@ -469,7 +469,7 @@ func TestProxyHandler(t *testing.T) {
 	handler2.ri = nil
 	handler.err = nil
 	proxy.UnregisterTargetHandler("custom2")
-	err = proxy.Handle(proto.Event_UPDATED, testRes)
+	err = proxy.Handle(proto.Event_UPDATED, nil, testRes)
 	assert.Nil(t, err)
 	assert.Nil(t, handler2.ri)
 	assert.Equal(t, testRes, handler.ri)

--- a/pkg/agent/handler/handlers_test.go
+++ b/pkg/agent/handler/handlers_test.go
@@ -438,20 +438,19 @@ func TestProxyHandler(t *testing.T) {
 		},
 	}
 	handler := &customHandler{}
-	proxy := NewProxyHandler()
-	pHandler := proxy.(Handler)
-	pHandler.Handle(proto.Event_UPDATED, testRes)
+	proxy := NewStreamWatchProxyHandler()
+	proxy.Handle(proto.Event_UPDATED, testRes)
 	assert.Nil(t, handler.ri)
 
 	proxy.RegisterTargetHandler("custom", handler)
-	pHandler.Handle(proto.Event_UPDATED, testRes)
+	proxy.Handle(proto.Event_UPDATED, testRes)
 	assert.Equal(t, testRes, handler.ri)
 	assert.Equal(t, proto.Event_UPDATED, handler.action)
 	handler.ri = nil
 
 	handler2 := &customHandler{}
 	proxy.RegisterTargetHandler("custom2", handler2)
-	pHandler.Handle(proto.Event_UPDATED, testRes)
+	proxy.Handle(proto.Event_UPDATED, testRes)
 	assert.Equal(t, testRes, handler.ri)
 	assert.Equal(t, proto.Event_UPDATED, handler.action)
 	assert.Equal(t, testRes, handler2.ri)
@@ -460,7 +459,7 @@ func TestProxyHandler(t *testing.T) {
 	handler.ri = nil
 	handler2.ri = nil
 	handler.err = errors.New("test")
-	err := pHandler.Handle(proto.Event_UPDATED, testRes)
+	err := proxy.Handle(proto.Event_UPDATED, testRes)
 	assert.NotNil(t, err)
 	assert.Equal(t, err, handler.err)
 	assert.Nil(t, handler.ri)
@@ -470,7 +469,7 @@ func TestProxyHandler(t *testing.T) {
 	handler2.ri = nil
 	handler.err = nil
 	proxy.UnregisterTargetHandler("custom2")
-	err = pHandler.Handle(proto.Event_UPDATED, testRes)
+	err = proxy.Handle(proto.Event_UPDATED, testRes)
 	assert.Nil(t, err)
 	assert.Nil(t, handler2.ri)
 	assert.Equal(t, testRes, handler.ri)

--- a/pkg/agent/stream/eventlistener.go
+++ b/pkg/agent/stream/eventlistener.go
@@ -114,15 +114,15 @@ func (em *EventListener) handleEvent(event *proto.Event) error {
 		ri = em.convertEventPayload(event)
 	}
 
-	em.handleResource(event.Type, ri)
+	em.handleResource(event.Type, event.Metadata, ri)
 
 	return nil
 }
 
 // handleResource loops through all the handlers and passes the event to each one for processing.
-func (em *EventListener) handleResource(action proto.Event_Type, resource *apiv1.ResourceInstance) {
+func (em *EventListener) handleResource(action proto.Event_Type, eventMetadata *proto.EventMeta, resource *apiv1.ResourceInstance) {
 	for _, h := range em.handlers {
-		err := h.Handle(action, resource)
+		err := h.Handle(action, eventMetadata, resource)
 		if err != nil {
 			log.Error(err)
 		}

--- a/pkg/agent/stream/eventlistener_test.go
+++ b/pkg/agent/stream/eventlistener_test.go
@@ -207,6 +207,6 @@ type mockHandler struct {
 	err error
 }
 
-func (m *mockHandler) Handle(_ proto.Event_Type, _ *apiv1.ResourceInstance) error {
+func (m *mockHandler) Handle(_ proto.Event_Type, _ *proto.EventMeta, _ *apiv1.ResourceInstance) error {
 	return m.err
 }

--- a/pkg/agent/stream/watchtopic.go
+++ b/pkg/agent/stream/watchtopic.go
@@ -33,7 +33,7 @@ func getOrCreateWatchTopic(name, scope string, rc ResourceClient, agentType conf
 		tmplFunc = NewTraceWatchTopic
 	case config.GovernanceAgent:
 		agentResourceKind = "GovernanceAgent"
-		// TODO
+		tmplFunc = NewGovernanceAgentWatchTopic
 	default:
 		return nil, resource.ErrUnsupportedAgentType
 	}
@@ -221,6 +221,91 @@ func NewTraceWatchTopic() string {
       }
     ],
     "description": "Watch Topic used by a traceability agent for resources in the {{.Scope}} environment."
+  }
+}`
+}
+
+// NewGovernanceAgentWatchTopic creates a WatchTopic template string
+func NewGovernanceAgentWatchTopic() string {
+	return `
+{
+  "group": "management",
+  "apiVersion": "v1alpha1",
+  "kind": "WatchTopic",
+  "name": "{{.Name}}",
+  "title": "{{.Title}}",
+  "spec": {
+    "filters": [
+      {
+        "group": "management",
+        "kind": "{{.AgentResourceKind}}",
+        "name": "*",
+        "scope": {
+          "kind": "Environment",
+          "name": "{{.Scope}}"
+        },
+        "type": [
+          "updated"
+        ]
+      },
+      {
+        "group": "management",
+        "kind": "AmplifyRuntimeConfig",
+        "name": "*",
+        "scope": {
+          "kind": "Environment",
+          "name": "{{.Scope}}"
+        },
+        "type": [
+          "created",
+          "updated",
+          "deleted"
+        ]
+      },
+      {
+        "group": "management",
+        "kind": "AccessRequest",
+        "name": "*",
+        "scope": {
+          "kind": "Environment",
+          "name": "{{.Scope}}"
+        },
+        "type": [
+          "created",
+          "updated",
+          "deleted"
+        ]
+      },
+      {
+        "group": "management",
+        "kind": "APIService",
+        "name": "*",
+        "scope": {
+          "kind": "Environment",
+          "name": "{{.Scope}}"
+        },
+        "type": [
+          "created",
+          "updated",
+          "deleted"
+        ]
+      },
+      {
+        "group": "management",
+        "kind": "APIServiceInstance",
+        "name": "*",
+        "scope": {
+          "kind": "Environment",
+          "name": "{{.Scope}}"
+        },
+        "type": [
+          "created",
+          "updated",
+          "deleted"
+        ]
+      }
+    ],
+    "description": "Watch Topic used by a governance agent for resources in the {{.Scope}} environment."
   }
 }`
 }


### PR DESCRIPTION
- Added methods to allow agent implementation to register/unregister event handlers
- Added Proxy resource handler to invoke registered event handlers. Proxy handler gets registered to event listener during the agent initialization, this allows agent implementation to register event handlers when needed(before agent initialization or while agent is running)
- Updates to pass event metadata to handlers