### PR TITLE
APIGOV-21601 - Fix for processing watch event before discovery

### DIFF
--- a/docs/discovery/index.md
+++ b/docs/discovery/index.md
@@ -46,7 +46,7 @@ Below is the list of Central configuration properties in YAML and their correspo
 | central.grpc.host              | CENTRAL_GRPC_HOST              | The host name of the gRPC based Amplify Central watch service (default value: uses the host from central.url config)                      |
 | central.grpc.port              | CENTRAL_GRPC_PORT              | The port of the gRPC based Amplify Central watch service (default value: uses the port from central.url config)                           |
 | central.cacheStoragePath       | CENTRAL_CACHESTORAGEPATH       | The file path the agent will use to persist internal cache (default value: ./data)                                                                 |
-| central.cacheStorageInterval   | CENTRAL_CACHESTORAGEINTERVAL   | The interval the agent will use to periodically check if the internal agent cache needs to be persisted (default value : 30 seconds)          |
+| central.cacheStorageInterval   | CENTRAL_CACHESTORAGEINTERVAL   | The interval the agent will use to periodically check if the internal agent cache needs to be persisted (default value : 10 seconds)          |
 
 The following is a sample of Central configuration in YAML
 

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -58,6 +58,9 @@ type Manager interface {
 	GetTeamByName(name string) *definitions.PlatformTeam
 	GetTeamByID(id string) *definitions.PlatformTeam
 	GetDefaultTeam() *definitions.PlatformTeam
+
+	ApplyResourceReadLock()
+	ReleaseResourceReadLock()
 }
 
 type cacheManager struct {
@@ -66,6 +69,7 @@ type cacheManager struct {
 	instanceMap             cache.Cache
 	categoryMap             cache.Cache
 	sequenceCache           cache.Cache
+	resourceCacheReadLock   sync.Mutex
 	cacheLock               sync.Mutex
 	persistedCache          cache.Cache
 	teams                   cache.Cache
@@ -224,11 +228,17 @@ func (c *cacheManager) GetAPIServiceCache() cache.Cache {
 
 // GetAPIServiceKeys - returns keys for APIService cache
 func (c *cacheManager) GetAPIServiceKeys() []string {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	return c.apiMap.GetKeys()
 }
 
 // GetAPIServiceWithAPIID - returns resource from APIService cache based on externalAPIID attribute
 func (c *cacheManager) GetAPIServiceWithAPIID(externalAPIID string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	api, _ := c.apiMap.Get(externalAPIID)
 	if api == nil {
 		api, _ = c.apiMap.GetBySecondaryKey(externalAPIID)
@@ -245,6 +255,9 @@ func (c *cacheManager) GetAPIServiceWithAPIID(externalAPIID string) *v1.Resource
 
 // GetAPIServiceWithPrimaryKey - returns resource from APIService cache based on externalAPIPrimaryKey attribute
 func (c *cacheManager) GetAPIServiceWithPrimaryKey(primaryKey string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	api, _ := c.apiMap.Get(primaryKey)
 	if api != nil {
 		apiSvc, ok := api.(*v1.ResourceInstance)
@@ -257,6 +270,9 @@ func (c *cacheManager) GetAPIServiceWithPrimaryKey(primaryKey string) *v1.Resour
 
 // GetAPIServiceWithName - returns resource from APIService cache based on externalAPIName attribute
 func (c *cacheManager) GetAPIServiceWithName(apiName string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	api, _ := c.apiMap.GetBySecondaryKey(apiName)
 	if api != nil {
 		apiSvc, ok := api.(*v1.ResourceInstance)
@@ -289,11 +305,17 @@ func (c *cacheManager) AddAPIServiceInstance(resource *v1.ResourceInstance) {
 
 // GetAPIServiceInstanceKeys - returns keys for APIServiceInstance cache
 func (c *cacheManager) GetAPIServiceInstanceKeys() []string {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	return c.instanceMap.GetKeys()
 }
 
 // GetAPIServiceInstanceByID - returns resource from APIServiceInstance cache based on instance ID
 func (c *cacheManager) GetAPIServiceInstanceByID(instanceID string) (*v1.ResourceInstance, error) {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	item, err := c.instanceMap.Get(instanceID)
 	if item != nil {
 		instance, ok := item.(*v1.ResourceInstance)
@@ -334,11 +356,17 @@ func (c *cacheManager) GetCategoryCache() cache.Cache {
 
 // GetCategoryKeys - returns keys for Category cache
 func (c *cacheManager) GetCategoryKeys() []string {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	return c.categoryMap.GetKeys()
 }
 
 // GetCategory - returns resource from Category cache based on name
 func (c *cacheManager) GetCategory(categoryName string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	category, _ := c.categoryMap.Get(categoryName)
 	if category != nil {
 		ri, ok := category.(*v1.ResourceInstance)
@@ -351,6 +379,9 @@ func (c *cacheManager) GetCategory(categoryName string) *v1.ResourceInstance {
 
 // GetCategoryWithTitle - returns resource from Category cache based on title
 func (c *cacheManager) GetCategoryWithTitle(title string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
 	category, _ := c.categoryMap.GetBySecondaryKey(title)
 	if category != nil {
 		ri, ok := category.(*v1.ResourceInstance)
@@ -448,4 +479,12 @@ func (c *cacheManager) GetTeamByID(id string) *definitions.PlatformTeam {
 		return nil
 	}
 	return &team
+}
+
+func (c *cacheManager) ApplyResourceReadLock() {
+	c.resourceCacheReadLock.Lock()
+}
+
+func (c *cacheManager) ReleaseResourceReadLock() {
+	c.resourceCacheReadLock.Unlock()
 }

--- a/pkg/agent/stream/client_test.go
+++ b/pkg/agent/stream/client_test.go
@@ -156,6 +156,8 @@ func (m *mockManager) RegisterWatch(_ string, _ chan *proto.Event, _ chan error)
 	return "", nil
 }
 
+func (m *mockManager) OnRegisterSuccess(_ wm.WatchCallback) {}
+
 func (m *mockManager) CloseWatch(_ string) error {
 	return nil
 }

--- a/pkg/config/agentfeaturesconfig.go
+++ b/pkg/config/agentfeaturesconfig.go
@@ -28,7 +28,7 @@ func NewAgentFeaturesConfiguration() AgentFeaturesConfig {
 		ConnectToCentral:     true,
 		ProcessSystemSignals: true,
 		VersionChecker:       true,
-		PersistCache:         true,
+		PersistCache:         false,
 	}
 }
 

--- a/pkg/config/agentfeaturesconfig_test.go
+++ b/pkg/config/agentfeaturesconfig_test.go
@@ -12,7 +12,7 @@ func TestDefaultAgentFeaturesConfig(t *testing.T) {
 	assert.True(t, agentFeaturesConfig.ConnectionToCentralEnabled())
 	assert.True(t, agentFeaturesConfig.ProcessSystemSignalsEnabled())
 	assert.True(t, agentFeaturesConfig.VersionCheckerEnabled())
-	assert.True(t, agentFeaturesConfig.PersistCacheEnabled())
+	assert.False(t, agentFeaturesConfig.PersistCacheEnabled())
 
 	cfgValidator, ok := cfg.(IConfigValidator)
 	assert.NotNil(t, cfgValidator)

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -202,7 +202,7 @@ func NewCentralConfig(agentType AgentType) CentralConfig {
 		ReportActivityFrequency:   5 * time.Minute,
 		UsageReporting:            NewUsageReporting(),
 		JobExecutionTimeout:       5 * time.Minute,
-		CacheStorageInterval:      60 * time.Second,
+		CacheStorageInterval:      10 * time.Second,
 	}
 }
 
@@ -670,7 +670,7 @@ func AddCentralConfigProperties(props properties.Properties, agentType AgentType
 	props.AddStringProperty(pathGRPCHost, "", "Host name for Amplify Central gRPC connection")
 	props.AddIntProperty(pathGRPCPort, 0, "Port for Amplify Central gRPC connection")
 	props.AddStringProperty(pathCacheStoragePath, "", "The directory path where agent cache will be persisted to file")
-	props.AddDurationProperty(pathCacheStorageInterval, 30*time.Second, "The interval to persist agent caches to file")
+	props.AddDurationProperty(pathCacheStorageInterval, 10*time.Second, "The interval to persist agent caches to file")
 
 	if supportsTraceability(agentType) {
 		props.AddStringProperty(pathEnvironmentID, "", "Offline Usage Reporting Only. The Environment ID the usage is associated with on Amplify Central")

--- a/pkg/watchmanager/manager.go
+++ b/pkg/watchmanager/manager.go
@@ -19,9 +19,13 @@ import (
 // NewManagerFunc func signature to create a Manager
 type NewManagerFunc func(cfg *Config, opts ...Option) (Manager, error)
 
+// WatchCallback - callback for watch manager
+type WatchCallback func()
+
 // Manager - Interface to manage watch connections
 type Manager interface {
 	RegisterWatch(topic string, eventChan chan *proto.Event, errChan chan error) (string, error)
+	OnRegisterSuccess(callback WatchCallback)
 	CloseWatch(id string) error
 	CloseConn()
 	Status() bool
@@ -36,14 +40,15 @@ type SequenceProvider interface {
 type TokenGetter func() (string, error)
 
 type watchManager struct {
-	cfg                *Config
-	clientMap          map[string]*watchClient
-	connection         *grpc.ClientConn
-	hClient            *harvesterClient
-	logger             logrus.FieldLogger
-	mutex              sync.Mutex
-	newWatchClientFunc newWatchClientFunc
-	options            *watchOptions
+	cfg                     *Config
+	clientMap               map[string]*watchClient
+	connection              *grpc.ClientConn
+	hClient                 *harvesterClient
+	logger                  logrus.FieldLogger
+	mutex                   sync.Mutex
+	newWatchClientFunc      newWatchClientFunc
+	registerSuccessCallback WatchCallback
+	options                 *watchOptions
 }
 
 // New - Creates a new watch manager
@@ -156,12 +161,20 @@ func (m *watchManager) RegisterWatch(link string, events chan *proto.Event, erro
 				}
 			}
 		}
+		if m.registerSuccessCallback != nil {
+			m.registerSuccessCallback()
+		}
 		client.processEvents()
 	}()
 
 	log.Infof("registered watch client. id: %s. watchtopic: %s", subID, link)
 
 	return subID, nil
+}
+
+// OnRegisterSuccess - sets the callback for successful watch registration
+func (m *watchManager) OnRegisterSuccess(callback WatchCallback) {
+	m.registerSuccessCallback = callback
 }
 
 // CloseWatch closes the specified watch stream by id


### PR DESCRIPTION
- Added callback on watch manager to be invoked after successful registration and processing harvested events
- Added methods to cache manager to acquire and release lock for read on api-server resource caches
- Updated streaming client to lock the resource cache for read and release the lock by setting up the callback on watch manager
- Reduced the default interval to persist cache to 10s
- Setting the default for persist cache agent feature to false for disabling the persisted cache by default even in gRPC mode. The feature can be enabled by setting the AGENTFEATURES_PERSISTCACHE config to true