### PR TITLE
APIGOV-22609 - fix updating of resources and sub resources based on spec hash

### DIFF
--- a/pkg/agent/accesscontrollisthandler.go
+++ b/pkg/agent/accesscontrollisthandler.go
@@ -44,7 +44,7 @@ func (j *aclUpdateJob) Status() error {
 
 func (j *aclUpdateJob) Execute() error {
 	newTeamIDs := agent.cacheManager.GetTeamsIDsInAPIServices()
-	newTeamIDs = sort.StringSlice(newTeamIDs)
+	sort.Strings(newTeamIDs)
 	if j.lastTeamIDs != nil && strings.Join(newTeamIDs, "") == strings.Join(j.lastTeamIDs, "") {
 		return nil
 	}

--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -147,7 +147,7 @@ func TestDiscoveryCache(t *testing.T) {
 			}
 			return &apiSvc, nil
 		},
-		RegisterAccessRequestDefinitionMock: func(_ *v1alpha1.AccessRequestDefinition, _ bool) (*v1alpha1.AccessRequestDefinition, error) {
+		RegisterAccessRequestDefinitionMock: func(_ *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
 			return accReqDef, nil
 		},
 		DeleteResourceInstanceMock: func(_ *v1.ResourceInstance) error {

--- a/pkg/agent/discovery_test.go
+++ b/pkg/agent/discovery_test.go
@@ -147,8 +147,9 @@ func TestDiscoveryCache(t *testing.T) {
 			}
 			return &apiSvc, nil
 		},
-		RegisterAccessRequestDefinitionMock: func(_ *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
-			return accReqDef, nil
+		CreateOrUpdateResourceMock: func(_ v1.Interface) (*v1.ResourceInstance, error) {
+			ri, _ := accReqDef.AsInstance()
+			return ri, nil
 		},
 		DeleteResourceInstanceMock: func(_ *v1.ResourceInstance) error {
 			deleteCalled = true

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -3,9 +3,7 @@ package agent
 import (
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
-	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
-	"github.com/Axway/agent-sdk/pkg/util"
 )
 
 // credential request definitions
@@ -15,20 +13,7 @@ func createOrUpdateCredentialRequestDefinition(data *v1alpha1.CredentialRequestD
 	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return nil, nil
 	}
-	crdRI, _ := agent.cacheManager.GetCredentialRequestDefinitionByName(data.Name)
-	if crdRI == nil {
-		return agent.apicClient.RegisterCredentialRequestDefinition(data, false)
-	}
-	newHash, _ := util.GetAgentDetailsValue(data, definitions.AttrSpecHash)
-	oldHash, _ := util.GetAgentDetailsValue(crdRI, definitions.AttrSpecHash)
-	if newHash != oldHash {
-		return agent.apicClient.RegisterCredentialRequestDefinition(data, true)
-	}
-	err := data.FromInstance(crdRI)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return agent.apicClient.RegisterCredentialRequestDefinition(data)
 }
 
 type crdBuilderOptions struct {
@@ -152,20 +137,7 @@ func createOrUpdateAccessRequestDefinition(data *v1alpha1.AccessRequestDefinitio
 	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return nil, nil
 	}
-	ardRI, _ := agent.cacheManager.GetAccessRequestDefinitionByName(data.Name)
-	if ardRI == nil {
-		return agent.apicClient.RegisterAccessRequestDefinition(data, false)
-	}
-	newHash, _ := util.GetAgentDetailsValue(data, definitions.AttrSpecHash)
-	oldHash, _ := util.GetAgentDetailsValue(ardRI, definitions.AttrSpecHash)
-	if newHash != oldHash {
-		return agent.apicClient.RegisterAccessRequestDefinition(data, true)
-	}
-	err := data.FromInstance(ardRI)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return agent.apicClient.RegisterAccessRequestDefinition(data)
 }
 
 // NewAccessRequestBuilder - called by the agents to build and register a new access request definition

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -2,18 +2,28 @@ package agent
 
 import (
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 )
 
 // credential request definitions
-
-// createOrUpdateCredentialRequestDefinition -
-func createOrUpdateCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
+// createOrUpdateDefinition -
+func createOrUpdateDefinition(data v1.Interface) (*v1.ResourceInstance, error) {
 	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
 		return nil, nil
 	}
-	return agent.apicClient.RegisterCredentialRequestDefinition(data)
+	return agent.apicClient.CreateOrUpdateResource(data)
+}
+
+// createOrUpdateCredentialRequestDefinition -
+func createOrUpdateCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
+	ri, err := createOrUpdateDefinition(data)
+	if ri == nil || err != nil {
+		return nil, err
+	}
+	err = data.FromInstance(ri)
+	return data, err
 }
 
 type crdBuilderOptions struct {
@@ -134,10 +144,12 @@ func NewOAuthCredentialRequestBuilder(options ...func(*crdBuilderOptions)) provi
 
 // createOrUpdateAccessRequestDefinition -
 func createOrUpdateAccessRequestDefinition(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
-	if agent.agentFeaturesCfg == nil || !agent.agentFeaturesCfg.MarketplaceProvisioningEnabled() {
-		return nil, nil
+	ri, err := createOrUpdateDefinition(data)
+	if ri == nil || err != nil {
+		return nil, err
 	}
-	return agent.apicClient.RegisterAccessRequestDefinition(data)
+	err = data.FromInstance(ri)
+	return data, err
 }
 
 // NewAccessRequestBuilder - called by the agents to build and register a new access request definition

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
+	"github.com/Axway/agent-sdk/pkg/util"
 )
 
 // credential request definitions
@@ -18,7 +19,9 @@ func createOrUpdateCredentialRequestDefinition(data *v1alpha1.CredentialRequestD
 	if crdRI == nil {
 		return agent.apicClient.RegisterCredentialRequestDefinition(data, false)
 	}
-	if data.SubResources[definitions.AttrSpecHash] != crdRI.SubResources[definitions.AttrSpecHash] {
+	newHash, _ := util.GetAgentDetailsValue(data, definitions.AttrSpecHash)
+	oldHash, _ := util.GetAgentDetailsValue(crdRI, definitions.AttrSpecHash)
+	if newHash != oldHash {
 		return agent.apicClient.RegisterCredentialRequestDefinition(data, true)
 	}
 	err := data.FromInstance(crdRI)
@@ -153,7 +156,9 @@ func createOrUpdateAccessRequestDefinition(data *v1alpha1.AccessRequestDefinitio
 	if ardRI == nil {
 		return agent.apicClient.RegisterAccessRequestDefinition(data, false)
 	}
-	if data.SubResources[definitions.AttrSpecHash] != ardRI.SubResources[definitions.AttrSpecHash] {
+	newHash, _ := util.GetAgentDetailsValue(data, definitions.AttrSpecHash)
+	oldHash, _ := util.GetAgentDetailsValue(ardRI, definitions.AttrSpecHash)
+	if newHash != oldHash {
 		return agent.apicClient.RegisterAccessRequestDefinition(data, true)
 	}
 	err := data.FromInstance(ardRI)

--- a/pkg/agent/provisioning_test.go
+++ b/pkg/agent/provisioning_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/mock"
 	"github.com/Axway/agent-sdk/pkg/config"
@@ -19,8 +20,9 @@ func TestNewCredentialRequestBuilder(t *testing.T) {
 	InitializeWithAgentFeatures(cfg, &config.AgentFeaturesConfiguration{MarketplaceProvisioning: true})
 
 	agent.apicClient = &mock.Client{
-		RegisterCredentialRequestDefinitionMock: func(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
-			return data, nil
+		CreateOrUpdateResourceMock: func(data v1.Interface) (*v1.ResourceInstance, error) {
+			ri, _ := data.AsInstance()
+			return ri, nil
 		},
 	}
 

--- a/pkg/agent/provisioning_test.go
+++ b/pkg/agent/provisioning_test.go
@@ -19,7 +19,7 @@ func TestNewCredentialRequestBuilder(t *testing.T) {
 	InitializeWithAgentFeatures(cfg, &config.AgentFeaturesConfiguration{MarketplaceProvisioning: true})
 
 	agent.apicClient = &mock.Client{
-		RegisterCredentialRequestDefinitionMock: func(data *v1alpha1.CredentialRequestDefinition, update bool) (*v1alpha1.CredentialRequestDefinition, error) {
+		RegisterCredentialRequestDefinitionMock: func(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
 			return data, nil
 		},
 	}

--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -11,7 +11,6 @@ import (
 
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
-	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	mv1a "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
@@ -121,7 +120,7 @@ func buildAPIServiceStatusSubResource(ownerErr error) *v1.ResourceStatus {
 }
 
 // processService -
-func (c *ServiceClient) processService(serviceBody *ServiceBody) (*v1alpha1.APIService, error) {
+func (c *ServiceClient) processService(serviceBody *ServiceBody) (*mv1a.APIService, error) {
 	// Default action to create service
 	serviceURL := c.cfg.GetServicesURL()
 	httpMethod := http.MethodPost
@@ -163,7 +162,7 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*v1alpha1.APIS
 	return svc, err
 }
 
-func (c *ServiceClient) updateAPIServiceSubresources(svc *v1alpha1.APIService) error {
+func (c *ServiceClient) updateAPIServiceSubresources(svc *mv1a.APIService) error {
 	subResources := make(map[string]interface{})
 	if svc.Status != nil {
 		subResources["status"] = svc.Status

--- a/pkg/apic/apiservice_test.go
+++ b/pkg/apic/apiservice_test.go
@@ -271,7 +271,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/apiservice.json", // for call to update the service
+			FileName: "./testdata/apiservice.json", // for call to update the service subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -279,7 +279,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision
+			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -287,7 +287,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/serviceinstance.json", // for call to update the serviceInstance
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceInstance subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -295,7 +295,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
+			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance subresource
 			RespCode: http.StatusOK,
 		},
 	})
@@ -318,7 +318,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/apiservice.json", // for call to update the service
+			FileName: "./testdata/apiservice.json", // for call to update the service subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -326,7 +326,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision
+			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -334,7 +334,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/serviceinstance.json", // for call to update the serviceinstance
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceinstance subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -342,7 +342,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
+			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance subresource
 			RespCode: http.StatusOK,
 		},
 	})

--- a/pkg/apic/apiservice_test.go
+++ b/pkg/apic/apiservice_test.go
@@ -267,7 +267,7 @@ func TestUpdateService(t *testing.T) {
 	// tests for updating existing revision
 	httpClient.SetResponses([]api.MockResponse{
 		{
-			FileName: "./testdata/apiservice-list.json", // for call to get the service
+			FileName: "./testdata/apiservice.json", // for call to update the service
 			RespCode: http.StatusOK,
 		},
 		{
@@ -275,11 +275,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/existingservicerevisions.json", // for call to get the serviceRevision
+			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision
 			RespCode: http.StatusOK,
 		},
 		{
@@ -287,11 +283,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/existingserviceinstances.json", // for call to get instance
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceInstance
 			RespCode: http.StatusOK,
 		},
 		{
@@ -299,15 +291,11 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/existingconsumerinstances.json", // for call to check existance of the consumerInstance
-			RespCode: http.StatusOK,
-		},
-		{
 			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
+			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
 			RespCode: http.StatusOK,
 		},
 	})
@@ -326,7 +314,7 @@ func TestUpdateService(t *testing.T) {
 	// tests for updating existing instance with same endpoint
 	httpClient.SetResponses([]api.MockResponse{
 		{
-			FileName: "./testdata/apiservice-list.json", // for call to get the service
+			FileName: "./testdata/apiservice.json", // for call to update the service
 			RespCode: http.StatusOK,
 		},
 		{
@@ -334,11 +322,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/existingservicerevisions.json", // this for call to get the revision
+			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision
 			RespCode: http.StatusOK,
 		},
 		{
@@ -346,11 +330,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/existingserviceinstances.json", // for call to get the serviceInstance
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceinstance
 			RespCode: http.StatusOK,
 		},
 		{
@@ -358,19 +338,11 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/existingconsumerinstances.json", // for call to get the consumerInstance
-			RespCode: http.StatusOK,
-		},
-		{
 			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
+			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
 			RespCode: http.StatusOK,
 		},
 	})

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -796,12 +796,11 @@ func (c *ServiceClient) updateSpecORCreateResourceInstance(data *apiv1.ResourceI
 	switch data.Kind {
 	case mv1a.AccessRequestDefinitionGVK().Kind:
 		existingRI, err = c.caches.GetAccessRequestDefinitionByName(data.Name)
-	// case v1.CredentailRequestDefinition:
-	default:
+	case mv1a.CredentialRequestDefinitionGVK().Kind:
 		existingRI, err = c.caches.GetCredentialRequestDefinitionByName(data.Name)
 	}
 
-	if err == nil {
+	if err == nil && existingRI != nil {
 		url = c.createAPIServerURL(data.GetSelfLink())
 		method = coreapi.PUT
 

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -97,8 +97,7 @@ type Client interface {
 	CreateResource(url string, bts []byte) (*apiv1.ResourceInstance, error)
 	UpdateResource(url string, bts []byte) (*apiv1.ResourceInstance, error)
 	UpdateResourceFinalizer(ri *apiv1.ResourceInstance, finalizer, description string, addAction bool) (*apiv1.ResourceInstance, error)
-	RegisterCredentialRequestDefinition(data *mv1a.CredentialRequestDefinition) (*mv1a.CredentialRequestDefinition, error)
-	RegisterAccessRequestDefinition(data *mv1a.AccessRequestDefinition) (*mv1a.AccessRequestDefinition, error)
+	CreateOrUpdateResource(apiv1.Interface) (*apiv1.ResourceInstance, error)
 }
 
 // New creates a new Client
@@ -846,38 +845,16 @@ func (c *ServiceClient) updateSpecORCreateResourceInstance(data *apiv1.ResourceI
 	return newRI, err
 }
 
-// RegisterCredentialRequestDefinition - Adds or updates a credential request definition
-func (c *ServiceClient) RegisterCredentialRequestDefinition(data *mv1a.CredentialRequestDefinition) (*mv1a.CredentialRequestDefinition, error) {
-	data.Metadata.Scope.Name = c.cfg.GetEnvironmentName()
+// CreateOrUpdateResource deletes a resource
+func (c *ServiceClient) CreateOrUpdateResource(data apiv1.Interface) (*apiv1.ResourceInstance, error) {
+	data.SetScopeName(c.cfg.GetEnvironmentName())
 	ri, err := data.AsInstance()
 	if err != nil {
 		return nil, err
 	}
 
 	ri, err = c.updateSpecORCreateResourceInstance(ri)
-	if err != nil {
-		return nil, err
-	}
-
-	err = data.FromInstance(ri)
-	return data, err
-}
-
-// RegisterAccessRequestDefinition - Adds or updates a access request definition
-func (c *ServiceClient) RegisterAccessRequestDefinition(data *mv1a.AccessRequestDefinition) (*mv1a.AccessRequestDefinition, error) {
-	data.Metadata.Scope.Name = c.cfg.GetEnvironmentName()
-	ri, err := data.AsInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	ri, err = c.updateSpecORCreateResourceInstance(ri)
-	if err != nil {
-		return nil, err
-	}
-
-	err = data.FromInstance(ri)
-	return data, err
+	return ri, err
 }
 
 // UpdateAPIV1ResourceInstance - updates a ResourceInstance by providing a url to the resource

--- a/pkg/apic/client_test.go
+++ b/pkg/apic/client_test.go
@@ -6,18 +6,17 @@ import (
 	"testing"
 	"time"
 
+	cache2 "github.com/Axway/agent-sdk/pkg/agent/cache"
+	"github.com/Axway/agent-sdk/pkg/api"
+	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
-	"github.com/Axway/agent-sdk/pkg/apic/definitions"
-
-	cache2 "github.com/Axway/agent-sdk/pkg/agent/cache"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
+	"github.com/Axway/agent-sdk/pkg/apic/definitions"
+	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/util/healthcheck"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewClient(t *testing.T) {
@@ -235,4 +234,130 @@ func TestCreateSubResourceUnscoped(t *testing.T) {
 
 	err := svcClient.CreateSubResourceUnscoped(ri.ResourceMeta, ri.SubResources)
 	assert.Nil(t, err)
+}
+
+func TestUpdateSpecORCreateResourceInstance(t *testing.T) {
+	tests := []struct {
+		name           string
+		gvk            apiv1.GroupVersionKind
+		oldHash        string
+		newHash        string
+		apiResponses   []api.MockResponse
+		expectedTagVal string
+		expectErr      bool
+	}{
+		{
+			name:    "should error with bad response from api call",
+			gvk:     mv1.AccessRequestDefinitionGVK(),
+			oldHash: "1234",
+			newHash: "1235",
+			apiResponses: []api.MockResponse{
+				{
+					RespCode: http.StatusUnauthorized,
+				},
+			},
+			expectedTagVal: "existing",
+			expectErr:      true,
+		},
+		{
+			name:           "should not update ARD as hash is unchanged",
+			gvk:            mv1.AccessRequestDefinitionGVK(),
+			oldHash:        "1234",
+			newHash:        "1234",
+			apiResponses:   []api.MockResponse{},
+			expectedTagVal: "existing",
+			expectErr:      false,
+		},
+		{
+			name:           "should not update CRD as hash is unchanged",
+			gvk:            mv1.CredentialRequestDefinitionGVK(),
+			oldHash:        "1234",
+			newHash:        "1234",
+			apiResponses:   []api.MockResponse{},
+			expectedTagVal: "existing",
+			expectErr:      false,
+		},
+		{
+			name:    "should update ARD as hash has changed",
+			gvk:     mv1.AccessRequestDefinitionGVK(),
+			oldHash: "1234",
+			newHash: "5234",
+			apiResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json",
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json",
+					RespCode: http.StatusOK,
+				},
+			},
+			expectedTagVal: "prod",
+			expectErr:      false,
+		},
+		{
+			name:    "should update CRD as hash has changed",
+			gvk:     mv1.CredentialRequestDefinitionGVK(),
+			oldHash: "1234",
+			newHash: "5234",
+			apiResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json",
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json",
+					RespCode: http.StatusOK,
+				},
+			},
+			expectedTagVal: "prod",
+			expectErr:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcClient, mockHTTPClient := GetTestServiceClient()
+			cfg := GetTestServiceClientCentralConfiguration(svcClient)
+			cfg.Environment = "mockenv"
+			cfg.PlatformURL = "http://foo.bar:4080"
+
+			// There should be one request for each sub resource of the ResourceInstance
+			mockHTTPClient.SetResponses(tt.apiResponses)
+
+			res := apiv1.ResourceInstance{
+				ResourceMeta: apiv1.ResourceMeta{
+					Name:             tt.name,
+					GroupVersionKind: tt.gvk,
+					SubResources: map[string]interface{}{
+						definitions.XAgentDetails: map[string]interface{}{
+							defs.AttrSpecHash: tt.oldHash,
+						},
+					},
+					Tags: []string{"existing"},
+				},
+				Spec: map[string]interface{}{},
+			}
+
+			// setup the cachedResources
+			switch tt.gvk.Kind {
+			case mv1.AccessRequestDefinitionGVK().Kind:
+				svcClient.caches.AddAccessRequestDefinition(&res)
+			case mv1.CredentialRequestDefinitionGVK().Kind:
+				svcClient.caches.AddCredentialRequestDefinition(&res)
+			}
+
+			newRes := res
+			newRes.Tags = []string{}
+			newRes.SubResources = map[string]interface{}{definitions.XAgentDetails: map[string]interface{}{defs.AttrSpecHash: tt.newHash}}
+
+			ri, err := svcClient.updateSpecORCreateResourceInstance(&newRes)
+			if tt.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedTagVal, ri.Tags[0])
+			}
+
+		})
+	}
 }

--- a/pkg/apic/mock/mockclient.go
+++ b/pkg/apic/mock/mockclient.go
@@ -51,8 +51,6 @@ type Client struct {
 	GetAccessControlListMock                                 func(aclName string) (*v1alpha1.AccessControlList, error)
 	UpdateAccessControlListMock                              func(acl *v1alpha1.AccessControlList) (*v1alpha1.AccessControlList, error)
 	CreateAccessControlListMock                              func(acl *v1alpha1.AccessControlList) (*v1alpha1.AccessControlList, error)
-	RegisterCredentialRequestDefinitionMock                  func(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error)
-	RegisterAccessRequestDefinitionMock                      func(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error)
 	UpdateAPIV1ResourceInstanceMock                          func(url string, ri *v1.ResourceInstance) (*v1.ResourceInstance, error)
 	UpdateResourceInstanceMock                               func(ri *v1.ResourceInstance) (*v1.ResourceInstance, error)
 	DeleteResourceInstanceMock                               func(ri *v1.ResourceInstance) error
@@ -62,6 +60,7 @@ type Client struct {
 	CreateResourceMock                                       func(url string, bts []byte) (*v1.ResourceInstance, error)
 	UpdateResourceMock                                       func(url string, bts []byte) (*v1.ResourceInstance, error)
 	UpdateResourceFinalizerMock                              func(res *v1.ResourceInstance, finalizer, description string, addAction bool) (*v1.ResourceInstance, error)
+	CreateOrUpdateResourceMock                               func(v1.Interface) (*v1.ResourceInstance, error)
 }
 
 func (m *Client) GetEnvironment() (*v1alpha1.Environment, error) {
@@ -333,20 +332,6 @@ func (m *Client) CreateAccessControlList(acl *v1alpha1.AccessControlList) (*v1al
 	return nil, nil
 }
 
-func (m *Client) RegisterCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
-	if m.RegisterCredentialRequestDefinitionMock != nil {
-		return m.RegisterCredentialRequestDefinitionMock(data)
-	}
-	return nil, nil
-}
-
-func (m *Client) RegisterAccessRequestDefinition(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
-	if m.RegisterAccessRequestDefinitionMock != nil {
-		return m.RegisterAccessRequestDefinitionMock(data)
-	}
-	return nil, nil
-}
-
 func (m *Client) UpdateAPIV1ResourceInstance(url string, ri *v1.ResourceInstance) (*v1.ResourceInstance, error) {
 	if m.UpdateAPIV1ResourceInstanceMock != nil {
 		return m.UpdateAPIV1ResourceInstanceMock(url, ri)
@@ -406,6 +391,13 @@ func (m *Client) UpdateResource(url string, bts []byte) (*v1.ResourceInstance, e
 func (m *Client) UpdateResourceFinalizer(res *v1.ResourceInstance, finalizer, description string, addAction bool) (*v1.ResourceInstance, error) {
 	if m.UpdateResourceFinalizerMock != nil {
 		return m.UpdateResourceFinalizerMock(res, finalizer, description, addAction)
+	}
+	return nil, nil
+}
+
+func (m *Client) CreateOrUpdateResource(iface v1.Interface) (*v1.ResourceInstance, error) {
+	if m.CreateOrUpdateResourceMock != nil {
+		return m.CreateOrUpdateResourceMock(iface)
 	}
 	return nil, nil
 }

--- a/pkg/apic/mock/mockclient.go
+++ b/pkg/apic/mock/mockclient.go
@@ -51,8 +51,8 @@ type Client struct {
 	GetAccessControlListMock                                 func(aclName string) (*v1alpha1.AccessControlList, error)
 	UpdateAccessControlListMock                              func(acl *v1alpha1.AccessControlList) (*v1alpha1.AccessControlList, error)
 	CreateAccessControlListMock                              func(acl *v1alpha1.AccessControlList) (*v1alpha1.AccessControlList, error)
-	RegisterCredentialRequestDefinitionMock                  func(data *v1alpha1.CredentialRequestDefinition, update bool) (*v1alpha1.CredentialRequestDefinition, error)
-	RegisterAccessRequestDefinitionMock                      func(data *v1alpha1.AccessRequestDefinition, update bool) (*v1alpha1.AccessRequestDefinition, error)
+	RegisterCredentialRequestDefinitionMock                  func(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error)
+	RegisterAccessRequestDefinitionMock                      func(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error)
 	UpdateAPIV1ResourceInstanceMock                          func(url string, ri *v1.ResourceInstance) (*v1.ResourceInstance, error)
 	DeleteResourceInstanceMock                               func(ri *v1.ResourceInstance) error
 	CreateSubResourceScopedMock                              func(rm v1.ResourceMeta, subs map[string]interface{}) error
@@ -332,16 +332,16 @@ func (m *Client) CreateAccessControlList(acl *v1alpha1.AccessControlList) (*v1al
 	return nil, nil
 }
 
-func (m *Client) RegisterCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition, update bool) (*v1alpha1.CredentialRequestDefinition, error) {
+func (m *Client) RegisterCredentialRequestDefinition(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error) {
 	if m.RegisterCredentialRequestDefinitionMock != nil {
-		return m.RegisterCredentialRequestDefinitionMock(data, update)
+		return m.RegisterCredentialRequestDefinitionMock(data)
 	}
 	return nil, nil
 }
 
-func (m *Client) RegisterAccessRequestDefinition(data *v1alpha1.AccessRequestDefinition, update bool) (*v1alpha1.AccessRequestDefinition, error) {
+func (m *Client) RegisterAccessRequestDefinition(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error) {
 	if m.RegisterAccessRequestDefinitionMock != nil {
-		return m.RegisterAccessRequestDefinitionMock(data, update)
+		return m.RegisterAccessRequestDefinitionMock(data)
 	}
 	return nil, nil
 }

--- a/pkg/apic/mock/mockclient.go
+++ b/pkg/apic/mock/mockclient.go
@@ -54,6 +54,7 @@ type Client struct {
 	RegisterCredentialRequestDefinitionMock                  func(data *v1alpha1.CredentialRequestDefinition) (*v1alpha1.CredentialRequestDefinition, error)
 	RegisterAccessRequestDefinitionMock                      func(data *v1alpha1.AccessRequestDefinition) (*v1alpha1.AccessRequestDefinition, error)
 	UpdateAPIV1ResourceInstanceMock                          func(url string, ri *v1.ResourceInstance) (*v1.ResourceInstance, error)
+	UpdateResourceInstanceMock                               func(ri *v1.ResourceInstance) (*v1.ResourceInstance, error)
 	DeleteResourceInstanceMock                               func(ri *v1.ResourceInstance) error
 	CreateSubResourceScopedMock                              func(rm v1.ResourceMeta, subs map[string]interface{}) error
 	CreateSubResourceUnscopedMock                            func(rm v1.ResourceMeta, subs map[string]interface{}) error
@@ -349,6 +350,13 @@ func (m *Client) RegisterAccessRequestDefinition(data *v1alpha1.AccessRequestDef
 func (m *Client) UpdateAPIV1ResourceInstance(url string, ri *v1.ResourceInstance) (*v1.ResourceInstance, error) {
 	if m.UpdateAPIV1ResourceInstanceMock != nil {
 		return m.UpdateAPIV1ResourceInstanceMock(url, ri)
+	}
+	return nil, nil
+}
+
+func (m *Client) UpdateResourceInstance(ri *v1.ResourceInstance) (*v1.ResourceInstance, error) {
+	if m.UpdateResourceInstanceMock != nil {
+		return m.UpdateResourceInstanceMock(ri)
 	}
 	return nil, nil
 }

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
@@ -87,14 +87,10 @@ func (a *accessRequestDef) Register() (*v1alpha1.AccessRequestDefinition, error)
 			GroupVersionKind: v1alpha1.AccessRequestDefinitionGVK(),
 			Name:             a.name,
 			Title:            a.title,
-			SubResources: map[string]interface{}{
-				definitions.XAgentDetails: map[string]interface{}{
-					definitions.AttrSpecHash: fmt.Sprint(hashInt),
-				},
-			},
 		},
 		Spec: spec,
 	}
+	util.SetAgentDetailsKey(ard, definitions.AttrSpecHash, fmt.Sprintf("%v", hashInt))
 
 	return a.registerFunc(ard)
 }

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
@@ -86,7 +86,7 @@ func (a *accessRequestDef) Register() (*v1alpha1.AccessRequestDefinition, error)
 	hashInt, _ := util.ComputeHash(spec)
 
 	ard := v1alpha1.NewAccessRequestDefinition(a.name, "")
-	ard.Title = c.title
+	ard.Title = a.title
 	ard.Spec = spec
 
 	util.SetAgentDetailsKey(ard, definitions.AttrSpecHash, fmt.Sprintf("%v", hashInt))

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
@@ -75,15 +75,15 @@ func (a *accessRequestDef) Register() (*v1alpha1.AccessRequestDefinition, error)
 		a.title = a.name
 	}
 
-	if a.name == "" {
-		return nil, fmt.Errorf("must set a name for the access request defintion")
-	}
-
 	spec := v1alpha1.AccessRequestDefinitionSpec{
 		Schema: a.schema,
 	}
 
 	hashInt, _ := util.ComputeHash(spec)
+
+	if a.name == "" {
+		a.name = util.ConvertUnitToString(hashInt)
+	}
 
 	ard := v1alpha1.NewAccessRequestDefinition(a.name, "")
 	ard.Title = a.title

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
@@ -3,7 +3,6 @@ package provisioning
 import (
 	"fmt"
 
-	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/util"
@@ -76,20 +75,20 @@ func (a *accessRequestDef) Register() (*v1alpha1.AccessRequestDefinition, error)
 		a.title = a.name
 	}
 
+	if a.name == "" {
+		return nil, fmt.Errorf("must set a name for the access request defintion")
+	}
+
 	spec := v1alpha1.AccessRequestDefinitionSpec{
 		Schema: a.schema,
 	}
 
 	hashInt, _ := util.ComputeHash(spec)
 
-	ard := &v1alpha1.AccessRequestDefinition{
-		ResourceMeta: v1.ResourceMeta{
-			GroupVersionKind: v1alpha1.AccessRequestDefinitionGVK(),
-			Name:             a.name,
-			Title:            a.title,
-		},
-		Spec: spec,
-	}
+	ard := v1alpha1.NewAccessRequestDefinition(a.name, "")
+	ard.Title = c.title
+	ard.Spec = spec
+
 	util.SetAgentDetailsKey(ard, definitions.AttrSpecHash, fmt.Sprintf("%v", hashInt))
 
 	return a.registerFunc(ard)

--- a/pkg/apic/provisioning/credentialrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/credentialrequestdefinitionbuilder.go
@@ -3,7 +3,6 @@ package provisioning
 import (
 	"fmt"
 
-	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/util"
@@ -120,14 +119,10 @@ func (c *credentialRequestDef) Register() (*v1alpha1.CredentialRequestDefinition
 		c.title = c.name
 	}
 
-	crd := &v1alpha1.CredentialRequestDefinition{
-		ResourceMeta: v1.ResourceMeta{
-			GroupVersionKind: v1alpha1.CredentialRequestDefinitionGVK(),
-			Name:             c.name,
-			Title:            c.title,
-		},
-		Spec: spec,
-	}
+	crd := v1alpha1.NewCredentialRequestDefinition(c.name, "")
+	crd.Title = c.title
+	crd.Spec = spec
+
 	util.SetAgentDetailsKey(crd, definitions.AttrSpecHash, fmt.Sprintf("%v", hashInt))
 
 	return c.registerFunc(crd)

--- a/pkg/apic/provisioning/credentialrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/credentialrequestdefinitionbuilder.go
@@ -123,16 +123,12 @@ func (c *credentialRequestDef) Register() (*v1alpha1.CredentialRequestDefinition
 	crd := &v1alpha1.CredentialRequestDefinition{
 		ResourceMeta: v1.ResourceMeta{
 			GroupVersionKind: v1alpha1.CredentialRequestDefinitionGVK(),
-			Title:            c.title,
 			Name:             c.name,
-			SubResources: map[string]interface{}{
-				definitions.XAgentDetails: map[string]interface{}{
-					definitions.AttrSpecHash: fmt.Sprint(hashInt),
-				},
-			},
+			Title:            c.title,
 		},
 		Spec: spec,
 	}
+	util.SetAgentDetailsKey(crd, definitions.AttrSpecHash, fmt.Sprintf("%v", hashInt))
 
 	return c.registerFunc(crd)
 }

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -123,7 +123,7 @@ func (c *ServiceClient) checkReferencesToAccessRequestDefinition(ard string) int
 	count := 0
 	for _, instanceKey := range c.caches.GetAPIServiceInstanceKeys() {
 		serviceInstance, err := c.caches.GetAPIServiceInstanceByID(instanceKey)
-		if err != nil {
+		if err != nil || serviceInstance == nil {
 			// skip this key as it did not return a service instance
 			continue
 		}

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -1,6 +1,8 @@
 package apic
 
 import (
+	"sort"
+
 	mv1a "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
@@ -112,8 +114,9 @@ func (s *ServiceBody) createAccessRequestDefintion() error {
 		oauthScopes = append(oauthScopes, scope)
 	}
 	if len(oauthScopes) > 0 {
+		// sort the strings for consistent specs
+		sort.Strings(oauthScopes)
 		_, err := provisioning.NewAccessRequestBuilder(s.setAccessRequestDefintion).
-			SetTitle(s.NameToPush).
 			SetSchema(
 				provisioning.NewSchemaBuilder().
 					AddProperty(

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -300,11 +300,13 @@ func MapStringInterfaceToStringString(data map[string]interface{}) map[string]st
 	return newData
 }
 
+// ConvertStringToUint -
 func ConvertStringToUint(val string) uint64 {
 	ret, _ := strconv.ParseUint(val, 10, 64)
 	return ret
 }
 
+// ConvertUnitToString -
 func ConvertUnitToString(val uint64) string {
 	return strconv.FormatUint(val, 10)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -299,3 +299,12 @@ func MapStringInterfaceToStringString(data map[string]interface{}) map[string]st
 	}
 	return newData
 }
+
+func ConvertStringToUint(val string) uint64 {
+	ret, _ := strconv.ParseUint(val, 10, 64)
+	return ret
+}
+
+func ConvertUnitToString(val uint64) string {
+	return strconv.FormatUint(val, 10)
+}


### PR DESCRIPTION
- update how the hash is set on the cred and access request defs
- combine CreateSubResourceScoped and CreateSubResourceUnscoped logic to single method that now returns the data from the last updated sub resource call
- fix use of updateOrCreateResource method to check if hash on central matches hash in resource sent in before updating it and its sub resources
- merge subresources from resource on central and subresources to be updated