### PR TITLE
APIGOV-22216 Add method to AccessRequest interface to expose instance details

### DIFF
--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -288,7 +288,7 @@ func (j *discoveryCache) updateCategoryCache() {
 }
 
 func (j *discoveryCache) updateARDCache() {
-	if !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
+	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return
 	}
 	log.Trace("updating access request definition cache")
@@ -362,7 +362,7 @@ func (j *discoveryCache) updateManagedApplicationCache() {
 }
 
 func (j *discoveryCache) updateCRDCache() {
-	if !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
+	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return
 	}
 	log.Trace("updating credential request definition cache")

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -152,22 +152,24 @@ func (h *accessRequestHandler) newReq(ar *mv1.AccessRequest, appDetails map[stri
 	stage, _ := util.GetAgentDetailsValue(instance, defs.AttrExternalAPIStage)
 
 	return &provAccReq{
-		apiID:         apiID,
-		appDetails:    appDetails,
-		stage:         stage,
-		accessData:    ar.Spec.Data,
-		accessDetails: util.GetAgentDetails(ar),
-		managedApp:    ar.Spec.ManagedApplication,
+		apiID:           apiID,
+		appDetails:      appDetails,
+		stage:           stage,
+		accessData:      ar.Spec.Data,
+		accessDetails:   util.GetAgentDetails(ar),
+		instanceDetails: util.GetAgentDetails(instance),
+		managedApp:      ar.Spec.ManagedApplication,
 	}, nil
 }
 
 type provAccReq struct {
-	apiID         string
-	appDetails    map[string]interface{}
-	accessDetails map[string]interface{}
-	accessData    map[string]interface{}
-	managedApp    string
-	stage         string
+	apiID           string
+	appDetails      map[string]interface{}
+	accessDetails   map[string]interface{}
+	accessData      map[string]interface{}
+	instanceDetails map[string]interface{}
+	managedApp      string
+	stage           string
 }
 
 // GetApplicationName gets the application name the access request is linked too.
@@ -205,4 +207,13 @@ func (r provAccReq) GetAccessRequestDetailsValue(key string) string {
 
 func (r provAccReq) GetStage() string {
 	return r.stage
+}
+
+// GetInstanceDetails returns the 'x-agent-details' sub resource of the API Service Instance
+func (r provAccReq) GetInstanceDetails() map[string]interface{} {
+	if r.instanceDetails == nil {
+		return map[string]interface{}{}
+	}
+
+	return r.instanceDetails
 }

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -148,13 +148,8 @@ func (h *accessRequestHandler) newReq(ar *mv1.AccessRequest, appDetails map[stri
 		return nil, err
 	}
 
-	apiID, _ := util.GetAgentDetailsValue(instance, defs.AttrExternalAPIID)
-	stage, _ := util.GetAgentDetailsValue(instance, defs.AttrExternalAPIStage)
-
 	return &provAccReq{
-		apiID:           apiID,
 		appDetails:      appDetails,
-		stage:           stage,
 		accessData:      ar.Spec.Data,
 		accessDetails:   util.GetAgentDetails(ar),
 		instanceDetails: util.GetAgentDetails(instance),
@@ -163,23 +158,16 @@ func (h *accessRequestHandler) newReq(ar *mv1.AccessRequest, appDetails map[stri
 }
 
 type provAccReq struct {
-	apiID           string
 	appDetails      map[string]interface{}
 	accessDetails   map[string]interface{}
 	accessData      map[string]interface{}
 	instanceDetails map[string]interface{}
 	managedApp      string
-	stage           string
 }
 
 // GetApplicationName gets the application name the access request is linked too.
 func (r provAccReq) GetApplicationName() string {
 	return r.managedApp
-}
-
-// GetAPIID gets the api service instance id that the access request is linked too.
-func (r provAccReq) GetAPIID() string {
-	return r.apiID
 }
 
 // GetAccessRequestData gets the data of the access request
@@ -203,10 +191,6 @@ func (r provAccReq) GetAccessRequestDetailsValue(key string) string {
 	}
 
 	return util.ToString(r.accessDetails[key])
-}
-
-func (r provAccReq) GetStage() string {
-	return r.stage
 }
 
 // GetInstanceDetails returns the 'x-agent-details' sub resource of the API Service Instance

--- a/pkg/agent/handler/accessrequest_test.go
+++ b/pkg/agent/handler/accessrequest_test.go
@@ -235,22 +235,26 @@ func TestAccessRequestHandler_wrong_kind(t *testing.T) {
 
 func Test_arReq(t *testing.T) {
 	r := provAccReq{
-		apiID: "123",
 		appDetails: map[string]interface{}{
 			"app_details_key": "app_details_value",
 		},
 		accessDetails: map[string]interface{}{
 			"access_details_key": "access_details_value",
 		},
+		accessData: map[string]interface{}{
+			"key": "val",
+		},
 		managedApp: "managed-app-name",
-		stage:      "api-stage",
+		instanceDetails: map[string]interface{}{
+			defs.AttrExternalAPIStage: "api-stage",
+			defs.AttrExternalAPIID:    "123",
+		},
 	}
 
-	assert.Equal(t, r.apiID, r.GetAPIID())
 	assert.Equal(t, r.managedApp, r.GetApplicationName())
 	assert.Equal(t, r.appDetails["app_details_key"], r.GetApplicationDetailsValue("app_details_key"))
 	assert.Equal(t, r.accessDetails["access_details_key"], r.GetAccessRequestDetailsValue("access_details_key"))
-	assert.Equal(t, r.stage, r.GetStage())
+	assert.Equal(t, r.accessData, r.GetAccessRequestData())
 
 	r.accessDetails = nil
 	r.appDetails = nil
@@ -312,7 +316,7 @@ type mockARProvision struct {
 func (m *mockARProvision) AccessRequestProvision(ar prov.AccessRequest) (status prov.RequestStatus) {
 	m.expectedProvType = provision
 	v := ar.(*provAccReq)
-	assert.Equal(m.t, m.expectedAPIID, v.apiID)
+	assert.Equal(m.t, m.expectedAPIID, v.instanceDetails[defs.AttrExternalAPIID])
 	assert.Equal(m.t, m.expectedAppName, v.managedApp)
 	assert.Equal(m.t, m.expectedAppDetails, v.appDetails)
 	assert.Equal(m.t, m.expectedAccessDetails, v.accessDetails)
@@ -322,7 +326,7 @@ func (m *mockARProvision) AccessRequestProvision(ar prov.AccessRequest) (status 
 func (m *mockARProvision) AccessRequestDeprovision(ar prov.AccessRequest) (status prov.RequestStatus) {
 	m.expectedProvType = deprovision
 	v := ar.(*provAccReq)
-	assert.Equal(m.t, m.expectedAPIID, v.apiID)
+	assert.Equal(m.t, m.expectedAPIID, v.instanceDetails[defs.AttrExternalAPIID])
 	assert.Equal(m.t, m.expectedAppName, v.managedApp)
 	assert.Equal(m.t, m.expectedAppDetails, v.appDetails)
 	assert.Equal(m.t, m.expectedAccessDetails, v.accessDetails)

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -146,7 +146,7 @@ func NewOAuthCredentialRequestBuilder(options ...func(*crdBuilderOptions)) provi
 
 // createOrUpdateAccessRequestDefinition -
 func createOrUpdateAccessRequestDefinition(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
-	if !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
+	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return nil, nil
 	}
 	ardRI, _ := agent.cacheManager.GetAccessRequestDefinitionByName(data.Name)

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -11,7 +11,7 @@ import (
 
 // createOrUpdateCredentialRequestDefinition -
 func createOrUpdateCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
-	if !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
+	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return nil, nil
 	}
 	crdRI, _ := agent.cacheManager.GetCredentialRequestDefinitionByName(data.Name)

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -177,7 +177,7 @@ func NewAPIKeyAccessRequestBuilder() provisioning.AccessRequestBuilder {
 
 // RegisterProvisioner - allow the agent to register a provisioner
 func RegisterProvisioner(provisioner provisioning.Provisioning) {
-	if !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
+	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return
 	}
 	agent.provisioner = provisioner

--- a/pkg/apic/provisioning/accessrequest.go
+++ b/pkg/apic/provisioning/accessrequest.go
@@ -14,4 +14,6 @@ type AccessRequest interface {
 	GetStage() string
 	// GetAccessRequestData returns the map[string]interface{} of data from the request
 	GetAccessRequestData() map[string]interface{}
+	// GetInstanceDetails returns the 'x-agent-details' sub resource of the API Service Instance
+	GetInstanceDetails() map[string]interface{}
 }

--- a/pkg/apic/provisioning/accessrequest.go
+++ b/pkg/apic/provisioning/accessrequest.go
@@ -4,14 +4,10 @@ package provisioning
 type AccessRequest interface {
 	// GetAccessRequestDetailsValue returns a value found on the 'x-agent-details' sub resource of the AccessRequest.
 	GetAccessRequestDetailsValue(key string) string
-	// GetAPIID returns the reference of the API on the data plane to be used
-	GetAPIID() string
 	// GetApplicationDetailsValue returns a value found on the 'x-agent-details' sub resource of the ManagedApplications.
 	GetApplicationDetailsValue(key string) string
 	// GetApplicationName returns the name of the managed application for this credential
 	GetApplicationName() string
-	// GetStage returns the api stage
-	GetStage() string
 	// GetAccessRequestData returns the map[string]interface{} of data from the request
 	GetAccessRequestData() map[string]interface{}
 	// GetInstanceDetails returns the 'x-agent-details' sub resource of the API Service Instance

--- a/pkg/apic/provisioning/mock/provisioning.go
+++ b/pkg/apic/provisioning/mock/provisioning.go
@@ -51,11 +51,12 @@ func (m MockCredentialRequest) GetCredentialData() map[string]interface{} {
 
 type MockAccessRequest struct {
 	provisioning.AccessRequest
-	APIID      string
-	AppDetails map[string]string
-	AppName    string
-	Details    map[string]string
-	Stage      string
+	APIID           string
+	AppDetails      map[string]string
+	AppName         string
+	Details         map[string]string
+	InstanceDetails map[string]interface{}
+	Stage           string
 }
 
 func (m MockAccessRequest) GetApplicationName() string {
@@ -76,6 +77,10 @@ func (m MockAccessRequest) GetAPIID() string {
 
 func (m MockAccessRequest) GetStage() string {
 	return m.Stage
+}
+
+func (m MockAccessRequest) GetInstanceDetails() map[string]interface{} {
+	return m.InstanceDetails
 }
 
 type MockRequestStatus struct {

--- a/pkg/apic/provisioning/mock/provisioning.go
+++ b/pkg/apic/provisioning/mock/provisioning.go
@@ -51,12 +51,17 @@ func (m MockCredentialRequest) GetCredentialData() map[string]interface{} {
 
 type MockAccessRequest struct {
 	provisioning.AccessRequest
-	APIID           string
-	AppDetails      map[string]string
-	AppName         string
-	Details         map[string]string
-	InstanceDetails map[string]interface{}
-	Stage           string
+	APIID             string
+	AppDetails        map[string]string
+	AppName           string
+	Details           map[string]string
+	InstanceDetails   map[string]interface{}
+	Stage             string
+	AccessRequestData map[string]interface{}
+}
+
+func (m MockAccessRequest) GetAccessRequestData() map[string]interface{} {
+	return m.AccessRequestData
 }
 
 func (m MockAccessRequest) GetApplicationName() string {

--- a/pkg/apic/provisioning/mock/provisioning.go
+++ b/pkg/apic/provisioning/mock/provisioning.go
@@ -51,12 +51,10 @@ func (m MockCredentialRequest) GetCredentialData() map[string]interface{} {
 
 type MockAccessRequest struct {
 	provisioning.AccessRequest
-	APIID             string
 	AppDetails        map[string]string
 	AppName           string
 	Details           map[string]string
 	InstanceDetails   map[string]interface{}
-	Stage             string
 	AccessRequestData map[string]interface{}
 }
 
@@ -74,14 +72,6 @@ func (m MockAccessRequest) GetAccessRequestDetailsValue(key string) string {
 
 func (m MockAccessRequest) GetApplicationDetailsValue(key string) string {
 	return m.AppDetails[key]
-}
-
-func (m MockAccessRequest) GetAPIID() string {
-	return m.APIID
-}
-
-func (m MockAccessRequest) GetStage() string {
-	return m.Stage
 }
 
 func (m MockAccessRequest) GetInstanceDetails() map[string]interface{} {


### PR DESCRIPTION
- In provisioning/accessrequest.go, add a method for retrieving instance details
- Remove GetAPIID() and GetAPIStage() methods from access request interface
