### PR TITLE
Ampgw 615 - Split Traceability agent from Governance agent.

### DIFF
--- a/pkg/agent/resource/governanceagents.go
+++ b/pkg/agent/resource/governanceagents.go
@@ -27,6 +27,5 @@ func createGovernanceAgentStatusResource(agentName, status, prevStatus, message 
 
 func mergeGovernanceAgentWithConfig(agentRes *apiV1.ResourceInstance, cfg *config.CentralConfiguration) {
 	governanceAgent(agentRes)
-	resCfgLogLevel := "info"
-	applyResConfigToCentralConfig(cfg, "", "", resCfgLogLevel)
+	applyResConfigToCentralConfig(cfg, "", "", "")
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -146,7 +146,7 @@ func NewCmd(rootCmd *cobra.Command, exeName, desc string, initConfigHandler Init
 	c.rootCmd.PreRunE = c.initialize
 
 	c.props = properties.NewPropertiesWithSecretResolver(c.rootCmd, c.secretResolver)
-	if agentType == config.TraceabilityAgent || agentType == config.GovernanceAgent {
+	if agentType == config.TraceabilityAgent {
 		properties.SetAliasKeyPrefix(c.agentName)
 	}
 
@@ -330,7 +330,7 @@ func (c *agentRootCommand) run(cmd *cobra.Command, args []string) (err error) {
 			// Setup logp to use beats logger.
 			// Setting up late here as log entries for agent/command initialization are not logged
 			// as the beats logger is initialized only when the beat instance is created.
-			if c.agentType == config.TraceabilityAgent || c.agentType == config.GovernanceAgent {
+			if c.agentType == config.TraceabilityAgent {
 				properties.SetAliasKeyPrefix(c.agentName)
 				log.SetIsLogP()
 			}


### PR DESCRIPTION
To make the Governance Agent for Amplify Gateway seperate from Traceability agent, 
the logs level should be standard ones (not harcoded any more)
and revert the mix of Gov Agent with Traceability.