### PR TITLE
APIGOV-21642 - Updates for API service/instance deletion

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -63,7 +63,6 @@ type agentData struct {
 
 	instanceCacheLock      *sync.Mutex
 	instanceValidatorJobID string
-	instanceValidatorJob   *instanceValidator
 }
 
 var agent agentData
@@ -241,7 +240,6 @@ func UnregisterResourceEventHandler(name string) {
 func startAPIServiceCache() {
 	// register the update cache job
 	newDiscoveryCacheJob := newDiscoveryCache(agent.agentResourceManager, false, agent.instanceCacheLock)
-	agent.instanceValidatorJob = newInstanceValidator(agent.instanceCacheLock, !agent.cfg.IsUsingGRPC())
 	if !agent.cfg.IsUsingGRPC() {
 		// healthcheck for central in gRPC mode is registered by streamer
 		hc.RegisterHealthcheck(util.AmplifyCentral, "central", agent.apicClient.Healthcheck)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -42,9 +42,6 @@ var AgentResourceType string
 // APIValidator - Callback for validating the API
 type APIValidator func(apiID, stageName string) bool
 
-// ServiceValidator - Callback for validating the API service on dataplane
-type ServiceValidator func(primaryKey, apiID, stageName string) bool
-
 // ConfigChangeHandler - Callback for Config change event
 type ConfigChangeHandler func()
 
@@ -59,7 +56,6 @@ type agentData struct {
 	teamMap                    cache.Cache
 	cacheManager               agentcache.Manager
 	apiValidator               APIValidator
-	serviceValidator           ServiceValidator
 	configChangeHandler        ConfigChangeHandler
 	agentResourceChangeHandler ConfigChangeHandler
 	proxyResourceHandler       *handler.StreamWatchProxyHandler

--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -148,8 +148,3 @@ func RegisterAPIValidator(apiValidator APIValidator) {
 func RegisterDeleteServiceValidator(validator interface{}) {
 	log.Warnf("the RegisterDeleteServiceValidator is no longer used, please remove the call to it")
 }
-
-// RegisterServiceValidator - Registers callback for validating if the service exists on dataplane
-func RegisterServiceValidator(validator ServiceValidator) {
-	agent.serviceValidator = validator
-}

--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -135,8 +135,9 @@ func PublishAPI(serviceBody apic.ServiceBody) error {
 func RegisterAPIValidator(apiValidator APIValidator) {
 	agent.apiValidator = apiValidator
 
-	if agent.instanceValidatorJobID == "" && apiValidator != nil && GetCentralConfig().IsUsingGRPC() {
-		jobID, err := jobs.RegisterIntervalJobWithName(agent.instanceValidatorJob, agent.cfg.GetPollInterval(), "API service instance validator")
+	if agent.instanceValidatorJobID == "" && apiValidator != nil {
+		instanceValidatorJob := newInstanceValidator(agent.instanceCacheLock, !agent.cfg.IsUsingGRPC())
+		jobID, err := jobs.RegisterIntervalJobWithName(instanceValidatorJob, agent.cfg.GetPollInterval(), "API service instance validator")
 		agent.instanceValidatorJobID = jobID
 		if err != nil {
 			log.Error(err)

--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -149,3 +149,8 @@ func RegisterAPIValidator(apiValidator APIValidator) {
 func RegisterDeleteServiceValidator(validator interface{}) {
 	log.Warnf("the RegisterDeleteServiceValidator is no longer used, please remove the call to it")
 }
+
+// RegisterServiceValidator - Registers callback for validating if the service exists on dataplane
+func RegisterServiceValidator(validator ServiceValidator) {
+	agent.serviceValidator = validator
+}

--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -81,7 +81,7 @@ func (j *discoveryCache) Execute() error {
 	if j.agentResourceManager != nil {
 		j.agentResourceManager.FetchAgentResource()
 	}
-	return agent.instanceValidatorJob.Execute()
+	return nil
 }
 
 func (j *discoveryCache) updateAPICache() {

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -71,7 +71,7 @@ func (j *instanceValidator) shouldDeleteService(externalAPIPrimaryKey, externalA
 		log.Tracef("Query instances with externalPrimaryKey attribute : %s", externalAPIPrimaryKey)
 	} else {
 		instanceCount = j.getServiceInstanceCount(definitions.AttrExternalAPIID, externalAPIID)
-		log.Tracef("Query instances with externalAPIID attribute :", externalAPIID)
+		log.Tracef("Query instances with externalAPIID attribute : %s", externalAPIID)
 	}
 
 	log.Tracef("Instances count : %d", instanceCount)

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -69,6 +69,14 @@ func (j *instanceValidator) deleteServiceInstanceOrService(resource *apiV1.Resou
 	var err error
 	var agentError *utilErrors.AgentError
 
+	defer func() {
+		// remove the api service instance from the cache for both scenarios
+		if j.isAgentPollMode {
+			// In GRPC mode delete is done on receiving delete event from service
+			agent.cacheManager.DeleteAPIServiceInstance(resource.Metadata.ID)
+		}
+	}()
+
 	// delete if it is an api service
 	if agent.serviceValidator != nil && !agent.serviceValidator(externalAPIPrimaryKey, externalAPIID, externalAPIStage) {
 		log.Infof("API no longer exists on the dataplane; deleting the API Service and corresponding catalog item %s", resource.Title)
@@ -100,10 +108,5 @@ func (j *instanceValidator) deleteServiceInstanceOrService(resource *apiV1.Resou
 		return
 	}
 
-	// remove the api service instance from the cache for both scenarios
-	if j.isAgentPollMode {
-		// In GRPC mode delete is done on receiving delete event from service
-		agent.cacheManager.DeleteAPIServiceInstance(resource.Metadata.ID)
-	}
 	log.Debugf(msg, resource.Title)
 }

--- a/pkg/agent/instancevalidator_test.go
+++ b/pkg/agent/instancevalidator_test.go
@@ -59,18 +59,11 @@ func setupAPIValidator(apiValidation bool) {
 	}
 }
 
-func setupServiceValidator(serviceValidation bool) {
-	agent.serviceValidator = func(primaryKey, apiID, stageName string) bool {
-		return serviceValidation
-	}
-}
-
 func TestValidatorAPIExistsOnDataplane(t *testing.T) {
 	// Setup
 	instanceValidator := newInstanceValidator(&sync.Mutex{}, true)
 	setupCache("12345", "test")
 	setupAPIValidator(true)
-	setupServiceValidator(true)
 	instanceValidator.Execute()
 	i, err := agent.cacheManager.GetAPIServiceInstanceByID("instance-12345")
 	assert.Nil(t, err)
@@ -90,7 +83,6 @@ func TestValidatorAPIDoesExistsDeleteService(t *testing.T) {
 		},
 	})
 	setupAPIValidator(false)
-	setupServiceValidator(false)
 	instanceValidator.Execute()
 	i, err := agent.cacheManager.GetAPIServiceInstanceByID("instance-12345")
 	assert.NotNil(t, err)

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -109,6 +109,8 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 		return err
 	}
 
+	ri, _ := instance.AsInstance()
+	c.caches.AddAPIServiceInstance(ri)
 	serviceBody.serviceContext.instanceName = instanceName
 
 	return err

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -98,7 +98,7 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 		return err
 	}
 
-	_, err = c.apiServiceDeployAPI(httpMethod, instanceURL, buffer)
+	ri, err := c.executeAPIServiceAPI(httpMethod, instanceURL, buffer)
 	if err != nil {
 		if serviceBody.serviceContext.serviceAction == addAPI {
 			_, rollbackErr := c.rollbackAPIService(*serviceBody, serviceBody.serviceContext.serviceName)
@@ -109,7 +109,6 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 		return err
 	}
 
-	ri, _ := instance.AsInstance()
 	c.caches.AddAPIServiceInstance(ri)
 	serviceBody.serviceContext.instanceName = instanceName
 


### PR DESCRIPTION
- Added RegisterServiceValidator method to allow agents to setup callback for validating if the service exists on dataplane.
- The SDK calls the service validator to check if the API service associated to the API on dataplane needs to be deleted