### PR TITLE
APIGOV-22010 - Fix for updating agent specific subresources

### DIFF
--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	mv1a "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
@@ -162,8 +163,10 @@ func (c *ServiceClient) updateAPIServiceSubresources(svc *v1alpha1.APIService) e
 		subResources["status"] = svc.Status
 	}
 
-	for key, value := range svc.SubResources {
-		subResources[key] = value
+	if len(svc.SubResources) > 0 {
+		if xAgentDetail, ok := svc.SubResources[defs.XAgentDetails]; ok {
+			subResources[defs.XAgentDetails] = xAgentDetail
+		}
 	}
 
 	if len(subResources) > 0 {

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -164,8 +164,11 @@ func (c *ServiceClient) processRevision(serviceBody *ServiceBody) error {
 		return err
 	}
 
-	if err == nil {
-		if len(revision.SubResources) > 0 {
+	if err == nil && len(revision.SubResources) > 0 {
+		if xAgentDetail, ok := revision.SubResources[defs.XAgentDetails]; ok {
+			subResources := map[string]interface{}{
+				defs.XAgentDetails: xAgentDetail,
+			}
 			err = c.CreateSubResourceScoped(
 				mv1a.EnvironmentResourceName,
 				c.cfg.GetEnvironmentName(),
@@ -173,7 +176,7 @@ func (c *ServiceClient) processRevision(serviceBody *ServiceBody) error {
 				revision.Name,
 				revision.Group,
 				revision.APIVersion,
-				revision.SubResources,
+				subResources,
 			)
 			if err != nil {
 				_, rollbackErr := c.rollbackAPIService(serviceBody.serviceContext.serviceName)

--- a/pkg/apic/consumerinstance.go
+++ b/pkg/apic/consumerinstance.go
@@ -13,6 +13,7 @@ import (
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	mv1a "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
@@ -240,8 +241,11 @@ func (c *ServiceClient) processConsumerInstance(serviceBody *ServiceBody) error 
 		return err
 	}
 
-	if err == nil {
-		if len(instance.SubResources) > 0 {
+	if err == nil && len(instance.SubResources) > 0 {
+		if xAgentDetail, ok := instance.SubResources[defs.XAgentDetails]; ok {
+			subResources := map[string]interface{}{
+				defs.XAgentDetails: xAgentDetail,
+			}
 			err = c.CreateSubResourceScoped(
 				mv1a.EnvironmentResourceName,
 				c.cfg.GetEnvironmentName(),
@@ -249,7 +253,7 @@ func (c *ServiceClient) processConsumerInstance(serviceBody *ServiceBody) error 
 				instance.Name,
 				instance.Group,
 				instance.APIVersion,
-				instance.SubResources,
+				subResources,
 			)
 			if err != nil {
 				_, rollbackErr := c.rollbackAPIService(serviceBody.serviceContext.serviceName)

--- a/pkg/migrate/attributemigration.go
+++ b/pkg/migrate/attributemigration.go
@@ -281,6 +281,10 @@ func (m *AttributeMigration) createSubResource(ri *v1.ResourceInstance) error {
 		return err
 	}
 
+	subResources := map[string]interface{}{
+		defs.XAgentDetails: ri.SubResources[defs.XAgentDetails],
+	}
+
 	err = m.client.CreateSubResourceScoped(
 		mv1a.EnvironmentResourceName,
 		m.cfg.GetEnvironmentName(),
@@ -288,7 +292,7 @@ func (m *AttributeMigration) createSubResource(ri *v1.ResourceInstance) error {
 		ri.Name,
 		ri.Group,
 		ri.APIVersion,
-		ri.SubResources,
+		subResources,
 	)
 
 	return err


### PR DESCRIPTION
- Changes to update only x-agent-details subresource rather than placing PUT call for all existing subresources on published resources.
- For APIService status is included for subresource updates on discovered APIServices