### PR TITLE
APIGOV-21460 - Updates for healthcheck based on gRPC connection

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -239,6 +239,7 @@ func startAPIServiceCache() {
 	// register the update cache job
 	newDiscoveryCacheJob := newDiscoveryCache(agent.agentResourceManager, false, instanceCacheLock)
 	if !agent.cfg.IsUsingGRPC() {
+		// healthcheck for central in gRPC mode is registered by streamer
 		hc.RegisterHealthcheck(util.AmplifyCentral, "central", agent.apicClient.Healthcheck)
 
 		id, err := jobs.RegisterIntervalJobWithName(newDiscoveryCacheJob, agent.cfg.GetPollInterval(), "New APIs Cache")
@@ -423,9 +424,7 @@ func startStreamMode(agent agentData) error {
 		return fmt.Errorf("could not start the watch manager: %s", err)
 	}
 
-	stopCh := make(chan interface{})
-	streamJob := stream.NewClientStreamJob(cs, stopCh)
-	_, err = jobs.RegisterChannelJobWithName(streamJob, stopCh, "Stream Client")
+	stream.NewClientStreamJob(cs)
 
 	return err
 }

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -61,7 +61,7 @@ func (su *agentStatusUpdate) Execute() error {
 
 	// get the status from the health check and jobs
 	status := su.getCombinedStatus()
-	log.Tracef("Type of agent status update being checked %s : ", su.typeOfStatusUpdate)
+	log.Tracef("Type of agent status update being checked : %s ", su.typeOfStatusUpdate)
 
 	// Check to see if this is the immediate status change
 	// If change of status is coming FROM or TO 'unhealthy', then report this immediately

--- a/pkg/agent/stream/client_test.go
+++ b/pkg/agent/stream/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
+	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	wm "github.com/Axway/agent-sdk/pkg/watchmanager"
 
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
@@ -68,6 +69,10 @@ func TestNewStreamer(t *testing.T) {
 	err = <-errCh
 	assert.Nil(t, err)
 
+	hcStatus := streamer.healthcheck("")
+	assert.NotNil(t, hcStatus)
+	assert.Equal(t, hc.OK, hcStatus.Result)
+
 	streamer.manager = nil
 	streamer.listener = nil
 
@@ -90,12 +95,15 @@ func TestNewStreamer(t *testing.T) {
 	manager.status = false
 
 	assert.NotNil(t, streamer.Status())
+
+	hcStatus = streamer.healthcheck("")
+	assert.NotNil(t, hcStatus)
+	assert.Equal(t, hc.FAIL, hcStatus.Result)
 }
 
 func TestClientStreamJob(t *testing.T) {
 	s := &mockStreamer{}
-	stopCh := make(chan interface{})
-	j := NewClientStreamJob(s, stopCh)
+	j := NewClientStreamJob(s)
 
 	assert.Nil(t, j.Status())
 	assert.True(t, j.Ready())

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -15,6 +15,20 @@ type channelJob struct {
 	channelJobProps
 }
 
+//newDetachedChannelJob - creates an channel job, detached from other cron jobs
+func newDetachedChannelJob(newJob Job, signalStop chan interface{}, name string, failJobChan chan string) (JobExecution, error) {
+	thisJob := channelJob{
+		createBaseJob(newJob, failJobChan, name, JobTypeDetachedChannel),
+		channelJobProps{
+			signalStop: signalStop,
+			stopChan:   make(chan bool),
+		},
+	}
+
+	go thisJob.start()
+	return &thisJob, nil
+}
+
 //newChannelJob - creates a channel run job
 func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJobChan chan string) (JobExecution, error) {
 	thisJob := channelJob{

--- a/pkg/jobs/channeljob_test.go
+++ b/pkg/jobs/channeljob_test.go
@@ -69,3 +69,21 @@ func TestChannelJob(t *testing.T) {
 	UnregisterJob(jobID)
 	time.Sleep(10 * time.Millisecond)
 }
+
+func TestDetachedChannelJob(t *testing.T) {
+	job := &channelJobImpl{
+		name:     "DetachedChannelJob",
+		runTime:  5 * time.Millisecond,
+		ready:    false,
+		stopChan: make(chan interface{}),
+	}
+
+	jobID, _ := RegisterDetachedChannelJob(job, job.stopChan)
+	assert.NotEmpty(t, jobID)
+	j := globalPool.detachedCronJobs[jobID]
+	assert.NotNil(t, j)
+
+	j = globalPool.cronJobs[jobID]
+	assert.Nil(t, j)
+
+}

--- a/pkg/jobs/definitions.go
+++ b/pkg/jobs/definitions.go
@@ -88,6 +88,7 @@ const (
 	JobTypeRetry            = "retry"
 	JobTypeInterval         = "interval"
 	JobTypeChannel          = "channel"
+	JobTypeDetachedChannel  = "detached channel"
 	JobTypeDetachedInterval = "detached interval"
 	JobTypeScheduled        = "scheduled"
 )

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -48,6 +48,16 @@ func RegisterChannelJobWithName(newJob Job, stopChan chan interface{}, name stri
 	return globalPool.RegisterChannelJobWithName(newJob, stopChan, name)
 }
 
+//RegisterDetachedChannelJob -  Runs a job with a stop channel, detached from other jobs in the globalPool
+func RegisterDetachedChannelJob(newJob Job, stopChan chan interface{}) (string, error) {
+	return globalPool.RegisterDetachedChannelJob(newJob, stopChan)
+}
+
+//RegisterDetachedChannelJobWithName - Runs a named job with a stop channel, detached from other jobs in the globalPool
+func RegisterDetachedChannelJobWithName(newJob Job, stopChan chan interface{}, name string) (string, error) {
+	return globalPool.RegisterDetachedChannelJobWithName(newJob, stopChan, name)
+}
+
 //RegisterDetachedIntervalJob - Runs a job with a specific interval between each run in the globalPool, detached from other jobs to always run
 func RegisterDetachedIntervalJob(newJob Job, interval time.Duration) (string, error) {
 	return globalPool.RegisterDetachedIntervalJob(newJob, interval)

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -140,6 +140,20 @@ func (p *Pool) RegisterChannelJobWithName(newJob Job, stopChan chan interface{},
 	return p.recordCronJob(job), nil
 }
 
+//RegisterDetachedChannelJob - Runs a job with a stop channel, detached from other jobs
+func (p *Pool) RegisterDetachedChannelJob(newJob Job, stopChan chan interface{}) (string, error) {
+	return p.RegisterDetachedChannelJobWithName(newJob, stopChan, JobTypeDetachedChannel)
+}
+
+//RegisterDetachedChannelJobWithName - Runs a named job with a stop channel, detached from other jobs
+func (p *Pool) RegisterDetachedChannelJobWithName(newJob Job, stopChan chan interface{}, name string) (string, error) {
+	job, err := newDetachedChannelJob(newJob, stopChan, name, p.failJobChan)
+	if err != nil {
+		return "", err
+	}
+	return p.recordDetachedCronJob(job), nil
+}
+
 //RegisterDetachedIntervalJob - Runs a job with a specific interval between each run, detached from other jobs
 func (p *Pool) RegisterDetachedIntervalJob(newJob Job, interval time.Duration) (string, error) {
 	return p.RegisterDetachedIntervalJobWithName(newJob, interval, JobTypeDetachedInterval)


### PR DESCRIPTION
- In gRPC mode, register central healthcheck based on the gRPC connection
- Updated jobs library to allow registering detachable channel job.
- Includes changes to register streamer client job as detachable channel job to allow recovering from gRPC connection failures. The job gets registered on initialization and on gRPC connection failure attempts to restart the streamer using a backoff interval