### PR TITLE
APIGOV-22588 Update discovery cache to fetch resources based on a watch topic

### DIFF
--- a/pkg/agent/discoverycache.go
+++ b/pkg/agent/discoverycache.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
-	catalog "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/catalog/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/migrate"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 
@@ -13,7 +12,6 @@ import (
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/config"
-	utilErrors "github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
@@ -22,17 +20,14 @@ const (
 )
 
 type discoveryCache struct {
-	envName                  string
 	centralURL               string
 	migrator                 migrate.Migrator
 	logger                   log.FieldLogger
-	instanceCacheLock        *sync.Mutex
-	discoveryCacheLock       *sync.Mutex
 	handlers                 []handler.Handler
-	agentType                config.AgentType
 	isMpEnabled              bool
 	client                   resourceClient
 	additionalDiscoveryFuncs []discoverFunc
+	watchTopic               *mv1.WatchTopic
 }
 
 type resourceClient interface {
@@ -47,7 +42,7 @@ type discoveryOpt func(dc *discoveryCache)
 
 func withAdditionalDiscoverFuncs(funcs ...discoverFunc) discoveryOpt {
 	return func(dc *discoveryCache) {
-		dc.additionalDiscoveryFuncs = funcs
+		dc.additionalDiscoveryFuncs = append(dc.additionalDiscoveryFuncs, funcs...)
 	}
 }
 
@@ -67,6 +62,7 @@ func newDiscoveryCache(
 	cfg config.CentralConfig,
 	client resourceClient,
 	handlers []handler.Handler,
+	watchTopic *mv1.WatchTopic,
 	opts ...discoveryOpt,
 ) *discoveryCache {
 	logger := log.NewFieldLogger().
@@ -74,14 +70,12 @@ func newDiscoveryCache(
 		WithComponent("discoveryCache")
 
 	dc := &discoveryCache{
-		agentType:          cfg.GetAgentType(),
-		instanceCacheLock:  &sync.Mutex{},
-		logger:             logger,
-		discoveryCacheLock: &sync.Mutex{},
-		handlers:           handlers,
-		envName:            cfg.GetEnvironmentName(),
-		centralURL:         cfg.GetURL(),
-		client:             client,
+		logger:                   logger,
+		handlers:                 handlers,
+		centralURL:               cfg.GetURL(),
+		client:                   client,
+		additionalDiscoveryFuncs: make([]discoverFunc, 0),
+		watchTopic:               watchTopic,
 	}
 
 	for _, opt := range opts {
@@ -90,44 +84,11 @@ func newDiscoveryCache(
 	return dc
 }
 
-func (dc *discoveryCache) daFuncs() []discoverFunc {
-	return []discoverFunc{
-		dc.handleAPISvc,
-		dc.handleServiceInstance,
-		dc.handleCategories,
-		dc.handleARD,
-		dc.handleCRD,
-		dc.handleAccessControlList,
-		dc.handleMarketplaceResources,
-	}
-}
-
-func (dc *discoveryCache) taFuncs() []discoverFunc {
-	return []discoverFunc{
-		dc.handleAPISvc,
-		dc.handleServiceInstance,
-		dc.handleMarketplaceResources,
-	}
-}
-
-func (dc *discoveryCache) getDiscoveryFuncs() []discoverFunc {
-	switch dc.agentType {
-	case config.DiscoveryAgent:
-		return dc.daFuncs()
-	case config.TraceabilityAgent:
-		return dc.taFuncs()
-	}
-	return nil
-}
-
 // execute rebuilds the discovery cache
 func (dc *discoveryCache) execute() error {
-	dc.discoveryCacheLock.Lock()
-	defer dc.discoveryCacheLock.Unlock()
-
 	dc.logger.Debug("executing resource cache update job")
 
-	discoveryFuncs := dc.getDiscoveryFuncs()
+	discoveryFuncs := dc.buildDiscoveryFuncs()
 	if dc.additionalDiscoveryFuncs != nil {
 		discoveryFuncs = append(discoveryFuncs, dc.additionalDiscoveryFuncs...)
 	}
@@ -160,197 +121,102 @@ func (dc *discoveryCache) execute() error {
 	return nil
 }
 
-func (dc *discoveryCache) handleAPISvc() error {
-	logger := dc.logger.WithField("kind", "APIService")
-	logger.Trace("fetching API Services and updating cache")
-	svcLink := mv1.NewAPIService("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(svcLink)
+// /apis/management/v1alpha1/environments/v7/apiservicerevisions
 
-	apiServices, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
+func (dc *discoveryCache) buildDiscoveryFuncs() []discoverFunc {
+	resources := make(map[string]discoverFunc)
+	mpResources := make(map[string]discoverFunc)
+
+	for _, filter := range dc.watchTopic.Spec.Filters {
+		f := dc.buildResourceFunc(filter)
+		if isMPResource(filter.Kind) {
+			mpResources[filter.Kind] = f
+		} else {
+			resources[filter.Kind] = f
+		}
 	}
 
-	for _, svc := range apiServices {
-		if dc.migrator != nil {
-			var err error
-			svc, err = dc.migrator.Migrate(svc)
-			if err != nil {
-				dc.logger.Debugf("failed to migrate service: %s", err)
+	var funcs []discoverFunc
+	for _, f := range resources {
+		funcs = append(funcs, f)
+	}
+
+	if dc.isMpEnabled {
+		marketplaceFuncs := dc.buildMarketplaceFuncs(mpResources)
+		funcs = append(funcs, dc.handleMarketplaceFuncs(marketplaceFuncs))
+	}
+
+	return funcs
+}
+
+func (dc *discoveryCache) buildMarketplaceFuncs(mpResources map[string]discoverFunc) []discoverFunc {
+	var marketplaceFuncs []discoverFunc
+
+	mApps, ok := mpResources[mv1.ManagedApplicationGVK().Kind]
+	if ok {
+		marketplaceFuncs = append(marketplaceFuncs, mApps)
+	}
+
+	accessReq, ok := mpResources[mv1.AccessRequestGVK().Kind]
+	if ok {
+		marketplaceFuncs = append(marketplaceFuncs, accessReq)
+	}
+
+	creds, ok := mpResources[mv1.CredentialGVK().Kind]
+	if ok {
+		marketplaceFuncs = append(marketplaceFuncs, creds)
+	}
+
+	return marketplaceFuncs
+}
+
+func (dc *discoveryCache) handleMarketplaceFuncs(marketplaceFuncs []discoverFunc) discoverFunc {
+	return func() error {
+		for _, f := range marketplaceFuncs {
+			if err := f(); err != nil {
+				return err
 			}
 		}
+		return nil
+	}
+}
 
-		action := getAction(svc.Metadata.State)
-		if err := dc.handleResource(svc, action); err != nil {
-			logger.WithError(err).WithField("name", svc.Name).Error("failed to handle api service")
+func (dc *discoveryCache) buildResourceFunc(filter mv1.WatchTopicSpecFilters) discoverFunc {
+	return func() error {
+		url := fmt.Sprintf("/%s/v1alpha1", filter.Group)
+		if filter.Scope != nil {
+			scopePlural, _ := v1.GetPluralFromKind(filter.Scope.Kind)
+			url = fmt.Sprintf("%s/%s/%s", url, scopePlural, filter.Scope.Name)
 		}
-	}
 
-	return nil
-}
+		var kindPlural, _ = v1.GetPluralFromKind(filter.Kind)
+		url = fmt.Sprintf("%s/%s", url, kindPlural)
 
-func (dc *discoveryCache) handleServiceInstance() error {
-	dc.logger.WithField("kind", "APIServiceInstance").Trace("fetching API Service Instances and updating cache")
-	dc.instanceCacheLock.Lock()
-	defer dc.instanceCacheLock.Unlock()
+		logger := dc.logger.WithField("kind", filter.Kind)
+		logger.Tracef("fetching %s and updating cache", filter.Kind)
 
-	svcInstanceLink := mv1.NewAPIServiceInstance("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(svcInstanceLink)
-
-	serviceInstances, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		e := utilErrors.Wrap(ErrUnableToGetAPIV1Resources, err.Error()).FormatError("APIServiceInstances")
-		dc.logger.Error(e)
-		return e
-	}
-
-	return dc.handleResourcesList(serviceInstances)
-}
-
-func (dc *discoveryCache) handleCategories() error {
-	dc.logger.WithField("kind", "Category").Trace("fetching Categories and updating cache")
-
-	categoriesLink := catalog.NewCategory("").GetKindLink()
-	url := dc.formatResourceURL(categoriesLink)
-
-	categories, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(categories)
-}
-
-func (dc *discoveryCache) handleAccessControlList() error {
-	dc.logger.WithField("kind", "AccessControlList").Trace("fetching AccessControlList and updating cache")
-
-	acl, _ := mv1.NewAccessControlList("", mv1.EnvironmentGVK().Kind, dc.envName)
-	aclLink := acl.GetKindLink()
-	url := dc.formatResourceURL(aclLink)
-
-	categories, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(categories)
-}
-
-func (dc *discoveryCache) handleARD() error {
-	if !dc.isMpEnabled {
-		return nil
-	}
-	dc.logger.WithField("kind", "AccessRequestDefinition").Trace("fetching AccessRequestDefinitions and updating cache")
-
-	ardLink := mv1.NewAccessRequestDefinition("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(ardLink)
-
-	ards, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(ards)
-}
-
-func (dc *discoveryCache) handleCRD() error {
-	if !dc.isMpEnabled {
-		return nil
-	}
-
-	dc.logger.WithField("kind", "CredentialRequestDefinition").Trace("fetching CredentialRequestDefinitions and updating cache")
-
-	crd := mv1.NewCredentialRequestDefinition("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(crd)
-
-	crds, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(crds)
-}
-
-func (dc *discoveryCache) handleManagedApp() error {
-	if !dc.isMpEnabled {
-		return nil
-	}
-
-	dc.logger.WithField("kind", "ManagedApplication").Trace("fetching ManagedApplications and updating cache")
-
-	managedAppLink := mv1.NewManagedApplication("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(managedAppLink)
-	managedApps, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(managedApps)
-}
-
-func (dc *discoveryCache) handleAccessRequest() error {
-	if !dc.isMpEnabled {
-		return nil
-	}
-
-	dc.logger.WithField("kind", "AccessRequest").Trace("fetching AccessRequests and updating cache")
-
-	arLink := mv1.NewAccessRequest("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(arLink)
-	accessRequests, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
-
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(accessRequests)
-}
-
-func (dc *discoveryCache) handleCredential() error {
-	if !dc.isMpEnabled {
-		return nil
-	}
-
-	logger := dc.logger.WithField("kind", "Credential")
-	logger.Trace("fetching Credentials and updating cache")
-
-	credLink := mv1.NewCredential("", dc.envName).GetKindLink()
-	url := dc.formatResourceURL(credLink)
-
-	credentials, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(
-		nil, url, apiServerPageSize,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	return dc.handleResourcesList(credentials)
-}
-
-func (dc *discoveryCache) handleMarketplaceResources() error {
-	funcs := []discoverFunc{
-		dc.handleManagedApp,
-		dc.handleAccessRequest,
-	}
-
-	if dc.agentType == config.DiscoveryAgent {
-		funcs = append(funcs, dc.handleCredential)
-	}
-
-	for _, f := range funcs {
-		if err := f(); err != nil {
-			return err
+		url = dc.formatResourceURL(url)
+		resources, err := dc.client.GetAPIV1ResourceInstancesWithPageSize(nil, url, apiServerPageSize)
+		if err != nil {
+			return fmt.Errorf("failed to fetch resources of kind %s: %s", filter.Kind, err)
 		}
-	}
 
-	return nil
+		return dc.handleResourcesList(resources)
+	}
 }
 
 func (dc *discoveryCache) handleResourcesList(list []*apiV1.ResourceInstance) error {
 	for _, ri := range list {
+		if dc.migrator != nil {
+			var err error
+			ri, err = dc.migrator.Migrate(ri)
+			if err != nil {
+				dc.logger.WithError(err).Error("failed to migrate resource")
+			}
+		}
+
 		action := getAction(ri.Metadata.State)
-		if err := dc.handleResource(ri, action); ri != nil {
+		if err := dc.handleResource(ri, action); err != nil {
 			dc.logger.
 				WithError(err).
 				WithField("kind", ri.Kind).
@@ -358,6 +224,7 @@ func (dc *discoveryCache) handleResourcesList(list []*apiV1.ResourceInstance) er
 				Error("failed to handle resource")
 		}
 	}
+
 	return nil
 }
 
@@ -381,4 +248,17 @@ func getAction(state string) proto.Event_Type {
 		return proto.Event_UPDATED
 	}
 	return proto.Event_CREATED
+}
+
+func isMPResource(kind string) bool {
+	switch kind {
+	case mv1.ManagedApplicationGVK().Kind:
+		return true
+	case mv1.AccessRequestGVK().Kind:
+		return true
+	case mv1.CredentialGVK().Kind:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/agent/discoverycache_test.go
+++ b/pkg/agent/discoverycache_test.go
@@ -9,7 +9,6 @@ import (
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
-	catalog "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/catalog/v1alpha1"
 	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
@@ -20,74 +19,46 @@ const envName = "mockEnv"
 
 func TestDiscoveryCache_execute(t *testing.T) {
 	tests := []struct {
-		agentType         config.AgentType
-		name              string
-		mpEnabled         bool
-		svcCount          int
-		instCount         int
-		accessReqDefCount int
-		categoryCount     int
-		crdCount          int
-		aclCount          int
-		managedAppCount   int
-		accessReqCount    int
-		credCount         int
+		agentType       config.AgentType
+		name            string
+		mpEnabled       bool
+		svcCount        int
+		managedAppCount int
+		accessReqCount  int
+		credCount       int
+		withMigration   bool
+		wt              *mv1.WatchTopic
 	}{
 		{
-			name:              "should fetch resources for a discovery agent",
-			agentType:         config.DiscoveryAgent,
-			mpEnabled:         true,
-			svcCount:          2,
-			instCount:         2,
-			categoryCount:     2,
-			accessReqDefCount: 2,
-			crdCount:          2,
-			aclCount:          2,
-			managedAppCount:   2,
-			accessReqCount:    2,
-			credCount:         2,
+			name:            "should fetch resources based on the watch topic",
+			agentType:       config.DiscoveryAgent,
+			mpEnabled:       true,
+			svcCount:        2,
+			managedAppCount: 2,
+			accessReqCount:  2,
+			credCount:       2,
+			wt:              mpWatchTopic,
 		},
 		{
-			name:              "should fetch resources for a discovery agent with marketplace disabled",
-			agentType:         config.DiscoveryAgent,
-			mpEnabled:         false,
-			svcCount:          2,
-			instCount:         2,
-			categoryCount:     2,
-			accessReqDefCount: 0,
-			crdCount:          0,
-			aclCount:          2,
-			managedAppCount:   0,
-			accessReqCount:    0,
-			credCount:         0,
+			name:            "should fetch resources and perform a migration",
+			agentType:       config.DiscoveryAgent,
+			mpEnabled:       true,
+			svcCount:        2,
+			managedAppCount: 2,
+			accessReqCount:  2,
+			credCount:       2,
+			withMigration:   true,
+			wt:              mpWatchTopic,
 		},
 		{
-			name:              "should fetch resources for a traceability agent",
-			agentType:         config.TraceabilityAgent,
-			mpEnabled:         true,
-			svcCount:          2,
-			instCount:         2,
-			categoryCount:     0,
-			accessReqDefCount: 0,
-			crdCount:          0,
-			aclCount:          0,
-			managedAppCount:   2,
-			accessReqCount:    2,
-			credCount:         0,
-		},
-		{
-			name:              "should fetch resources for a traceability agent with marketplace disabled",
-			agentType:         config.TraceabilityAgent,
-			mpEnabled:         false,
-			svcCount:          2,
-			instCount:         2,
-			categoryCount:     0,
-			accessReqDefCount: 0,
-			crdCount:          0,
-			aclCount:          0,
-			managedAppCount:   0,
-			accessReqCount:    0,
-			credCount:         0,
+			name:            "should fetch resources based on the watch topic with marketplace disabled",
+			agentType:       config.TraceabilityAgent,
+			mpEnabled:       false,
+			svcCount:        2,
+			managedAppCount: 0,
+			accessReqCount:  0,
+			credCount:       0,
+			wt:              watchTopicNoMP,
 		},
 	}
 
@@ -101,32 +72,12 @@ func TestDiscoveryCache_execute(t *testing.T) {
 			scopeName := agent.cfg.GetEnvironmentName()
 			c := &mockRIClient{
 				svcs:        newAPIServices(scopeName),
-				instances:   newAPISvcInstance(scopeName),
-				categories:  newCategories(),
-				ards:        newARDs(scopeName),
-				crds:        newCRDs(scopeName),
-				acls:        newAccessControlLists(scopeName),
 				managedApps: newManagedApps(scopeName),
 				accessReqs:  newAccessReqs(scopeName),
 				creds:       newCredentials(scopeName),
 			}
 			svcHandler := &mockHandler{
 				kind: mv1.APIServiceGVK().Kind,
-			}
-			instanceHandler := &mockHandler{
-				kind: mv1.APIServiceInstanceGVK().Kind,
-			}
-			accessReqDefHandler := &mockHandler{
-				kind: mv1.AccessRequestDefinitionGVK().Kind,
-			}
-			categoryHandler := &mockHandler{
-				kind: catalog.CategoryGVK().Kind,
-			}
-			crdHandler := &mockHandler{
-				kind: mv1.CredentialRequestDefinitionGVK().Kind,
-			}
-			aclHandler := &mockHandler{
-				kind: mv1.AccessControlListGVK().Kind,
 			}
 			managedAppHandler := &mockHandler{
 				kind: mv1.ManagedApplicationGVK().Kind,
@@ -140,118 +91,45 @@ func TestDiscoveryCache_execute(t *testing.T) {
 
 			handlers := []handler.Handler{
 				svcHandler,
-				instanceHandler,
-				categoryHandler,
-				accessReqDefHandler,
-				crdHandler,
-				aclHandler,
 				managedAppHandler,
 				accessReqHandler,
 				credHandler,
 			}
-			dc := newDiscoveryCache(
-				cfg,
-				c,
-				handlers,
+
+			opts := []discoveryOpt{
 				withMpEnabled(tc.mpEnabled),
 				withAdditionalDiscoverFuncs(func() error {
 					return nil
 				}),
+			}
+
+			migration := &mig{}
+			if tc.withMigration {
+				opts = append(opts, withMigration(migration))
+			}
+
+			dc := newDiscoveryCache(
+				cfg,
+				c,
+				handlers,
+				tc.wt,
+				opts...,
 			)
 
 			err := dc.execute()
 			assert.Nil(t, err)
 			assert.Equal(t, tc.svcCount, svcHandler.count)
-			assert.Equal(t, tc.instCount, instanceHandler.count)
-			assert.Equal(t, tc.categoryCount, categoryHandler.count)
-			assert.Equal(t, tc.accessReqDefCount, accessReqDefHandler.count)
-			assert.Equal(t, tc.crdCount, crdHandler.count)
-			assert.Equal(t, tc.aclCount, aclHandler.count)
 			assert.Equal(t, tc.managedAppCount, managedAppHandler.count)
 			assert.Equal(t, tc.accessReqCount, accessReqHandler.count)
 			assert.Equal(t, tc.credCount, credHandler.count)
+			if tc.withMigration {
+				assert.True(t, migration.called)
+			} else {
+				assert.False(t, migration.called)
+			}
 		})
 	}
 
-}
-
-func TestDiscoveryCacheWithAdditionalDiscoveryFuncs(t *testing.T) {
-	cfg := createCentralCfg("apicentral.axway.com", envName)
-	cfg.AgentType = config.DiscoveryAgent
-	agent.cacheManager = agentcache.NewAgentCacheManager(agent.cfg, false)
-	agent.cfg = cfg
-	Initialize(cfg)
-	scopeName := agent.cfg.GetEnvironmentName()
-	svcs := newAPIServices(scopeName)
-	c := &mockRIClient{
-		svcs: svcs,
-	}
-	h1 := &mockHandler{}
-	handlers := []handler.Handler{
-		h1,
-	}
-	dc := newDiscoveryCache(cfg, c, handlers)
-
-	err := dc.handleAPISvc()
-	assert.Nil(t, err)
-	assert.Equal(t, len(svcs), h1.count)
-}
-
-func TestDiscoveryCache_handleMarketplaceResources(t *testing.T) {
-	tests := []struct {
-		name      string
-		agentType config.AgentType
-		credCount int
-	}{
-		{
-			name:      "should fetch credentials for a discovery agent",
-			credCount: 2,
-			agentType: config.DiscoveryAgent,
-		},
-		{
-			name:      "should not fetch credentials for a traceability agent",
-			credCount: 0,
-			agentType: config.TraceabilityAgent,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := createCentralCfg("apicentral.axway.com", envName)
-			agent.cacheManager = agentcache.NewAgentCacheManager(agent.cfg, false)
-			agent.cfg = cfg
-			Initialize(cfg)
-			cfg.AgentType = tc.agentType
-
-			scopeName := agent.cfg.GetEnvironmentName()
-			managedApps := newManagedApps(scopeName)
-			accessReqs := newAccessReqs(scopeName)
-			creds := newCredentials(scopeName)
-			c := &mockRIClient{
-				creds:       creds,
-				managedApps: managedApps,
-				accessReqs:  accessReqs,
-			}
-
-			h1 := &mockHandler{
-				kind: mv1.ManagedApplicationGVK().Kind,
-			}
-			h2 := &mockHandler{
-				kind: mv1.AccessRequestGVK().Kind,
-			}
-			h3 := &mockHandler{
-				kind: mv1.CredentialGVK().Kind,
-			}
-			handlers := []handler.Handler{h1, h2, h3}
-			dc := newDiscoveryCache(cfg, c, handlers, withMpEnabled(true))
-
-			err := dc.handleMarketplaceResources()
-			assert.Nil(t, err)
-			assert.Equal(t, len(managedApps), h1.count)
-			assert.Equal(t, len(accessReqs), h2.count)
-			assert.Equal(t, tc.credCount, h3.count)
-		})
-	}
 }
 
 type mockHandler struct {
@@ -276,43 +154,11 @@ func newAPIServices(scope string) []*apiv1.ResourceInstance {
 	}
 }
 
-func newAPISvcInstance(scope string) []*apiv1.ResourceInstance {
-	inst1, _ := mv1.NewAPIServiceInstance("inst1", scope).AsInstance()
-	inst2, _ := mv1.NewAPIServiceInstance("inst2", scope).AsInstance()
-	return []*apiv1.ResourceInstance{
-		inst1, inst2,
-	}
-}
-
-func newCategories() []*apiv1.ResourceInstance {
-	cat1, _ := catalog.NewCategory("cat1").AsInstance()
-	cat2, _ := catalog.NewCategory("cat2").AsInstance()
-	return []*apiv1.ResourceInstance{
-		cat1, cat2,
-	}
-}
-
-func newARDs(scope string) []*apiv1.ResourceInstance {
-	ard1, _ := mv1.NewAccessRequestDefinition("ard1", scope).AsInstance()
-	ard2, _ := mv1.NewAccessRequestDefinition("ard2", scope).AsInstance()
-	return []*apiv1.ResourceInstance{
-		ard1, ard2,
-	}
-}
-
 func newManagedApps(scope string) []*apiv1.ResourceInstance {
 	app1, _ := mv1.NewManagedApplication("app1", scope).AsInstance()
 	app2, _ := mv1.NewManagedApplication("app2", scope).AsInstance()
 	return []*apiv1.ResourceInstance{
 		app1, app2,
-	}
-}
-
-func newCRDs(scope string) []*apiv1.ResourceInstance {
-	crd1, _ := mv1.NewCredentialRequestDefinition("crd1", scope).AsInstance()
-	crd2, _ := mv1.NewCredentialRequestDefinition("crd2", scope).AsInstance()
-	return []*apiv1.ResourceInstance{
-		crd1, crd2,
 	}
 }
 
@@ -332,49 +178,24 @@ func newCredentials(scope string) []*apiv1.ResourceInstance {
 	}
 }
 
-func newAccessControlLists(scope string) []*apiv1.ResourceInstance {
-	acl1, _ := mv1.NewAccessControlList("acl1", mv1.EnvironmentGVK().Kind, scope)
-	inst1, _ := acl1.AsInstance()
-	acl2, _ := mv1.NewAccessControlList("acl2", mv1.EnvironmentGVK().Kind, scope)
-	inst2, _ := acl2.AsInstance()
-	return []*apiv1.ResourceInstance{
-		inst1, inst2,
-	}
-}
-
 type mockRIClient struct {
 	svcs        []*apiv1.ResourceInstance
-	instances   []*apiv1.ResourceInstance
-	categories  []*apiv1.ResourceInstance
-	ards        []*apiv1.ResourceInstance
-	crds        []*apiv1.ResourceInstance
 	managedApps []*apiv1.ResourceInstance
 	accessReqs  []*apiv1.ResourceInstance
 	creds       []*apiv1.ResourceInstance
-	acls        []*apiv1.ResourceInstance
 	err         error
 }
 
 func (m mockRIClient) GetAPIV1ResourceInstancesWithPageSize(_ map[string]string, URL string, _ int) ([]*apiv1.ResourceInstance, error) {
 	fmt.Println(URL)
-	if strings.Contains(URL, "apiserviceinstances") {
-		return m.instances, m.err
-	} else if strings.Contains(URL, "apiservices") {
+	if strings.Contains(URL, "apiservices") {
 		return m.svcs, m.err
-	} else if strings.Contains(URL, "categories") {
-		return m.categories, m.err
-	} else if strings.Contains(URL, "accessrequestdefinitions") {
-		return m.ards, m.err
-	} else if strings.Contains(URL, "credentialrequestdefinitions") {
-		return m.crds, m.err
 	} else if strings.Contains(URL, "managedapplications") {
 		return m.managedApps, m.err
 	} else if strings.Contains(URL, "accessrequests") {
 		return m.accessReqs, m.err
 	} else if strings.Contains(URL, "credentials") {
 		return m.creds, m.err
-	} else if strings.Contains(URL, "accesscontrollists") {
-		return m.acls, m.err
 	}
 	return make([]*apiv1.ResourceInstance, 0), m.err
 }
@@ -386,4 +207,69 @@ type mig struct {
 func (m *mig) Migrate(ri *apiv1.ResourceInstance) (*apiv1.ResourceInstance, error) {
 	m.called = true
 	return ri, nil
+}
+
+var mpWatchTopic = &mv1.WatchTopic{
+	ResourceMeta: apiv1.ResourceMeta{},
+	Owner:        nil,
+	Spec: mv1.WatchTopicSpec{
+		Description: "",
+		Filters: []mv1.WatchTopicSpecFilters{
+			{
+				Group: "management",
+				Kind:  mv1.APIServiceGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: envName,
+				},
+			},
+			{
+				Group: "management",
+				Kind:  mv1.ManagedApplicationGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: envName,
+				},
+			},
+			{
+				Group: "management",
+				Kind:  mv1.AccessRequestGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: envName,
+				},
+			},
+			{
+				Group: "management",
+				Kind:  mv1.CredentialGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: envName,
+				},
+			},
+		},
+	},
+}
+
+var watchTopicNoMP = &mv1.WatchTopic{
+	ResourceMeta: apiv1.ResourceMeta{},
+	Owner:        nil,
+	Spec: mv1.WatchTopicSpec{
+		Description: "",
+		Filters: []mv1.WatchTopicSpecFilters{
+			{
+				Group: "management",
+				Kind:  mv1.APIServiceGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: envName,
+				},
+			},
+		},
+	},
 }

--- a/pkg/agent/poller/client.go
+++ b/pkg/agent/poller/client.go
@@ -7,6 +7,7 @@ import (
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/agent/events"
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
+	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/harvester"
@@ -44,12 +45,9 @@ func NewPollClient(
 	cacheManager agentcache.Manager,
 	onStreamConnection OnStreamConnection,
 	onClientStop onClientStopCb,
+	wt *v1alpha1.WatchTopic,
 	handlers ...handler.Handler,
 ) (*PollClient, error) {
-	wt, err := events.GetWatchTopic(cfg, apiClient)
-	if err != nil {
-		return nil, err
-	}
 
 	seq := events.NewSequenceProvider(cacheManager, wt.Name)
 	hcfg := harvester.NewConfig(cfg, getToken, seq)

--- a/pkg/agent/poller/client_test.go
+++ b/pkg/agent/poller/client_test.go
@@ -35,7 +35,7 @@ func TestPollClientStart(t *testing.T) {
 	}
 
 	cacheManager := agentcache.NewAgentCacheManager(cfg, false)
-	pollClient, err := NewPollClient(httpClient, cfg, getToken, cacheManager, nil, nil)
+	pollClient, err := NewPollClient(httpClient, cfg, getToken, cacheManager, nil, nil, watchTopic)
 	assert.NotNil(t, pollClient)
 	assert.Nil(t, err)
 
@@ -131,4 +131,23 @@ func (m mockHarvester) ReceiveSyncEvents(_ string, _ int64, _ chan *proto.Event)
 		}
 	}
 	return 0, m.err
+}
+
+var watchTopic = &mv1.WatchTopic{
+	ResourceMeta: apiv1.ResourceMeta{},
+	Owner:        nil,
+	Spec: mv1.WatchTopicSpec{
+		Description: "",
+		Filters: []mv1.WatchTopicSpecFilters{
+			{
+				Group: "management",
+				Kind:  mv1.APIServiceGVK().Kind,
+				Name:  "*",
+				Scope: &mv1.WatchTopicSpecScope{
+					Kind: "Environment",
+					Name: "mockEnvName",
+				},
+			},
+		},
+	},
 }

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -62,18 +62,14 @@ func NewStreamerClient(
 	cacheManager agentcache.Manager,
 	onStreamConnection OnStreamConnection,
 	onEventSyncError func(),
+	wt *v1alpha1.WatchTopic,
 	handlers ...handler.Handler,
 ) (*StreamerClient, error) {
 	logger := log.NewFieldLogger().
 		WithPackage("sdk.agent.stream").
 		WithComponent("Client")
+
 	tenant := cfg.GetTenantID()
-
-	wt, err := events.GetWatchTopic(cfg, apiClient)
-	if err != nil {
-		return nil, err
-	}
-
 	host, port := getWatchServiceHostPort(cfg)
 
 	watchCfg := &wm.Config{
@@ -137,7 +133,6 @@ func NewStreamerClient(
 	}
 
 	if cfg.IsFetchOnStartupEnabled() {
-		log.Debug("[INIT] Fetch and cache watch topic resources")
 		loadErr := cacheStartupResources(s)
 		if loadErr != nil {
 			return nil, loadErr

--- a/pkg/apic/auth/apicauth.go
+++ b/pkg/apic/auth/apicauth.go
@@ -378,7 +378,6 @@ func (ptp *platformTokenGetter) Close() error {
 
 // fetchNewToken fetches a new token from the platform and updates the token cache.
 func (ptp *platformTokenGetter) fetchNewToken() (string, error) {
-	log.Debug("[INIT] Get cached token is empty. Try and fetch a new token")
 	privateKey, err := ptp.getPrivateKey()
 	if err != nil {
 		return "", err
@@ -394,7 +393,6 @@ func (ptp *platformTokenGetter) fetchNewToken() (string, error) {
 		*privateKey.Precomputed.Qinv = big.Int{}
 	}()
 
-	log.Debug("[INIT] Get public key")
 	publicKey, err := ptp.getPublicKey()
 	if err != nil {
 		return "", err

--- a/pkg/migrate/attributemigration.go
+++ b/pkg/migrate/attributemigration.go
@@ -77,7 +77,7 @@ func NewAttributeMigration(client client, cfg config.CentralConfig) *AttributeMi
 // that refer to the APIService will all have their attributes updated.
 func (m *AttributeMigration) Migrate(ri *v1.ResourceInstance) (*v1.ResourceInstance, error) {
 	if ri.Kind != mv1a.APIServiceGVK().Kind {
-		return ri, fmt.Errorf("expected resource instance kind to be api service")
+		return ri, nil
 	}
 
 	// skip migration if x-agent-details is found for the service.

--- a/pkg/migrate/marketplacemigration.go
+++ b/pkg/migrate/marketplacemigration.go
@@ -51,7 +51,7 @@ type MarketplaceMigration struct {
 // Migrate -
 func (m *MarketplaceMigration) Migrate(ri *v1.ResourceInstance) (*v1.ResourceInstance, error) {
 	if ri.Kind != mv1a.APIServiceGVK().Kind {
-		return ri, fmt.Errorf("expected resource instance kind to be api service")
+		return ri, nil
 	}
 
 	err := m.updateService(ri)


### PR DESCRIPTION
- Fetch the watch topic before the discovery cache starts
- Create funcs in the discovery cache to fetch resources based on the watch topic
- Maintain the same order for fetching marketplace resources