### PR TITLE
APIGOV-21493 Retrieve resources from cache instead of making requests for resources by attributes

### DIFF
--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -98,7 +98,7 @@ func (m *mockSvcClient) GetSubscriptionManager() apic.SubscriptionManager { retu
 func (m *mockSvcClient) GetCatalogItemIDForConsumerInstance(instanceID string) (string, error) {
 	return "", nil
 }
-func (m *mockSvcClient) DeleteServiceByAPIID(externalAPIID string) error    { return nil }
+func (m *mockSvcClient) DeleteServiceByName(_ string) error                 { return nil }
 func (m *mockSvcClient) DeleteConsumerInstance(instanceName string) error   { return nil }
 func (m *mockSvcClient) DeleteAPIServiceInstance(instanceName string) error { return nil }
 func (m *mockSvcClient) UpdateConsumerInstanceSubscriptionDefinition(externalAPIID, subscriptionDefinitionName string) error {

--- a/pkg/agent/instancevalidator_test.go
+++ b/pkg/agent/instancevalidator_test.go
@@ -78,11 +78,7 @@ func TestValidatorAPIDoesExistsDeleteService(t *testing.T) {
 	setupCache("12345", "test")
 	setupAPICClient([]api.MockResponse{
 		{
-			FileName: "../apic/testdata/apiservice-list.json", // for call to get the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "../apic/testdata/apiservice-list.json", // for call to get the consumer instances
+			FileName: "../apic/testdata/consumerinstancelist.json", // for call to get the consumer instances
 			RespCode: http.StatusOK,
 		},
 		{

--- a/pkg/agent/resource/manager_test.go
+++ b/pkg/agent/resource/manager_test.go
@@ -85,7 +85,7 @@ func (m *mockSvcClient) GetSubscriptionManager() apic.SubscriptionManager { retu
 func (m *mockSvcClient) GetCatalogItemIDForConsumerInstance(instanceID string) (string, error) {
 	return "", nil
 }
-func (m *mockSvcClient) DeleteServiceByAPIID(externalAPIID string) error    { return nil }
+func (m *mockSvcClient) DeleteServiceByName(_ string) error                 { return nil }
 func (m *mockSvcClient) DeleteConsumerInstance(instanceName string) error   { return nil }
 func (m *mockSvcClient) DeleteAPIServiceInstance(instanceName string) error { return nil }
 func (m *mockSvcClient) UpdateConsumerInstanceSubscriptionDefinition(externalAPIID, subscriptionDefinitionName string) error {

--- a/pkg/agent/teamcache.go
+++ b/pkg/agent/teamcache.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/Axway/agent-sdk/pkg/agent/cache"
+
 	"github.com/Axway/agent-sdk/pkg/apic"
 	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util/log"
@@ -16,6 +18,8 @@ const qaTeamCacheInterval = "QA_CENTRAL_TEAMCACHE_INTERVAL"
 type centralTeamsCache struct {
 	jobs.Job
 	teamChannel chan string
+	cache       cache.Manager
+	client      apic.Client
 }
 
 func (j *centralTeamsCache) Ready() bool {
@@ -27,7 +31,7 @@ func (j *centralTeamsCache) Status() error {
 }
 
 func (j *centralTeamsCache) Execute() error {
-	platformTeams, err := agent.apicClient.GetTeam(map[string]string{})
+	platformTeams, err := j.client.GetTeam(map[string]string{})
 	if err != nil {
 		return err
 	}
@@ -37,23 +41,11 @@ func (j *centralTeamsCache) Execute() error {
 	}
 
 	for _, team := range platformTeams {
-		if id, err := agent.teamMap.Get(team.Name); err != nil || id != team.ID {
-			err = agent.teamMap.Set(team.Name, team.ID)
-			if j.teamChannel != nil {
-				log.Tracef("sending %s (%s) team to acl", team.Name, team.ID)
-				j.teamChannel <- team.ID
-			}
-		}
-		if team.Default {
-			if _, err := agent.teamMap.GetBySecondaryKey(apic.DefaultTeamKey); err != nil {
-				// remove the secondary key from an existing cache item before adding it to a new one
-				agent.teamMap.DeleteSecondaryKey(apic.DefaultTeamKey)
-			}
-
-			agent.teamMap.SetSecondaryKey(team.Name, apic.DefaultTeamKey)
-		}
-		if err != nil {
-			return err
+		savedTeam := j.cache.GetTeamByID(team.ID)
+		if savedTeam == nil {
+			j.cache.AddTeam(&team)
+			log.Tracef("sending %s (%s) team to acl", team.Name, team.ID)
+			j.teamChannel <- team.ID
 		}
 	}
 
@@ -61,16 +53,20 @@ func (j *centralTeamsCache) Execute() error {
 }
 
 // registerTeamMapCacheJob -
-func registerTeamMapCacheJob(teamChannel chan string) {
+func registerTeamMapCacheJob(teamChannel chan string, cache cache.Manager, client apic.Client) {
 	job := &centralTeamsCache{
 		teamChannel: teamChannel,
+		cache:       cache,
+		client:      client,
 	}
-
 	// execute the job on startup to populate the team cache
 	job.Execute()
+	jobs.RegisterIntervalJobWithName(job, getJobInterval(), "Team Cache")
+}
 
+func getJobInterval() time.Duration {
 	interval := time.Hour
-	// chgeck for QA env vars
+	// check for QA env vars
 	if val := os.Getenv(qaTeamCacheInterval); val != "" {
 		if duration, err := time.ParseDuration(val); err == nil {
 			log.Tracef("Using %s (%s) rather than the default (%s) for non-QA", qaTeamCacheInterval, val, time.Hour)
@@ -80,18 +76,5 @@ func registerTeamMapCacheJob(teamChannel chan string) {
 		}
 	}
 
-	jobs.RegisterIntervalJobWithName(job, interval, "Team Cache")
-}
-
-// GetTeamFromCache -
-func GetTeamFromCache(teamName string) (string, bool) {
-	id, found := agent.teamMap.Get(teamName)
-	if teamName == "" {
-		// get the default team
-		id, found = agent.teamMap.GetBySecondaryKey(apic.DefaultTeamKey)
-	}
-	if found != nil {
-		return "", false
-	}
-	return id.(string), true
+	return interval
 }

--- a/pkg/agent/teamcache_test.go
+++ b/pkg/agent/teamcache_test.go
@@ -7,69 +7,127 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Axway/agent-sdk/pkg/agent/cache"
+
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 
-	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTeamCache(t *testing.T) {
-	type queryRes struct {
-		teams     []string
-		numOnChan int
-	}
-
 	testCases := []struct {
-		name       string
-		queries    []queryRes
-		notInCache []string
+		name               string
+		teams              []*definitions.PlatformTeam
+		cached             []*definitions.PlatformTeam
+		expectedTeamsSaved int
 	}{
 		{
-			name: "Teams",
-			queries: []queryRes{
+			name:               "Should save one team to the cache",
+			expectedTeamsSaved: 1,
+			cached:             []*definitions.PlatformTeam{},
+			teams: []*definitions.PlatformTeam{
 				{
-					teams:     []string{"TeamA"},
-					numOnChan: 1,
-				},
-				{
-					teams:     []string{"TeamA", "TeamB", "TeamC"},
-					numOnChan: 2,
-				},
-				{
-					teams:     []string{"TeamA", "TeamB", "TeamC", "TeamD"},
-					numOnChan: 1,
+					Name:    "TeamA",
+					ID:      "1",
+					Default: true,
 				},
 			},
-			notInCache: []string{"TeamE"},
+		},
+		{
+			name:               "Should save two teams to the cache, and skip one team that already exists",
+			expectedTeamsSaved: 2,
+			cached: []*definitions.PlatformTeam{
+				{
+					Name:    "TeamA",
+					ID:      "1",
+					Default: true,
+				},
+			},
+			teams: []*definitions.PlatformTeam{
+				{
+					Name:    "TeamA",
+					ID:      "1",
+					Default: true,
+				},
+				{
+					Name:    "TeamB",
+					ID:      "2",
+					Default: false,
+				},
+				{
+					Name:    "TeamC",
+					ID:      "3",
+					Default: false,
+				},
+			},
+		},
+		{
+			name:               "Should save one team to the cache, and skip 3 that already exist",
+			expectedTeamsSaved: 1,
+			cached: []*definitions.PlatformTeam{
+				{
+					Name:    "TeamA",
+					ID:      "1",
+					Default: true,
+				},
+				{
+					Name:    "TeamB",
+					ID:      "2",
+					Default: false,
+				},
+				{
+					Name:    "TeamC",
+					ID:      "3",
+					Default: false,
+				},
+			},
+			teams: []*definitions.PlatformTeam{
+				{
+					Name:    "TeamA",
+					ID:      "1",
+					Default: true,
+				},
+				{
+					Name:    "TeamB",
+					ID:      "2",
+					Default: false,
+				},
+				{
+					Name:    "TeamC",
+					ID:      "3",
+					Default: false,
+				},
+				{
+					Name:    "TeamD",
+					ID:      "4",
+					Default: false,
+				},
+			},
 		},
 	}
 
 	for _, test := range testCases {
+
 		t.Run(test.name, func(t *testing.T) {
-			request := 0
 			s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 				switch {
 				case strings.Contains(req.RequestURI, "/auth"):
 					token := "{\"access_token\":\"somevalue\",\"expires_in\": 12235677}"
 					resp.Write([]byte(token))
 				case strings.Contains(req.RequestURI, "platformTeams"):
-					// add teams to reply
-					reply := make([]*definitions.PlatformTeam, 0)
-					for i, team := range test.queries[request].teams {
-						reply = append(reply, &definitions.PlatformTeam{
-							ID:      team,
-							Name:    team,
-							Default: i == 0,
-						})
-					}
-					request++
-					data, _ := json.Marshal(reply)
+					data, _ := json.Marshal(test.teams)
 					resp.Write(data)
 				}
 			}))
 			defer s.Close()
 
 			cfg := createCentralCfg(s.URL, "env")
+			caches := cache.NewAgentCacheManager(cfg, false)
+
+			for _, item := range test.cached {
+				caches.AddTeam(item)
+			}
+
 			resetResources()
 			agent.teamMap = nil
 			err := Initialize(cfg)
@@ -78,36 +136,26 @@ func TestTeamCache(t *testing.T) {
 			assert.NotNil(t, agent.apicClient)
 
 			teamChanel := make(chan string)
-			job := centralTeamsCache{teamChannel: teamChanel}
+			job := centralTeamsCache{
+				teamChannel: teamChanel,
+				client:      agent.apicClient,
+				cache:       caches,
+			}
 
-			// receive all the teams
-			allTeams := make([]string, 0)
-			receivedTeams := make([]string, 0)
-			for _, q := range test.queries {
-				allTeams = append(allTeams, q.teams...)
-				go job.Execute()
-				expected := q.numOnChan
-				for expected > 0 {
-					team := <-teamChanel
-					receivedTeams = append(receivedTeams, team)
-					expected--
+			go job.Execute()
+			count := 0
+			for {
+				if count >= test.expectedTeamsSaved {
+					break
+				}
+				select {
+				case team := <-teamChanel:
+					count++
+					assert.NotNil(t, team)
 				}
 			}
-			expectedTeams := util.RemoveDuplicateValuesFromStringSlice(allTeams)
 
-			// test validations
-			assert.ElementsMatch(t, expectedTeams, receivedTeams)
-			defTeam, found := GetTeamFromCache("")
-			assert.True(t, found, "a default team was not in the cache")
-			assert.Equal(t, expectedTeams[0], defTeam)
-			for _, team := range expectedTeams {
-				_, found := GetTeamFromCache(team)
-				assert.True(t, found, "%s team was not in the cache", team)
-			}
-			for _, team := range test.notInCache {
-				_, found := GetTeamFromCache(team)
-				assert.False(t, found, "%s team was in the cache", team)
-			}
+			assert.Equal(t, test.expectedTeamsSaved, count)
 		})
 	}
 }

--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -2,10 +2,7 @@ package apic
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
-
-	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
@@ -72,7 +69,7 @@ func (c *ServiceClient) updateAPIServiceResource(apiSvc *v1alpha1.APIService, se
 	}
 }
 
-//processService -
+// processService -
 func (c *ServiceClient) processService(serviceBody *ServiceBody) (*v1alpha1.APIService, error) {
 	uuid, _ := uuid.NewUUID()
 	serviceName := uuid.String()
@@ -83,7 +80,7 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*v1alpha1.APIS
 	serviceBody.serviceContext.serviceAction = addAPI
 
 	// If service exists, update existing service
-	apiService, err := c.getAPIServiceByExternalAPIID(serviceBody)
+	apiService, err := c.getAPIServiceFromCache(serviceBody)
 	if err != nil {
 		return nil, err
 	}
@@ -111,70 +108,31 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*v1alpha1.APIS
 	return apiService, err
 }
 
-// deleteService
-func (c *ServiceClient) deleteServiceByAPIID(externalAPIID string) error {
-	svc, err := c.getAPIServiceByAttribute(externalAPIID, "")
-	if err != nil {
-		return err
-	}
-	if svc == nil {
-		return errors.New("no API Service found for externalAPIID " + externalAPIID)
-	}
-	_, err = c.apiServiceDeployAPI(http.MethodDelete, c.cfg.GetServicesURL()+"/"+svc.Name, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// getAPIServiceByExternalAPIID - Returns the API service based on external api identification
-func (c *ServiceClient) getAPIServiceByExternalAPIID(serviceBody *ServiceBody) (*v1alpha1.APIService, error) {
-	if serviceBody.PrimaryKey != "" {
-		apiService, err := c.getAPIServiceByAttribute(serviceBody.RestAPIID, serviceBody.PrimaryKey)
-		if apiService != nil || err != nil {
-			return apiService, err
-		}
-	}
-	return c.getAPIServiceByAttribute(serviceBody.RestAPIID, "")
-}
-
-// getAPIServiceByAttribute - Returns the API service based on attribute
-func (c *ServiceClient) getAPIServiceByAttribute(externalAPIID, primaryKey string) (*v1alpha1.APIService, error) {
-	headers, err := c.createHeader()
-	if err != nil {
-		return nil, err
-	}
-	query := map[string]string{}
-	if primaryKey != "" {
-		query["query"] = "attributes." + definitions.AttrExternalAPIPrimaryKey + "==\"" + primaryKey + "\""
-	} else {
-		query["query"] = "attributes." + definitions.AttrExternalAPIID + "==\"" + externalAPIID + "\""
-	}
-
-	request := coreapi.Request{
-		Method:      coreapi.GET,
-		URL:         c.cfg.GetServicesURL(),
-		Headers:     headers,
-		QueryParams: query,
-	}
-
-	response, err := c.apiClient.Send(request)
-	if err != nil {
-		return nil, err
-	}
-	if response.Code != http.StatusOK {
-		if response.Code != http.StatusNotFound {
-			responseErr := readResponseErrors(response.Code, response.Body)
-			return nil, utilerrors.Wrap(ErrRequestQuery, responseErr)
-		}
+func (c *ServiceClient) getAPIServiceByExternalAPIID(apiID string) (*v1alpha1.APIService, error) {
+	ri := c.caches.GetAPIServiceWithAPIID(apiID)
+	if ri == nil {
 		return nil, nil
 	}
-	apiServices := make([]v1alpha1.APIService, 0)
-	json.Unmarshal(response.Body, &apiServices)
-	if len(apiServices) > 0 {
-		return &apiServices[0], nil
+	apiSvc := &v1alpha1.APIService{}
+	err := apiSvc.FromInstance(ri)
+	return apiSvc, err
+}
+
+func (c *ServiceClient) getAPIServiceByPrimaryKey(primaryKey string) (*v1alpha1.APIService, error) {
+	ri := c.caches.GetAPIServiceWithPrimaryKey(primaryKey)
+	if ri == nil {
+		return nil, nil
 	}
-	return nil, nil
+	apiSvc := &v1alpha1.APIService{}
+	err := apiSvc.FromInstance(ri)
+	return apiSvc, err
+}
+
+func (c *ServiceClient) getAPIServiceFromCache(serviceBody *ServiceBody) (*v1alpha1.APIService, error) {
+	if serviceBody.PrimaryKey != "" {
+		return c.getAPIServiceByPrimaryKey(serviceBody.PrimaryKey)
+	}
+	return c.getAPIServiceByExternalAPIID(serviceBody.RestAPIID)
 }
 
 // rollbackAPIService - if the process to add api/revision/instance fails, delete the api that was created

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -152,15 +152,6 @@ func (c *ServiceClient) getRevisionInstances(instanceName, url string) ([]*v1alp
 	return c.GetAPIServiceInstances(queryParams, url)
 }
 
-// deleteAPIServiceInstance -
-func (c *ServiceClient) deleteAPIServiceInstance(name string) error {
-	_, err := c.apiServiceDeployAPI(http.MethodDelete, c.cfg.GetInstancesURL()+"/"+name, nil)
-	if err != nil && err.Error() != strconv.Itoa(http.StatusNotFound) {
-		return err
-	}
-	return nil
-}
-
 // GetAPIServiceInstanceByName - Returns the API service instance for specified name
 func (c *ServiceClient) GetAPIServiceInstanceByName(instanceName string) (*v1alpha1.APIServiceInstance, error) {
 	headers, err := c.createHeader()

--- a/pkg/apic/client_test.go
+++ b/pkg/apic/client_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	cache2 "github.com/Axway/agent-sdk/pkg/agent/cache"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Axway/agent-sdk/pkg/api"
@@ -16,7 +18,7 @@ import (
 
 func TestNewClient(t *testing.T) {
 	cfg := corecfg.NewCentralConfig(corecfg.DiscoveryAgent)
-	client := New(cfg, MockTokenGetter)
+	client := New(cfg, MockTokenGetter, cache2.NewAgentCacheManager(cfg, false))
 	assert.NotNil(t, client)
 }
 

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -272,7 +272,7 @@ func (c *ServiceClient) getAPIServerConsumerInstance(consumerInstanceName string
 	return consumerInstance, nil
 }
 
-//UpdateConsumerInstanceSubscriptionDefinition -
+// UpdateConsumerInstanceSubscriptionDefinition -
 func (c *ServiceClient) UpdateConsumerInstanceSubscriptionDefinition(externalAPIID, subscriptionDefinitionName string) error {
 	consumerInstance, err := c.getConsumerInstancesByExternalAPIID(externalAPIID)
 	if err != nil {
@@ -298,8 +298,9 @@ func (c *ServiceClient) UpdateConsumerInstanceSubscriptionDefinition(externalAPI
 	return err
 }
 
-// getConsumerInstancesByExternalAPIID
+// getConsumerInstancesByExternalAPIID gets consumer instances
 func (c *ServiceClient) getConsumerInstancesByExternalAPIID(externalAPIID string) ([]*v1alpha1.ConsumerInstance, error) {
+	// TODO: what to do for attributes on consumer instances?
 	headers, err := c.createHeader()
 	if err != nil {
 		return nil, err

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -3,6 +3,8 @@ package apic
 import (
 	"sync"
 
+	cache2 "github.com/Axway/agent-sdk/pkg/agent/cache"
+
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
@@ -34,8 +36,6 @@ const (
 
 	DefaultTeamKey = "DefaultTeam"
 )
-
-type apiErrorResponse map[string][]apiError
 
 type apiError struct {
 	Code    int    `json:"code"`
@@ -107,9 +107,8 @@ type ServiceClient struct {
 	cfg                                corecfg.CentralConfig
 	apiClient                          coreapi.Client
 	DefaultSubscriptionSchema          SubscriptionSchema
+	caches                             cache2.Manager
 	subscriptionSchemaCache            cache.Cache
-	categoryCache                      cache.Cache
-	teamCache                          cache.Cache
 	subscriptionMgr                    SubscriptionManager
 	DefaultSubscriptionApprovalWebhook corecfg.WebhookConfig
 	subscriptionRegistrationLock       sync.Mutex

--- a/pkg/apic/definitions/definitions.go
+++ b/pkg/apic/definitions/definitions.go
@@ -1,16 +1,5 @@
 package definitions
 
-// Constants for attributes
-const (
-	AttrPreviousAPIServiceRevisionID = "prevAPIServiceRevisionID"
-	AttrPreviousAPIServiceInstanceID = "prevAPIServiceInstanceID"
-	AttrExternalAPIID                = "externalAPIID"
-	AttrExternalAPIPrimaryKey        = "externalAPIPrimaryKey"
-	AttrExternalAPIName              = "externalAPIName"
-	AttrExternalAPIStage             = "externalAPIStage"
-	AttrCreatedBy                    = "createdBy"
-)
-
 // PlatformUserInfo - Represents user resource from platform
 type PlatformUserInfo struct {
 	Success bool `json:"success"`
@@ -31,3 +20,14 @@ type PlatformTeam struct {
 	Name    string `json:"name"`
 	Default bool   `json:"default"`
 }
+
+// Constants for attributes
+const (
+	AttrPreviousAPIServiceRevisionID = "prevAPIServiceRevisionID"
+	AttrPreviousAPIServiceInstanceID = "prevAPIServiceInstanceID"
+	AttrExternalAPIID                = "externalAPIID"
+	AttrExternalAPIPrimaryKey        = "externalAPIPrimaryKey"
+	AttrExternalAPIName              = "externalAPIName"
+	AttrExternalAPIStage             = "externalAPIStage"
+	AttrCreatedBy                    = "createdBy"
+)

--- a/pkg/apic/mockserviceclient.go
+++ b/pkg/apic/mockserviceclient.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	cache2 "github.com/Axway/agent-sdk/pkg/agent/cache"
+
 	"github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/cache"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
@@ -53,7 +55,7 @@ func GetTestServiceClient() (*ServiceClient, *api.MockHTTPClient) {
 		cfg:                                cfg,
 		tokenRequester:                     MockTokenGetter,
 		subscriptionSchemaCache:            cache.New(),
-		teamCache:                          cache.New(),
+		caches:                             cache2.NewAgentCacheManager(cfg, false),
 		apiClient:                          apiClient,
 		DefaultSubscriptionApprovalWebhook: webhook,
 		DefaultSubscriptionSchema:          NewSubscriptionSchema(cfg.GetEnvironmentName() + SubscriptionSchemaNameSuffix),


### PR DESCRIPTION
- Add the cacheManager to the ServiceClient
- Add the team cache to the cacheManager
- Remove calls for resources by attributes
- Look for resources in local cache