### PR TITLE
Update builders for the market place integration

### DIFF
--- a/docs/discovery/provisioning.md
+++ b/docs/discovery/provisioning.md
@@ -159,6 +159,8 @@ type StringPropertyBuilder interface {
   AddEnumValue(value string) StringPropertyBuilder
   // IsEncrypted - Set that this field must be encrypted at rest, used only in credential provisioning schema
   IsEncrypted() StringPropertyBuilder
+  // SetDefaultValue - Define the initial value for the property
+  SetDefaultValue(value string) StringPropertyBuilder
 }
 ```
 
@@ -204,6 +206,8 @@ type NumberPropertyBuilder interface {
   SetMinValue(min float64) NumberPropertyBuilder
   // SetMaxValue - Set the maximum allowed property value
   SetMaxValue(min float64) NumberPropertyBuilder
+  // SetDefaultValue - Define the initial value for the property
+  SetDefaultValue(value float64) NumberPropertyBuilder
 }
 ```
 
@@ -215,7 +219,8 @@ provisioning.NewSchemaPropertyBuilder().
   SetDescription("Description of the Number property.").
   IsNumber().
     SetMinValue(3.14).
-    SetMaxValue(100.5)
+    SetMaxValue(100.5).
+    SetDefaultValue(50.42)
 ```
 
 #### Integer Property Builder
@@ -226,6 +231,8 @@ type IntegerPropertyBuilder interface {
   SetMinValue(min int64) IntegerPropertyBuilder
   // SetMaxValue - Set the maximum allowed property value
   SetMaxValue(min int64) IntegerPropertyBuilder
+  // SetDefaultValue - Define the initial value for the property
+  SetDefaultValue(value int64) IntegerPropertyBuilder
 }
 ```
 
@@ -237,7 +244,8 @@ provisioning.NewSchemaPropertyBuilder().
   SetDescription("Description of the Integer property.").
   IsInteger().
     SetMinValue(10).
-    SetMaxValue(42)
+    SetMaxValue(42).
+    SetDefaultValue(10)
 ```
 
 #### Array Property Builder
@@ -246,7 +254,7 @@ Create an array of property.
 
 ```go
 type ArrayPropertyBuilder interface {
-  // AddItem - Add a item property in the array property
+  // AddItem - Add an item property in the array property
   AddItem(item PropertyBuilder) ArrayPropertyBuilder
   // SetMinItems - Set the minimum number of items in the array property
   SetMinItems(min uint) ArrayPropertyBuilder

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -225,7 +225,7 @@ func (r provAccReq) GetApplicationDetailsValue(key string) string {
 
 // GetAccessRequestDetailsValue returns a value found on the 'x-agent-details' sub resource of the AccessRequest.
 func (r provAccReq) GetAccessRequestDetailsValue(key string) string {
-	if r.appDetails == nil {
+	if r.accessDetails == nil {
 		return ""
 	}
 

--- a/pkg/apic/provisioning/propertybuilder_test.go
+++ b/pkg/apic/provisioning/propertybuilder_test.go
@@ -150,8 +150,8 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 			}},
 		{"Full String property with unsorted enum and first value",
 			NewSchemaPropertyBuilder().
-				SetLabel("The Label").
 				SetName("TheName").
+				SetLabel("The Label").
 				SetDescription("TheDescription").
 				SetRequired().
 				SetHidden().
@@ -160,17 +160,19 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 				IsEncrypted().
 				SetEnumValues([]string{"c", "a", "b"}).
 				AddEnumValue("addedValue").
-				SetFirstEnumValue("firstValue"),
+				SetFirstEnumValue("firstValue").
+				SetDefaultValue("a"),
 			propertyDefinition{
-				Name:        "TheName",
-				Title:       "The Label",
-				Description: "TheDescription",
-				Required:    true,
-				Format:      "hidden",
-				ReadOnly:    true,
-				IsEncrypted: true,
-				Type:        DataTypeString,
-				Enum:        []string{"firstValue", "c", "a", "b", "addedValue"},
+				Name:         "TheName",
+				Title:        "The Label",
+				Description:  "TheDescription",
+				Required:     true,
+				Format:       "hidden",
+				ReadOnly:     true,
+				IsEncrypted:  true,
+				Type:         DataTypeString,
+				Enum:         []string{"firstValue", "c", "a", "b", "addedValue"},
+				DefaultValue: "a",
 			}},
 		{"Full String property with sorted enum and first value",
 			NewSchemaPropertyBuilder().
@@ -185,17 +187,19 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 				SetEnumValues([]string{"c", "a", "b"}).
 				AddEnumValue("addedValue").
 				SetFirstEnumValue("firstValue").
-				SetSortEnumValues(),
+				SetSortEnumValues().
+				SetDefaultValue("a"),
 			propertyDefinition{
-				Name:        "TheName",
-				Title:       "The Label",
-				Description: "TheDescription",
-				Required:    true,
-				Format:      "hidden",
-				ReadOnly:    true,
-				IsEncrypted: true,
-				Type:        DataTypeString,
-				Enum:        []string{"firstValue", "a", "addedValue", "b", "c"},
+				Name:         "TheName",
+				Title:        "The Label",
+				Description:  "TheDescription",
+				Required:     true,
+				Format:       "hidden",
+				ReadOnly:     true,
+				IsEncrypted:  true,
+				Type:         DataTypeString,
+				Enum:         []string{"firstValue", "a", "addedValue", "b", "c"},
+				DefaultValue: "a",
 			}},
 		{"Minimal Number property",
 			NewSchemaPropertyBuilder().
@@ -217,17 +221,19 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 				SetReadOnly().
 				IsNumber().
 				SetMinValue(0.0).
-				SetMaxValue(100.5),
+				SetMaxValue(100.5).
+				SetDefaultValue(50.5),
 			propertyDefinition{
-				Name:        "TheName",
-				Title:       "The Label",
-				Description: "TheDescription",
-				Required:    true,
-				Format:      "hidden",
-				ReadOnly:    true,
-				Type:        DataTypeNumber,
-				Minimum:     getFloat64Pointer(0.0),
-				Maximum:     getFloat64Pointer(100.5),
+				Name:         "TheName",
+				Title:        "The Label",
+				Description:  "TheDescription",
+				Required:     true,
+				Format:       "hidden",
+				ReadOnly:     true,
+				Type:         DataTypeNumber,
+				Minimum:      getFloat64Pointer(0.0),
+				Maximum:      getFloat64Pointer(100.5),
+				DefaultValue: getFloat64Pointer(50.5),
 			}},
 		{"Minimal Integer property",
 			NewSchemaPropertyBuilder().
@@ -249,17 +255,19 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 				SetReadOnly().
 				IsInteger().
 				SetMinValue(0).
-				SetMaxValue(100),
+				SetMaxValue(100).
+				SetDefaultValue(50),
 			propertyDefinition{
-				Name:        "TheName",
-				Title:       "The Label",
-				Description: "TheDescription",
-				Required:    true,
-				Format:      "hidden",
-				ReadOnly:    true,
-				Type:        DataTypeInteger,
-				Minimum:     getFloat64Pointer(0),
-				Maximum:     getFloat64Pointer(100),
+				Name:         "TheName",
+				Title:        "The Label",
+				Description:  "TheDescription",
+				Required:     true,
+				Format:       "hidden",
+				ReadOnly:     true,
+				Type:         DataTypeInteger,
+				Minimum:      getFloat64Pointer(0),
+				Maximum:      getFloat64Pointer(100),
+				DefaultValue: getFloat64Pointer(50),
 			}},
 		{"Minimal Array property",
 			NewSchemaPropertyBuilder().
@@ -306,47 +314,48 @@ func Test_SubscriptionPropertyBuilder_Build_with_valid_values(t *testing.T) {
 				MinItems: getUintPointer(0),
 				MaxItems: getUintPointer(1),
 			}},
-		// {"Minimal Object property",
-		// 	NewSchemaPropertyBuilder().
-		// 		SetName("TheName").
-		// 		IsObject(),
-		// 	propertyDefinition{
-		// 		Name:  "TheName",
-		// 		Title: "TheName",
-		// 		Type:  DataTypeObject,
-		// 	}},
-		// {"Full Object property",
-		// 	NewSchemaPropertyBuilder().
-		// 		SetName("TheName").
-		// 		SetDescription("TheDescription").
-		// 		SetRequired().
-		// 		SetHidden().
-		// 		SetReadOnly().
-		// 		IsObject().
-		// 		AddProperty(NewSchemaPropertyBuilder().
-		// 			SetName("PropertyName").
-		// 			SetRequired().
-		// 			IsString()),
-		// 	propertyDefinition{
-		// 		Name:        "TheName",
-		// 		Title:       "TheName",
-		// 		Description: "TheDescription",
-		// 		Required:    true,
-		// 		Format:      "hidden",
-		// 		ReadOnly:    true,
-		// 		Type:        DataTypeObject,
-		// 		Properties: map[string]propertyDefinition{
-		// 			"PropertyName": {
-		// 				Name:     "PropertyName",
-		// 				Title:    "PropertyName",
-		// 				Type:     DataTypeString,
-		// 				Required: true,
-		// 			},
-		// 		},
-		// 		RequiredProperties: []string{
-		// 			"PropertyName",
-		// 		},
-		// }},
+		{"Minimal Object property",
+			NewSchemaPropertyBuilder().
+				SetName("TheName").
+				IsObject(),
+			propertyDefinition{
+				Name: "TheName",
+				Type: DataTypeObject,
+			}},
+		{"Full Object property",
+			NewSchemaPropertyBuilder().
+				SetName("TheName").
+				SetLabel("The Label").
+				SetDescription("TheDescription").
+				SetRequired().
+				SetHidden().
+				SetReadOnly().
+				IsObject().
+				AddProperty(NewSchemaPropertyBuilder().
+					SetName("PropertyName").
+					SetLabel("Property Label").
+					SetRequired().
+					IsString()),
+			propertyDefinition{
+				Name:        "TheName",
+				Title:       "The Label",
+				Description: "TheDescription",
+				Required:    true,
+				Format:      "hidden",
+				ReadOnly:    true,
+				Type:        DataTypeObject,
+				Properties: map[string]propertyDefinition{
+					"PropertyName": {
+						Name:     "PropertyName",
+						Title:    "Property Label",
+						Type:     DataTypeString,
+						Required: true,
+					},
+				},
+				RequiredProperties: []string{
+					"PropertyName",
+				},
+			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -365,6 +374,11 @@ func Test_SubscriptionPropertyBuilder_Build_with_error(t *testing.T) {
 	}{
 		{"String property without name", NewSchemaPropertyBuilder().
 			IsString(), "without a name"},
+		{"String property with default value not present in enum list", NewSchemaPropertyBuilder().
+			SetName("aString").
+			IsString().
+			SetEnumValues([]string{"a", "b"}).
+			SetDefaultValue("z"), "must be present in the enum list"},
 		{"Number property without name", NewSchemaPropertyBuilder().
 			IsNumber(), "without a name"},
 		{"Number property with min greater than max", NewSchemaPropertyBuilder().
@@ -372,6 +386,16 @@ func Test_SubscriptionPropertyBuilder_Build_with_error(t *testing.T) {
 			IsNumber().
 			SetMinValue(2).
 			SetMaxValue(1), "greater than"},
+		{"Number property with default value greater than max", NewSchemaPropertyBuilder().
+			SetName("aNumber").
+			IsNumber().
+			SetMaxValue(1).
+			SetDefaultValue(2), "must be equal or lower than max value"},
+		{"Number property with default value lower than min", NewSchemaPropertyBuilder().
+			SetName("aNumber").
+			IsNumber().
+			SetMinValue(2).
+			SetDefaultValue(1), "must be equal or greater than min value"},
 		{"Integer property without name", NewSchemaPropertyBuilder().
 			IsInteger(),
 			"without a name"},
@@ -380,6 +404,16 @@ func Test_SubscriptionPropertyBuilder_Build_with_error(t *testing.T) {
 			IsInteger().
 			SetMinValue(2).
 			SetMaxValue(1), "greater than"},
+		{"Integer property with default value greater than max", NewSchemaPropertyBuilder().
+			SetName("aNumber").
+			IsInteger().
+			SetMaxValue(1).
+			SetDefaultValue(2), "must be equal or lower than max value"},
+		{"Integer property with default value lower than min", NewSchemaPropertyBuilder().
+			SetName("aNumber").
+			IsInteger().
+			SetMinValue(2).
+			SetDefaultValue(1), "must be equal or greater than min value"},
 		{"Array property without name", NewSchemaPropertyBuilder().
 			IsArray(), "without a name"},
 		{"Array property with min items greater than max items", NewSchemaPropertyBuilder().
@@ -395,12 +429,12 @@ func Test_SubscriptionPropertyBuilder_Build_with_error(t *testing.T) {
 			SetName("anArray").
 			IsArray().
 			AddItem(NewSchemaPropertyBuilder()), "without a name"},
-		// {"Object property without name", NewSchemaPropertyBuilder().
-		// 	IsObject(), "without a name"},
-		// {"Object property with error on added property", NewSchemaPropertyBuilder().
-		// 	SetName("anObject").
-		// 	IsObject().
-		// 	AddProperty(NewSchemaPropertyBuilder()), "without a name"},
+		{"Object property without name", NewSchemaPropertyBuilder().
+			IsObject(), "without a name"},
+		{"Object property with error on added property", NewSchemaPropertyBuilder().
+			SetName("anObject").
+			IsObject().
+			AddProperty(NewSchemaPropertyBuilder()), "without a name"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -41,7 +41,7 @@ type ServiceBuilder interface {
 	AddServiceEndpoint(protocol, host string, port int32, basePath string) ServiceBuilder
 	SetCredentialRequestDefinitions(credentialRequestDefNames []string) ServiceBuilder
 	AddCredentialRequestDefinition(credentialRequestDefName string) ServiceBuilder
-	SetAccessRequestDefinitionName(accessRequestDefName string) ServiceBuilder
+	SetAccessRequestDefinitionName(accessRequestDefName string, isUnique bool) ServiceBuilder
 
 	SetUnstructuredType(assetType string) ServiceBuilder
 	SetUnstructuredContentType(contentType string) ServiceBuilder
@@ -341,7 +341,8 @@ func (b *serviceBodyBuilder) AddCredentialRequestDefinition(credentialRequestDef
 }
 
 // SetAccessRequestDefinitionName -
-func (b *serviceBodyBuilder) SetAccessRequestDefinitionName(accessRequestDefName string) ServiceBuilder {
+func (b *serviceBodyBuilder) SetAccessRequestDefinitionName(accessRequestDefName string, isUnique bool) ServiceBuilder {
 	b.serviceBody.ardName = accessRequestDefName
+	b.serviceBody.uniqueARD = isUnique
 	return b
 }


### PR DESCRIPTION
Hi,

During the integration of the Streams discovery agent, we updated the Agent-SDK with missing features (regarding the unified catalog):

- add defaultValue for Integer/Number properties
- change SetAccessRequestDefinitionName signature to integrate the uniqueARD boolean (based on the same signature of ServiceBody method)
- fix a potential issue (with a copy/paste typo) in method GetAccessRequestDetailsValue of AccessRequest