### PR TITLE
APIGOV-21522 - Changes based on feedback

### DIFF
--- a/pkg/transaction/metric/cachestorage.go
+++ b/pkg/transaction/metric/cachestorage.go
@@ -159,7 +159,8 @@ func (c *cacheStorage) loadAPIMetric(storageCache cache.Cache) {
 
 			var apiStatusMetric *APIMetric
 			for _, duration := range apiMetric.Values {
-				apiStatusMetric = c.collector.updateMetric(APIDetails{apiMetric.API.ID, apiMetric.API.Name, apiMetric.API.Revision, apiMetric.API.TeamID, apiMetric.API.Stage}, apiMetric.StatusCode, duration)
+				api := APIDetails{apiMetric.API.ID, apiMetric.API.Name, apiMetric.API.Revision, apiMetric.API.TeamID, apiMetric.API.APIServiceInstance, apiMetric.API.Stage}
+				apiStatusMetric = c.collector.updateMetric(api, apiMetric.StatusCode, duration)
 			}
 			if apiStatusMetric != nil {
 				apiStatusMetric.StartTime = apiMetric.StartTime

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -8,7 +8,6 @@ var now = time.Now
 const (
 	schemaPath              = "/api/v1/report.schema.json"
 	metricEvent             = "api.transaction.status.metric"
-	subscriptionMetricEvent = "subscription.status.metric"
 	messageKey              = "message"
 	metricKey               = "metric"
 	metricFlow              = "api-central-metric"
@@ -18,6 +17,7 @@ const (
 	lighthouseVolume        = "Volume"
 	transactionCountMetric  = "transaction.count"
 	transactionVolumeMetric = "transaction.volume"
+	unknown                 = "unknown"
 )
 
 // Detail - holds the details for computing metrics
@@ -53,29 +53,8 @@ type APIDetails struct {
 	Stage              string `json:"-"`
 }
 
-// APIMetric - struct to hold metric specific for status code based API transactions
+// APIMetric - struct to hold metric aggregated for subscription,application,api,statuscode
 type APIMetric struct {
-	API         APIDetails         `json:"api"`
-	StatusCode  string             `json:"statusCode"`
-	Status      string             `json:"status"`
-	Count       int64              `json:"count"`
-	Response    ResponseMetrics    `json:"response"`
-	Observation ObservationDetails `json:"observation"`
-	StartTime   time.Time          `json:"-"`
-}
-
-// GetStartTime - Returns the start time for API metric
-func (a *APIMetric) GetStartTime() time.Time {
-	return a.StartTime
-}
-
-// GetType - Returns APIMetric
-func (a *APIMetric) GetType() string {
-	return "APIMetric"
-}
-
-// SubscriptionMetric - struct to hold metric aggregated for subscription,application,api,statuscode
-type SubscriptionMetric struct {
 	Subscription SubscriptionDetails `json:"subscription"`
 	App          AppDetails          `json:"application"`
 	API          APIDetails          `json:"api"`
@@ -88,13 +67,13 @@ type SubscriptionMetric struct {
 }
 
 // GetStartTime - Returns the start time for subscription metric
-func (a *SubscriptionMetric) GetStartTime() time.Time {
+func (a *APIMetric) GetStartTime() time.Time {
 	return a.StartTime
 }
 
-// GetType - Returns SubscriptionMetric
-func (a *SubscriptionMetric) GetType() string {
-	return "SubscriptionMetric"
+// GetType - Returns APIMetric
+func (a *APIMetric) GetType() string {
+	return "APIMetric"
 }
 
 // cachedMetric - struct to hold metric specific that gets cached and used for agent recovery

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -99,11 +99,13 @@ func (a *SubscriptionMetric) GetType() string {
 
 // cachedMetric - struct to hold metric specific that gets cached and used for agent recovery
 type cachedMetric struct {
-	API        APIDetails `json:"api"`
-	StatusCode string     `json:"statusCode"`
-	Count      int64      `json:"count"`
-	Values     []int64    `json:"values"`
-	StartTime  time.Time  `json:"startTime"`
+	App          AppDetails          `json:"app,omitempty"`
+	Subscription SubscriptionDetails `json:"subscription,omitempty"`
+	API          APIDetails          `json:"api"`
+	StatusCode   string              `json:"statusCode"`
+	Count        int64               `json:"count"`
+	Values       []int64             `json:"values"`
+	StartTime    time.Time           `json:"startTime"`
 }
 
 // V4EventDistribution - represents V7 distribution

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -45,11 +45,12 @@ type ObservationDetails struct {
 
 // APIDetails - Holds the api details
 type APIDetails struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Revision int    `json:"revision"`
-	TeamID   string `json:"teamId"`
-	Stage    string `json:"-"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Revision           int    `json:"revision,omitempty"`
+	TeamID             string `json:"teamId,omitempty"`
+	APIServiceInstance string `json:"apiServiceInstance,omitempty"`
+	Stage              string `json:"-"`
 }
 
 // APIMetric - struct to hold metric specific for status code based API transactions
@@ -76,6 +77,8 @@ func (a *APIMetric) GetType() string {
 // SubscriptionMetric - struct to hold metric aggregated for subscription,application,api,statuscode
 type SubscriptionMetric struct {
 	Subscription SubscriptionDetails `json:"subscription"`
+	App          AppDetails          `json:"application"`
+	API          APIDetails          `json:"api"`
 	StatusCode   string              `json:"statusCode"`
 	Status       string              `json:"status"`
 	Count        int64               `json:"count"`
@@ -146,20 +149,15 @@ type LighthouseUsageEvent struct {
 
 // AppDetails - struct for app details to report
 type AppDetails struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	ConsumerOrgGUID string `json:"consumerOrgId,omitempty"`
 }
 
 // SubscriptionDetails - struct for subscription metric detail
 type SubscriptionDetails struct {
-	ID                 string `json:"id"`
-	Name               string `json:"name"`
-	AppID              string `json:"appId"`
-	AppName            string `json:"appName"`
-	ConsumerOrgGUID    string `json:"-"`
-	APIID              string `json:"apiId"`
-	APIName            string `json:"apiName"`
-	APIServiceInstance string `json:"apiServiceInstance"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // Data - struct for data to report as API Metrics

--- a/pkg/transaction/metric/metricbatch.go
+++ b/pkg/transaction/metric/metricbatch.go
@@ -92,6 +92,8 @@ func (b *EventBatch) ACK() {
 					v4Data = &SubscriptionMetric{}
 				}
 				if v4Data != nil {
+					buf, _ := json.Marshal(v4Event["data"])
+					json.Unmarshal(buf, v4Data)
 					eventID := event.Content.Meta[metricKey].(string)
 					b.collector.cleanupMetricCounter(b.histograms[eventID], v4Data)
 				}

--- a/pkg/transaction/metric/metricbatch.go
+++ b/pkg/transaction/metric/metricbatch.go
@@ -88,8 +88,6 @@ func (b *EventBatch) ACK() {
 				switch eventType.(string) {
 				case metricEvent:
 					v4Data = &APIMetric{}
-				case subscriptionMetricEvent:
-					v4Data = &SubscriptionMetric{}
 				}
 				if v4Data != nil {
 					buf, _ := json.Marshal(v4Event["data"])

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -271,14 +271,18 @@ func (c *collector) updateConsumerMetric(metricAppDetail Detail) {
 		// setup the start time to be used for reporting metric event
 		consumerAPIStatusMap[statusCode] = &SubscriptionMetric{
 			Subscription: SubscriptionDetails{
-				ID:                 subscriptionID,
-				Name:               subscriptionName,
-				AppID:              appID,
-				AppName:            appName,
-				APIID:              apiID,
-				APIName:            metricAppDetail.APIDetails.Name,
+				ID:   subscriptionID,
+				Name: subscriptionName,
+			},
+			App: AppDetails{
+				ID:              appID,
+				Name:            appName,
+				ConsumerOrgGUID: consumerOrgGUID,
+			},
+			API: APIDetails{
+				ID:                 apiID,
+				Name:               metricAppDetail.APIDetails.Name,
 				APIServiceInstance: apiServiceInstanceName,
-				ConsumerOrgGUID:    consumerOrgGUID,
 			},
 			StatusCode: statusCode,
 			Status:     c.getStatusText(statusCode),
@@ -479,13 +483,9 @@ func (c *collector) generateAppMetricEvent(histogram metrics.Histogram, subscrip
 
 	subscriptionStatusMetric.Observation.Start = util.ConvertTimeToMillis(c.metricStartTime)
 	subscriptionStatusMetric.Observation.End = util.ConvertTimeToMillis(c.metricEndTime)
-	// Generate app subscription metric for provider
+	// Generate app subscription metric
 	c.generateAppV4Event(histogram, subscriptionStatusMetric, c.orgGUID)
 
-	// Generate app subscription metric for consumer
-	if subscriptionStatusMetric.Subscription.ConsumerOrgGUID != "" && subscriptionStatusMetric.Subscription.ConsumerOrgGUID != c.orgGUID {
-		c.generateAppV4Event(histogram, subscriptionStatusMetric, subscriptionStatusMetric.Subscription.ConsumerOrgGUID)
-	}
 }
 
 func (c *collector) generateAppV4Event(histogram metrics.Histogram, v4data V4Data, orgGUID string) {

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -258,7 +258,7 @@ func TestMetricCollector(t *testing.T) {
 			expectedTransactionCount:  []int{5},
 			trackVolume:               false,
 			expectedTransactionVolume: []int{0},
-			expectedMetricEventsAcked: 3, // API metric + Provider + Consumer subscription metric
+			expectedMetricEventsAcked: 2, // API metric + Provider + Consumer subscription metric
 			appName:                   "managed-app-2",
 		},
 		// Success case with no usage report
@@ -324,7 +324,7 @@ func TestMetricCollector(t *testing.T) {
 			for l := 0; l < test.loopCount; l++ {
 				for i := 0; i < test.apiTransactionCount[l]; i++ {
 					metricDetail := Detail{
-						APIDetails: APIDetails{"111", "111", 1, teamID, ""},
+						APIDetails: APIDetails{"111", "111", 1, teamID, "", ""},
 						StatusCode: "200",
 						Duration:   10,
 						Bytes:      10,
@@ -380,12 +380,12 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector := createMetricCollector()
 			metricCollector := myCollector.(*collector)
 
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "200", 5, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "200", 10, 10, "")
 			metricCollector.Execute()
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "401", 15, 10, "")
+			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", ""}, "200", 20, 10, "")
+			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", ""}, "200", 10, 10, "")
 
 			// No event generation/publish, store the cache
 			metricCollector.storage.save()
@@ -401,11 +401,11 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector = createMetricCollector()
 			metricCollector = myCollector.(*collector)
 
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "200", 10, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "200", 5, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", ""}, "401", 15, 10, "")
+			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", ""}, "200", 20, 10, "")
+			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", ""}, "200", 10, 10, "")
 
 			metricCollector.Execute()
 			// Validate only one usage report sent with 3 previous transactions and 5 new transactions
@@ -515,7 +515,7 @@ func TestOfflineMetricCollector(t *testing.T) {
 			reportGenerator := metricCollector.reports.(*cacheOfflineReport)
 			for testLoops < test.loopCount {
 				for i := 0; i < test.apiTransactionCount[testLoops]; i++ {
-					metricCollector.AddMetric(APIDetails{"111", "111", 1, "team123", ""}, "200", 10, 10, "")
+					metricCollector.AddMetric(APIDetails{"111", "111", 1, "team123", "", ""}, "200", 10, 10, "")
 				}
 				metricCollector.Execute()
 				testLoops++

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -244,7 +244,7 @@ func TestMetricCollector(t *testing.T) {
 			expectedTransactionCount:  []int{5},
 			trackVolume:               false,
 			expectedTransactionVolume: []int{0},
-			expectedMetricEventsAcked: 2, // API metric + Provider subscription metric
+			expectedMetricEventsAcked: 1, // API metric + Provider subscription metric
 			appName:                   "managed-app-1",
 		},
 		// Success case with consumer metric event
@@ -258,7 +258,7 @@ func TestMetricCollector(t *testing.T) {
 			expectedTransactionCount:  []int{5},
 			trackVolume:               false,
 			expectedTransactionVolume: []int{0},
-			expectedMetricEventsAcked: 2, // API metric + Provider + Consumer subscription metric
+			expectedMetricEventsAcked: 1, // API metric + Provider + Consumer subscription metric
 			appName:                   "managed-app-2",
 		},
 		// Success case with no usage report
@@ -285,7 +285,7 @@ func TestMetricCollector(t *testing.T) {
 			expectedTransactionCount:  []int{5, 5, 17},
 			trackVolume:               true,
 			expectedTransactionVolume: []int{50, 50, 170},
-			expectedMetricEventsAcked: 2,
+			expectedMetricEventsAcked: 1,
 			appName:                   "unknown",
 		},
 		// Success case, retry metrics
@@ -299,7 +299,7 @@ func TestMetricCollector(t *testing.T) {
 			expectedTransactionCount:  []int{5},
 			trackVolume:               true,
 			expectedTransactionVolume: []int{50},
-			expectedMetricEventsAcked: 2,
+			expectedMetricEventsAcked: 1,
 			appName:                   "unknown",
 		},
 		// Retry limit hit


### PR DESCRIPTION
- Combine the provider and consumer subscription/application metric event
- Restructure data in metric event to have separate sections for subscription, application and api
- Combine the api and subscription/application metric to single event of type "api.transaction.status.metric"