### PR TITLE
APIGOV-22760 - bubble up error but do not kill the agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ replace (
 )
 
 retract ( // errored versions
+	[v1.1.21, v1.1.23]
 	v1.1.16
 	[v1.1.4, v1.1.9]
-	[v1.1.21, v1.1.23] 
 )

--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -89,7 +89,7 @@ func (j *discoveryCache) updateAPICache() error {
 			var err error
 			svc, err = j.migrator.Migrate(svc)
 			if err != nil {
-				return fmt.Errorf("failed to migrate service: %s", err)
+				j.logger.Debugf("failed to migrate service: %s", err)
 			}
 		}
 

--- a/pkg/migrate/marketplacemigration.go
+++ b/pkg/migrate/marketplacemigration.go
@@ -56,7 +56,7 @@ func (m *MarketplaceMigration) Migrate(ri *v1.ResourceInstance) (*v1.ResourceIns
 
 	err := m.updateService(ri)
 	if err != nil {
-		return ri, fmt.Errorf("migration marketplace provisioning failed")
+		return ri, fmt.Errorf("migration marketplace provisioning failed: %s", err)
 	}
 
 	return ri, nil


### PR DESCRIPTION
1.  bubble up the agent to .Migrate so the real error is exposed
2.  do not kill the agent, try to do the other apiservices if they exist

@jcollins-axway @tsjohns9 - hopefully i didn't miss the mark on this one.  Dave has an api that didn't have a spec value.  So the migration caught that and bubbled it up.  But it was getting eaten by the last error and that was being displayed.  Beyond that, if the first of many apiservices failed, we exited.  Removed return from the loop to try all the apiservices before returning and do not kill the agent as part of the migration.