### PR TITLE
APIGOV-22764 fetch latest sequence ID from harvester before discovery cache starts

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -24,6 +24,7 @@ func resetResources() {
 	agent.cacheManager = nil
 	agent.isInitialized = false
 	agent.apicClient = nil
+	agent.agentFeaturesCfg = nil
 }
 
 func createCentralCfg(url, env string) *config.CentralConfiguration {

--- a/pkg/agent/cache/fetchonstartupresources.go
+++ b/pkg/agent/cache/fetchonstartupresources.go
@@ -10,7 +10,7 @@ const key = "fetch-on-startup"
 func (c *cacheManager) AddFetchOnStartupResources(resources []*v1.ResourceInstance) {
 
 	var allResources []*v1.ResourceInstance
-	if !c.hasKey() {
+	if !c.hasFetchOnStartupKey() {
 		allResources = resources
 	} else {
 		cached, err := c.fetchOnStartup.Get(key)
@@ -31,7 +31,7 @@ func (c *cacheManager) GetAllFetchOnStartupResources() []*v1.ResourceInstance {
 	c.ApplyResourceReadLock()
 	defer c.ReleaseResourceReadLock()
 
-	if c.hasKey() {
+	if c.hasFetchOnStartupKey() {
 		resources, err := c.fetchOnStartup.Get(key)
 		if err != nil {
 			log.Errorf("Error fetching key \"%s\" from cache: %v", key, err)
@@ -43,13 +43,13 @@ func (c *cacheManager) GetAllFetchOnStartupResources() []*v1.ResourceInstance {
 }
 
 func (c *cacheManager) DeleteAllFetchOnStartupResources() error {
-	if c.hasKey() {
+	if c.hasFetchOnStartupKey() {
 		return c.fetchOnStartup.Delete(key)
 	}
 	return nil
 }
 
-func (c *cacheManager) hasKey() bool {
+func (c *cacheManager) hasFetchOnStartupKey() bool {
 	keys := c.fetchOnStartup.GetKeys()
 	return len(keys) == 1 && keys[0] == key
 }

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -141,7 +141,7 @@ func NewAgentCacheManager(cfg config.CentralConfig, persistCacheEnabled bool) Ma
 		accessRequestMap:        cache.New(),
 		subscriptionMap:         cache.New(),
 		sequenceCache:           cache.New(),
-		fetchOnStartup:        cache.New(),
+		fetchOnStartup:          cache.New(),
 		teams:                   cache.New(),
 		ardMap:                  cache.New(),
 		crdMap:                  cache.New(),

--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -78,7 +78,7 @@ func (es *EventSync) SyncCache() error {
 			return err
 		}
 	}
-	return nil
+	return es.startCentralEventProcessor()
 }
 
 func (es *EventSync) initCache() error {
@@ -106,7 +106,7 @@ func (es *EventSync) rebuildCache() {
 
 func (es *EventSync) startCentralEventProcessor() error {
 	if agent.cfg.IsUsingGRPC() {
-		return es.startPollMode()
+		return es.startStreamMode()
 	}
 	return es.startPollMode()
 }

--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/Axway/agent-sdk/pkg/agent/events"
+	"github.com/Axway/agent-sdk/pkg/agent/poller"
+	"github.com/Axway/agent-sdk/pkg/agent/stream"
+	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/harvester"
+	"github.com/Axway/agent-sdk/pkg/migrate"
+)
+
+// EventSync struct for syncing events from central
+type EventSync struct {
+	mpEnabled      bool
+	watchTopic     *mv1.WatchTopic
+	sequence       events.SequenceProvider
+	harvester      harvester.Harvest
+	discoveryCache *discoveryCache
+}
+
+// NewEventSync creates an EventSync
+func NewEventSync() (*EventSync, error) {
+	migrations := []migrate.Migrator{
+		migrate.NewAttributeMigration(agent.apicClient, agent.cfg),
+	}
+
+	isMpEnabled := agent.agentFeaturesCfg != nil && agent.agentFeaturesCfg.MarketplaceProvisioningEnabled()
+
+	if isMpEnabled {
+		marketplaceMigration := migrate.NewMarketplaceMigration(agent.apicClient, agent.cfg, agent.cacheManager)
+		agent.marketplaceMigration = marketplaceMigration
+		migrations = append(migrations, marketplaceMigration)
+	}
+
+	mig := migrate.NewMigrateAll(migrations...)
+
+	opts := []discoveryOpt{
+		withMigration(mig),
+		withMpEnabled(isMpEnabled),
+	}
+
+	if agent.agentResourceManager != nil {
+		opts = append(opts, withAdditionalDiscoverFuncs(agent.agentResourceManager.FetchAgentResource))
+	}
+
+	wt, err := events.GetWatchTopic(agent.cfg, GetCentralClient())
+	if err != nil {
+		return nil, err
+	}
+
+	sequence := events.NewSequenceProvider(agent.cacheManager, wt.Name)
+	hCfg := harvester.NewConfig(agent.cfg, agent.tokenRequester, sequence)
+	hClient := harvester.NewClient(hCfg)
+
+	discoveryCache := newDiscoveryCache(
+		agent.cfg,
+		GetCentralClient(),
+		newHandlers(),
+		wt,
+		opts...,
+	)
+
+	return &EventSync{
+		mpEnabled:      isMpEnabled,
+		watchTopic:     wt,
+		sequence:       sequence,
+		harvester:      hClient,
+		discoveryCache: discoveryCache,
+	}, nil
+}
+
+// SyncCache initializes agent cache and starts the agent in stream or poll mode
+func (es *EventSync) SyncCache() error {
+	if !agent.cacheManager.HasLoadedPersistedCache() {
+		if err := es.initCache(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (es *EventSync) initCache() error {
+	seqID, err := es.harvester.ReceiveSyncEvents(es.watchTopic.GetSelfLink(), 0, nil)
+	if err != nil {
+		return err
+	}
+	// event channel is not ready yet, so subtract one from the latest sequence id to process the event
+	// when the poll/stream client is ready
+	es.sequence.SetSequence(seqID - 1)
+	err = es.discoveryCache.execute()
+	if err != nil {
+		return err
+	}
+	agent.cacheManager.SaveCache()
+	return nil
+}
+
+func (es *EventSync) rebuildCache() {
+	agent.cacheManager.Flush()
+	if err := es.initCache(); err != nil {
+		logger.WithError(err).Error("failed to rebuild cache")
+	}
+}
+
+func (es *EventSync) startCentralEventProcessor() error {
+	if agent.cfg.IsUsingGRPC() {
+		return es.startPollMode()
+	}
+	return es.startPollMode()
+}
+
+func (es *EventSync) startPollMode() error {
+	handlers := newHandlers()
+
+	pc, err := poller.NewPollClient(
+		agent.apicClient,
+		agent.cfg,
+		handlers,
+		poller.WithHarvester(es.harvester, es.sequence, es.watchTopic.GetSelfLink()),
+		poller.WithOnClientStop(es.rebuildCache),
+		poller.WithOnConnect(),
+	)
+
+	if err != nil {
+		return fmt.Errorf("could not start the harvester poll client: %s", err)
+	}
+
+	newEventProcessorJob(pc, "Poll Client")
+
+	return err
+}
+
+func (es *EventSync) startStreamMode() error {
+	handlers := newHandlers()
+
+	sc, err := stream.NewStreamerClient(
+		agent.apicClient,
+		agent.cfg,
+		agent.tokenRequester,
+		handlers,
+		stream.WithOnStreamConnection(),
+		stream.WithEventSyncError(es.rebuildCache),
+		stream.WithWatchTopic(es.watchTopic),
+		stream.WithHarvester(es.harvester, es.sequence),
+		stream.WithCacheManager(agent.cacheManager),
+	)
+
+	if err != nil {
+		return fmt.Errorf("could not start the watch manager: %s", err)
+	}
+
+	agent.streamer = sc
+	newEventProcessorJob(sc, "Stream Client")
+
+	return err
+}

--- a/pkg/agent/eventsync_test.go
+++ b/pkg/agent/eventsync_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"testing"
+
+	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/apic/mock"
+	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventSync_pollMode(t *testing.T) {
+	resetResources()
+	cfg := createCentralCfg("https://abc.com", "mockenv")
+	err := Initialize(cfg)
+
+	mc := &mock.Client{}
+	mc.GetResourceMock = func(url string) (*apiv1.ResourceInstance, error) {
+		wt := v1alpha1.NewWatchTopic("mock-wt")
+		ri, err := wt.AsInstance()
+		return ri, err
+	}
+	InitializeForTest(mc)
+	assert.Nil(t, err)
+
+	es, err := NewEventSync()
+	assert.Nil(t, err)
+	assert.NotNil(t, es.watchTopic)
+	assert.NotNil(t, es.discoveryCache)
+	assert.NotNil(t, es.sequence)
+	assert.NotNil(t, es.harvester)
+
+	es.harvester = &mockHarvester{}
+	err = es.SyncCache()
+	assert.Nil(t, err)
+}
+
+func TestEventSync_streamMode(t *testing.T) {
+	resetResources()
+	cfg := createCentralCfg("https://abc.com", "mockenv")
+	cfg.GRPCCfg = config.GRPCConfig{
+		Enabled:  true,
+		Insecure: true,
+	}
+	err := Initialize(cfg)
+	agent.agentFeaturesCfg = &config.AgentFeaturesConfiguration{
+		ConnectToCentral:        true,
+		ProcessSystemSignals:    true,
+		VersionChecker:          false,
+		PersistCache:            false,
+		MarketplaceProvisioning: true,
+	}
+
+	mc := &mock.Client{}
+	mc.GetResourceMock = func(url string) (*apiv1.ResourceInstance, error) {
+		wt := v1alpha1.NewWatchTopic("mock-wt")
+		ri, err := wt.AsInstance()
+		return ri, err
+	}
+	InitializeForTest(mc)
+	assert.Nil(t, err)
+
+	es, err := NewEventSync()
+	assert.Nil(t, err)
+	assert.NotNil(t, es.watchTopic)
+	assert.NotNil(t, es.discoveryCache)
+	assert.NotNil(t, es.sequence)
+	assert.NotNil(t, es.harvester)
+
+	es.harvester = &mockHarvester{}
+	err = es.SyncCache()
+	assert.Nil(t, err)
+}
+
+type mockHarvester struct{}
+
+func (m mockHarvester) EventCatchUp(link string, events chan *proto.Event) error {
+	return nil
+}
+
+func (m mockHarvester) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, eventCh chan *proto.Event) (int64, error) {
+	return 1, nil
+}

--- a/pkg/agent/poller/client.go
+++ b/pkg/agent/poller/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/harvester"
-	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/errors"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
@@ -35,33 +34,6 @@ type harvesterConfig struct {
 }
 
 type onClientStopCb func()
-
-type ClientOpt func(pc *PollClient)
-
-// WithHarvester configures the polling client to use harvester
-func WithHarvester(hClient harvester.Harvest, sequence events.SequenceProvider, topicSelfLink string) ClientOpt {
-	return func(pc *PollClient) {
-		pc.harvesterConfig.hClient = hClient
-		pc.harvesterConfig.topicSelfLink = topicSelfLink
-		pc.harvesterConfig.sequence = sequence
-	}
-}
-
-// WithOnClientStop func to execute when the client shuts down
-func WithOnClientStop(cb func()) ClientOpt {
-	return func(pc *PollClient) {
-		pc.onClientStop = cb
-	}
-}
-
-// WithOnConnect func to execute when a connection to central is made
-func WithOnConnect() ClientOpt {
-	return func(pc *PollClient) {
-		pc.onStreamConnection = func() {
-			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
-		}
-	}
-}
 
 // NewPollClient creates a polling client
 func NewPollClient(

--- a/pkg/agent/poller/client.go
+++ b/pkg/agent/poller/client.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/agent/events"
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
-	"github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
-	"github.com/Axway/agent-sdk/pkg/apic/auth"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/harvester"
+	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/errors"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
@@ -20,51 +18,70 @@ import (
 type PollClient struct {
 	apiClient          events.APIClient
 	handlers           []handler.Handler
-	hcfg               *harvester.Config
 	interval           time.Duration
 	listener           events.Listener
 	newListener        events.NewListenerFunc
 	onClientStop       onClientStopCb
-	onStreamConnection OnStreamConnection
-	poller             *manager
-	seq                events.SequenceProvider
-	topicSelfLink      string
-	newPollManager     newPollManagerFunc
+	onStreamConnection func()
+	poller             *pollExecutor
+	newPollManager     newPollExecutorFunc
+	harvesterConfig    harvesterConfig
+}
+
+type harvesterConfig struct {
+	sequence      events.SequenceProvider
+	topicSelfLink string
+	hClient       harvester.Harvest
 }
 
 type onClientStopCb func()
 
-// OnStreamConnection func for updating the PollClient after connecting to central
-type OnStreamConnection func(*PollClient)
+type ClientOpt func(pc *PollClient)
+
+// WithHarvester configures the polling client to use harvester
+func WithHarvester(hClient harvester.Harvest, sequence events.SequenceProvider, topicSelfLink string) ClientOpt {
+	return func(pc *PollClient) {
+		pc.harvesterConfig.hClient = hClient
+		pc.harvesterConfig.topicSelfLink = topicSelfLink
+		pc.harvesterConfig.sequence = sequence
+	}
+}
+
+// WithOnClientStop func to execute when the client shuts down
+func WithOnClientStop(cb func()) ClientOpt {
+	return func(pc *PollClient) {
+		pc.onClientStop = cb
+	}
+}
+
+// WithOnConnect func to execute when a connection to central is made
+func WithOnConnect() ClientOpt {
+	return func(pc *PollClient) {
+		pc.onStreamConnection = func() {
+			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
+		}
+	}
+}
 
 // NewPollClient creates a polling client
 func NewPollClient(
 	apiClient events.APIClient,
 	cfg config.CentralConfig,
-	getToken auth.TokenGetter,
-	cacheManager agentcache.Manager,
-	onStreamConnection OnStreamConnection,
-	onClientStop onClientStopCb,
-	wt *v1alpha1.WatchTopic,
-	handlers ...handler.Handler,
+	handlers []handler.Handler,
+	options ...ClientOpt,
 ) (*PollClient, error) {
-
-	seq := events.NewSequenceProvider(cacheManager, wt.Name)
-	hcfg := harvester.NewConfig(cfg, getToken, seq)
-
 	pc := &PollClient{
-		apiClient:          apiClient,
-		handlers:           handlers,
-		hcfg:               hcfg,
-		interval:           cfg.GetPollInterval(),
-		listener:           nil,
-		newListener:        events.NewEventListener,
-		onClientStop:       onClientStop,
-		onStreamConnection: onStreamConnection,
-		poller:             nil,
-		seq:                hcfg.SequenceProvider,
-		topicSelfLink:      wt.GetSelfLink(),
-		newPollManager:     newPollManager,
+		apiClient:      apiClient,
+		handlers:       handlers,
+		interval:       cfg.GetPollInterval(),
+		listener:       nil,
+		newListener:    events.NewEventListener,
+		newPollManager: newPollExecutor,
+		poller:         nil,
+	}
+
+	for _, opt := range options {
+		opt(pc)
 	}
 
 	return pc, nil
@@ -77,19 +94,23 @@ func (p *PollClient) Start() error {
 	p.listener = p.newListener(
 		eventCh,
 		p.apiClient,
-		p.seq,
+		p.harvesterConfig.sequence,
 		p.handlers...,
 	)
 
-	poller := p.newPollManager(p.hcfg, p.interval, p.onClientStop)
+	poller := p.newPollManager(
+		p.interval,
+		withOnStop(p.onClientStop),
+		withHarvester(p.harvesterConfig),
+	)
 	p.poller = poller
 
 	listenCh := p.listener.Listen()
 
-	p.poller.RegisterWatch(p.topicSelfLink, eventCh, eventErrorCh)
+	p.poller.RegisterWatch(eventCh, eventErrorCh)
 
 	if p.onStreamConnection != nil {
-		p.onStreamConnection(p)
+		p.onStreamConnection()
 	}
 
 	select {

--- a/pkg/agent/poller/options.go
+++ b/pkg/agent/poller/options.go
@@ -1,0 +1,52 @@
+package poller
+
+import (
+	"github.com/Axway/agent-sdk/pkg/agent/events"
+	"github.com/Axway/agent-sdk/pkg/harvester"
+	"github.com/Axway/agent-sdk/pkg/util"
+	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
+)
+
+// ClientOpt func for setting fields on the PollClient
+type ClientOpt func(pc *PollClient)
+
+// WithHarvester configures the polling client to use harvester
+func WithHarvester(hClient harvester.Harvest, sequence events.SequenceProvider, topicSelfLink string) ClientOpt {
+	return func(pc *PollClient) {
+		pc.harvesterConfig.hClient = hClient
+		pc.harvesterConfig.topicSelfLink = topicSelfLink
+		pc.harvesterConfig.sequence = sequence
+	}
+}
+
+// WithOnClientStop func to execute when the client shuts down
+func WithOnClientStop(cb func()) ClientOpt {
+	return func(pc *PollClient) {
+		pc.onClientStop = cb
+	}
+}
+
+// WithOnConnect func to execute when a connection to central is made
+func WithOnConnect() ClientOpt {
+	return func(pc *PollClient) {
+		pc.onStreamConnection = func() {
+			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
+		}
+	}
+}
+
+type executorOpt func(m *pollExecutor)
+
+func withHarvester(cfg harvesterConfig) executorOpt {
+	return func(m *pollExecutor) {
+		m.harvester = cfg.hClient
+		m.sequence = cfg.sequence
+		m.topicSelfLink = cfg.topicSelfLink
+	}
+}
+
+func withOnStop(cb onClientStopCb) executorOpt {
+	return func(m *pollExecutor) {
+		m.onStop = cb
+	}
+}

--- a/pkg/agent/poller/poller.go
+++ b/pkg/agent/poller/poller.go
@@ -2,6 +2,7 @@ package poller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent/events"
@@ -10,49 +11,77 @@ import (
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 )
 
-type manager struct {
-	harvester harvester.Harvest
-	logger    log.FieldLogger
-	timer     *time.Timer
-	sequence  events.SequenceProvider
-	ctx       context.Context
-	cancel    context.CancelFunc
-	interval  time.Duration
-	onStop    onClientStopCb
+type pollExecutor struct {
+	harvester     harvester.Harvest
+	sequence      events.SequenceProvider
+	topicSelfLink string
+	logger        log.FieldLogger
+	timer         *time.Timer
+	ctx           context.Context
+	cancel        context.CancelFunc
+	interval      time.Duration
+	onStop        onClientStopCb
 }
 
-type newPollManagerFunc func(cfg *harvester.Config, interval time.Duration, onStop onClientStopCb) *manager
+type newPollExecutorFunc func(interval time.Duration, options ...executorOpt) *pollExecutor
 
-func newPollManager(cfg *harvester.Config, interval time.Duration, onStop onClientStopCb) *manager {
+type executorOpt func(m *pollExecutor)
+
+func withHarvester(cfg harvesterConfig) executorOpt {
+	return func(m *pollExecutor) {
+		m.harvester = cfg.hClient
+		m.sequence = cfg.sequence
+		m.topicSelfLink = cfg.topicSelfLink
+	}
+}
+
+func withOnStop(cb onClientStopCb) executorOpt {
+	return func(m *pollExecutor) {
+		m.onStop = cb
+	}
+}
+
+func newPollExecutor(interval time.Duration, options ...executorOpt) *pollExecutor {
 	logger := log.NewFieldLogger().
-		WithComponent("manager").
+		WithComponent("pollExecutor").
 		WithPackage("sdk.agent.poller")
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &manager{
-		harvester: harvester.NewClient(cfg),
-		logger:    logger,
-		timer:     time.NewTimer(interval),
-		ctx:       ctx,
-		cancel:    cancel,
-		interval:  interval,
-		sequence:  cfg.SequenceProvider,
-		onStop:    onStop,
+	pm := &pollExecutor{
+		logger:   logger,
+		timer:    time.NewTimer(interval),
+		ctx:      ctx,
+		cancel:   cancel,
+		interval: interval,
 	}
+
+	for _, opt := range options {
+		opt(pm)
+	}
+
+	return pm
 }
 
 // RegisterWatch registers a watch topic for polling events and publishing events on a channel
-func (m *manager) RegisterWatch(topic string, eventChan chan *proto.Event, errChan chan error) {
+func (m *pollExecutor) RegisterWatch(eventChan chan *proto.Event, errChan chan error) {
+	if m.harvester == nil {
+		go func() {
+			m.Stop()
+			errChan <- fmt.Errorf("harvester is not configured for the polling client")
+		}()
+		return
+	}
+
 	go func() {
-		err := m.sync(topic, eventChan)
+		err := m.sync(m.topicSelfLink, eventChan)
 		m.Stop()
 		errChan <- err
 	}()
 }
 
-func (m *manager) sync(topic string, eventChan chan *proto.Event) error {
-	if err := m.harvester.EventCatchUp(topic, eventChan); err != nil {
+func (m *pollExecutor) sync(topicSelfLink string, eventChan chan *proto.Event) error {
+	if err := m.harvester.EventCatchUp(topicSelfLink, eventChan); err != nil {
 		m.logger.WithError(err).Error("harvester returned an error when syncing events")
 		m.onHarvesterErr()
 		return err
@@ -64,20 +93,19 @@ func (m *manager) sync(topic string, eventChan chan *proto.Event) error {
 			m.logger.Info("harvester polling has been stopped")
 			return nil
 		case <-m.timer.C:
-			if err := m.tick(topic, eventChan); err != nil {
+			if err := m.tick(topicSelfLink, eventChan); err != nil {
 				return err
 			}
 		}
 	}
 }
 
-func (m *manager) tick(topic string, eventChan chan *proto.Event) error {
-	seq := m.sequence.GetSequence()
-	logger := m.logger.WithField("sequenceID", seq)
+func (m *pollExecutor) tick(topicSelfLink string, eventChan chan *proto.Event) error {
+	sequence := m.sequence.GetSequence()
+	logger := m.logger.WithField("sequenceID", sequence)
 	logger.Debug("retrieving harvester events")
 
-	_, err := m.harvester.ReceiveSyncEvents(topic, seq, eventChan)
-	if err != nil {
+	if _, err := m.harvester.ReceiveSyncEvents(topicSelfLink, sequence, eventChan); err != nil {
 		logger.WithError(err).Error("harvester returned an error when syncing events")
 		m.onHarvesterErr()
 		return err
@@ -87,7 +115,7 @@ func (m *manager) tick(topic string, eventChan chan *proto.Event) error {
 	return nil
 }
 
-func (m *manager) onHarvesterErr() {
+func (m *pollExecutor) onHarvesterErr() {
 	if m.onStop == nil {
 		return
 	}
@@ -96,13 +124,13 @@ func (m *manager) onHarvesterErr() {
 }
 
 // Stop stops the poller
-func (m *manager) Stop() {
+func (m *pollExecutor) Stop() {
 	m.timer.Stop()
 	m.cancel()
 	m.logger.Debug("poller has been stopped")
 }
 
 // Status returns a bool indicating the status of the poller
-func (m *manager) Status() bool {
+func (m *pollExecutor) Status() bool {
 	return m.ctx.Err() == nil
 }

--- a/pkg/agent/poller/poller.go
+++ b/pkg/agent/poller/poller.go
@@ -25,22 +25,6 @@ type pollExecutor struct {
 
 type newPollExecutorFunc func(interval time.Duration, options ...executorOpt) *pollExecutor
 
-type executorOpt func(m *pollExecutor)
-
-func withHarvester(cfg harvesterConfig) executorOpt {
-	return func(m *pollExecutor) {
-		m.harvester = cfg.hClient
-		m.sequence = cfg.sequence
-		m.topicSelfLink = cfg.topicSelfLink
-	}
-}
-
-func withOnStop(cb onClientStopCb) executorOpt {
-	return func(m *pollExecutor) {
-		m.onStop = cb
-	}
-}
-
 func newPollExecutor(interval time.Duration, options ...executorOpt) *pollExecutor {
 	logger := log.NewFieldLogger().
 		WithComponent("pollExecutor").

--- a/pkg/agent/poller/poller_test.go
+++ b/pkg/agent/poller/poller_test.go
@@ -7,6 +7,8 @@ import (
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/agent/events"
 	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/apic/mock"
+	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,4 +58,30 @@ func TestPollerRegisterWatchError(t *testing.T) {
 
 	err := <-errCh
 	assert.NotNil(t, err)
+}
+
+func TestPollClientOptions(t *testing.T) {
+	cfg := config.NewCentralConfig(config.DiscoveryAgent)
+	pc, _ := NewPollClient(
+		&mock.Client{}, cfg, nil,
+		WithHarvester(&mockHarvester{}, &mockSequence{}, "/self/link"),
+		WithOnClientStop(func() {}),
+		WithOnConnect(),
+	)
+
+	assert.NotNil(t, pc.harvesterConfig.hClient)
+	assert.NotNil(t, pc.harvesterConfig.sequence)
+	assert.NotNil(t, pc.harvesterConfig.topicSelfLink)
+	assert.NotNil(t, pc.onClientStop)
+	assert.NotNil(t, pc.onStreamConnection)
+}
+
+type mockSequence struct{}
+
+func (m mockSequence) GetSequence() int64 {
+	return 0
+}
+
+func (m mockSequence) SetSequence(_ int64) {
+
 }

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent/events"
+	"github.com/Axway/agent-sdk/pkg/harvester"
 
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
 	"github.com/Axway/agent-sdk/pkg/util"
@@ -29,9 +30,6 @@ import (
 	wm "github.com/Axway/agent-sdk/pkg/watchmanager"
 )
 
-// OnStreamConnection - callback StreamerClient will invoke after stream connection is established
-type OnStreamConnection func(*StreamerClient)
-
 // StreamerClient client for starting a watch controller stream and handling the events
 type StreamerClient struct {
 	apiClient               events.APIClient
@@ -40,8 +38,8 @@ type StreamerClient struct {
 	manager                 wm.Manager
 	newListener             events.NewListenerFunc
 	newManager              wm.NewManagerFunc
-	onStreamConnection      OnStreamConnection
-	seq                     events.SequenceProvider
+	onStreamConnection      func()
+	sequence                events.SequenceProvider
 	topicSelfLink           string
 	watchCfg                *wm.Config
 	watchOpts               []wm.Option
@@ -52,6 +50,49 @@ type StreamerClient struct {
 	fetchOnStartupRetention time.Duration
 	logger                  log.FieldLogger
 	environmentURL          string
+	wt                      *v1alpha1.WatchTopic
+	harvester               harvester.Harvest
+	onEventSyncError        func()
+}
+
+type StreamOpt func(client *StreamerClient)
+
+// WithWatchTopic sets the watch topic
+func WithWatchTopic(wt *v1alpha1.WatchTopic) StreamOpt {
+	return func(client *StreamerClient) {
+		client.wt = wt
+		client.topicSelfLink = wt.GetSelfLink()
+	}
+}
+
+func WithCacheManager(cache agentcache.Manager) StreamOpt {
+	return func(client *StreamerClient) {
+		client.cacheManager = cache
+	}
+}
+
+// WithHarvester configures the streaming client to use harvester for syncing initial events
+func WithHarvester(hClient harvester.Harvest, sequence events.SequenceProvider) StreamOpt {
+	return func(client *StreamerClient) {
+		client.sequence = sequence
+		client.harvester = hClient
+	}
+}
+
+// WithEventSyncError sets the callback func to run when there is an error syncing events
+func WithEventSyncError(cb func()) StreamOpt {
+	return func(client *StreamerClient) {
+		client.onEventSyncError = cb
+	}
+}
+
+// WithOnStreamConnection func to execute when a connection to central is made
+func WithOnStreamConnection() StreamOpt {
+	return func(pc *StreamerClient) {
+		pc.onStreamConnection = func() {
+			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
+		}
+	}
 }
 
 // NewStreamerClient creates a StreamerClient
@@ -59,11 +100,8 @@ func NewStreamerClient(
 	apiClient events.APIClient,
 	cfg config.CentralConfig,
 	getToken auth.TokenGetter,
-	cacheManager agentcache.Manager,
-	onStreamConnection OnStreamConnection,
-	onEventSyncError func(),
-	wt *v1alpha1.WatchTopic,
-	handlers ...handler.Handler,
+	handlers []handler.Handler,
+	options ...StreamOpt,
 ) (*StreamerClient, error) {
 	logger := log.NewFieldLogger().
 		WithPackage("sdk.agent.stream").
@@ -78,19 +116,35 @@ func NewStreamerClient(
 		TenantID:    tenant,
 		TokenGetter: getToken.GetToken,
 	}
-	seq := events.NewSequenceProvider(cacheManager, wt.Name)
 
-	watchOpts := []wm.Option{
+	s := &StreamerClient{
+		handlers:                handlers,
+		apiClient:               apiClient,
+		watchCfg:                watchCfg,
+		loadOnStartup:           make([]v1alpha1.WatchTopicSpecFilters, 0),
+		newManager:              wm.New,
+		newListener:             events.NewEventListener,
+		logger:                  logger,
+		environmentURL:          cfg.GetEnvironmentURL(),
+		fetchOnStartupPageSize:  cfg.GetFetchOnStartupPageSize(),
+		fetchOnStartupRetention: cfg.GetFetchOnStartupRetention(),
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
+	s.watchOpts = []wm.Option{
 		wm.WithLogger(logrus.NewEntry(log.Get())),
-		wm.WithSyncEvents(seq),
+		wm.WithHarvester(s.harvester, s.sequence),
 		wm.WithProxy(cfg.GetProxyURL()),
-		wm.WithEventSyncError(onEventSyncError),
+		wm.WithEventSyncError(s.onEventSyncError),
 	}
 
 	if cfg.IsGRPCInsecure() {
-		watchOpts = append(watchOpts, wm.WithTLSConfig(nil))
+		s.watchOpts = append(s.watchOpts, wm.WithTLSConfig(nil))
 	} else {
-		watchOpts = append(watchOpts, wm.WithTLSConfig(cfg.GetTLSConfig().BuildTLSConfig()))
+		s.watchOpts = append(s.watchOpts, wm.WithTLSConfig(cfg.GetTLSConfig().BuildTLSConfig()))
 	}
 
 	if cfg.GetSingleURL() != "" {
@@ -101,35 +155,16 @@ func NewStreamerClient(
 		}
 	}
 
-	fetchOnStartup := make([]v1alpha1.WatchTopicSpecFilters, 0)
-	if cfg.IsFetchOnStartupEnabled() {
-		for _, filter := range wt.Spec.Filters {
+	if cfg.IsFetchOnStartupEnabled() && s.wt != nil {
+		for _, filter := range s.wt.Spec.Filters {
 			for _, ftype := range filter.Type {
 				if filter.Scope.Kind == v1alpha1.EnvironmentGVK().Kind &&
 					(ftype == events.WatchTopicFilterTypeCreated || ftype == events.WatchTopicFilterTypeUpdated) {
-					fetchOnStartup = append(fetchOnStartup, filter)
+					s.loadOnStartup = append(s.loadOnStartup, filter)
 					break
 				}
 			}
 		}
-	}
-
-	s := &StreamerClient{
-		handlers:                handlers,
-		apiClient:               apiClient,
-		topicSelfLink:           wt.Metadata.SelfLink,
-		watchCfg:                watchCfg,
-		watchOpts:               watchOpts,
-		loadOnStartup:           fetchOnStartup,
-		newManager:              wm.New,
-		newListener:             events.NewEventListener,
-		seq:                     seq,
-		onStreamConnection:      onStreamConnection,
-		cacheManager:            cacheManager,
-		logger:                  logger,
-		environmentURL:          cfg.GetEnvironmentURL(),
-		fetchOnStartupPageSize:  cfg.GetFetchOnStartupPageSize(),
-		fetchOnStartupRetention: cfg.GetFetchOnStartupRetention(),
 	}
 
 	if cfg.IsFetchOnStartupEnabled() {
@@ -168,7 +203,7 @@ func (s *StreamerClient) Start() error {
 	s.listener = s.newListener(
 		eventCh,
 		s.apiClient,
-		s.seq,
+		s.sequence,
 		s.handlers...,
 	)
 
@@ -187,7 +222,7 @@ func (s *StreamerClient) Start() error {
 	}
 
 	if s.onStreamConnection != nil {
-		s.onStreamConnection(s)
+		s.onStreamConnection()
 	}
 
 	select {

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -55,46 +55,6 @@ type StreamerClient struct {
 	onEventSyncError        func()
 }
 
-type StreamOpt func(client *StreamerClient)
-
-// WithWatchTopic sets the watch topic
-func WithWatchTopic(wt *v1alpha1.WatchTopic) StreamOpt {
-	return func(client *StreamerClient) {
-		client.wt = wt
-		client.topicSelfLink = wt.GetSelfLink()
-	}
-}
-
-func WithCacheManager(cache agentcache.Manager) StreamOpt {
-	return func(client *StreamerClient) {
-		client.cacheManager = cache
-	}
-}
-
-// WithHarvester configures the streaming client to use harvester for syncing initial events
-func WithHarvester(hClient harvester.Harvest, sequence events.SequenceProvider) StreamOpt {
-	return func(client *StreamerClient) {
-		client.sequence = sequence
-		client.harvester = hClient
-	}
-}
-
-// WithEventSyncError sets the callback func to run when there is an error syncing events
-func WithEventSyncError(cb func()) StreamOpt {
-	return func(client *StreamerClient) {
-		client.onEventSyncError = cb
-	}
-}
-
-// WithOnStreamConnection func to execute when a connection to central is made
-func WithOnStreamConnection() StreamOpt {
-	return func(pc *StreamerClient) {
-		pc.onStreamConnection = func() {
-			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
-		}
-	}
-}
-
 // NewStreamerClient creates a StreamerClient
 func NewStreamerClient(
 	apiClient events.APIClient,

--- a/pkg/agent/stream/client_test.go
+++ b/pkg/agent/stream/client_test.go
@@ -8,6 +8,7 @@ import (
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/agent/events"
 	"github.com/Axway/agent-sdk/pkg/agent/handler"
+	"github.com/Axway/agent-sdk/pkg/apic/mock"
 
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
@@ -377,6 +378,23 @@ func TestNewStreamerWithFetchOnStartupWithNamedTopic(t *testing.T) {
 
 }
 
+func TestClientOptions(t *testing.T) {
+	sc, _ := NewStreamerClient(
+		&mock.Client{},
+		config.NewCentralConfig(config.DiscoveryAgent),
+		&mockTokenGetter{},
+		nil,
+		WithHarvester(&mockHarvester{}, &mockSequence{}),
+		WithEventSyncError(func() {
+		}),
+		WithOnStreamConnection(),
+	)
+	assert.NotNil(t, sc.harvester)
+	assert.NotNil(t, sc.sequence)
+	assert.NotNil(t, sc.onEventSyncError)
+	assert.NotNil(t, sc.onStreamConnection)
+}
+
 func stop(t *testing.T, streamer *StreamerClient, errCh chan error) {
 	t.Helper()
 	// should stop the listener and write nil to the listener's error channel
@@ -468,4 +486,24 @@ func (m *mockHandler) Handle(_ context.Context, _ *proto.EventMeta, ri *apiv1.Re
 	}
 	m.received = append(m.received, ri)
 	return m.err
+}
+
+type mockHarvester struct{}
+
+func (m mockHarvester) EventCatchUp(link string, events chan *proto.Event) error {
+	return nil
+}
+
+func (m mockHarvester) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, eventCh chan *proto.Event) (int64, error) {
+	return 0, nil
+}
+
+type mockSequence struct{}
+
+func (m mockSequence) GetSequence() int64 {
+	return 0
+}
+
+func (m mockSequence) SetSequence(sequenceID int64) {
+	return
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -301,8 +301,12 @@ func (c *agentRootCommand) initConfig() error {
 
 	if !c.initialized {
 		if util.IsNotTest() && c.agentFeaturesCfg.ConnectionToCentralEnabled() && !c.centralCfg.GetUsageReportingConfig().IsOfflineMode() {
-			err = agent.SyncCache()
+			eventSync, err := agent.NewEventSync()
 			if err != nil {
+				return errors.Wrap(errors.ErrInitServicesNotReady, err.Error())
+			}
+
+			if err := eventSync.SyncCache(); err != nil {
 				return errors.Wrap(errors.ErrInitServicesNotReady, err.Error())
 			}
 		}

--- a/pkg/harvester/harvesterclient.go
+++ b/pkg/harvester/harvesterclient.go
@@ -143,7 +143,7 @@ func (h *Client) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, event
 
 		for _, event := range pagedEvents {
 			lastID = event.Metadata.GetSequenceID()
-			if !h.skipPublish {
+			if !h.skipPublish || eventCh != nil {
 				eventCh <- event.toProtoEvent()
 			}
 		}

--- a/pkg/harvester/harvesterclient.go
+++ b/pkg/harvester/harvesterclient.go
@@ -123,7 +123,6 @@ func (h *Client) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, event
 		req.Headers["Content-Type"] = "application/json"
 		res, err := h.Client.Send(req)
 		if err != nil {
-			// send signal to discovery cache
 			return lastID, err
 		}
 
@@ -143,7 +142,7 @@ func (h *Client) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, event
 
 		for _, event := range pagedEvents {
 			lastID = event.Metadata.GetSequenceID()
-			if !h.skipPublish || eventCh != nil {
+			if !h.skipPublish && eventCh != nil {
 				eventCh <- event.toProtoEvent()
 			}
 		}

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -1,9 +1,5 @@
 package jobs
 
-import (
-	"github.com/Axway/agent-sdk/pkg/util/log"
-)
-
 type channelJobProps struct {
 	signalStop chan interface{}
 	stopChan   chan bool
@@ -48,7 +44,7 @@ func (b *channelJob) handleExecution() {
 	b.err = b.job.Execute()
 	if b.err != nil {
 		b.setExecutionError()
-		log.Error(b.err)
+		b.baseJob.logger.Error(b.err)
 		b.stop() // stop the job on error
 		b.consecutiveFails++
 	}
@@ -72,14 +68,14 @@ func (b *channelJob) start() {
 //stop - write to the stop channel to stop the execution loop
 func (b *channelJob) stop() {
 	if b.isStopped {
-		log.Tracef("job has already been stopped")
+		b.baseJob.logger.Tracef("job has already been stopped")
 		return
 	}
 	b.stopLog()
 	if b.IsReady() {
-		log.Tracef("writing to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
-		log.Tracef("wrote to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -2,8 +2,6 @@ package jobs
 
 import (
 	"time"
-
-	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
 type intervalJobProps struct {
@@ -35,7 +33,7 @@ func (b *intervalJob) handleExecution() {
 	b.executeCronJob()
 	if b.err != nil {
 		b.setExecutionError()
-		log.Error(b.err)
+		b.logger.Error(b.err)
 		b.SetStatus(JobStatusStopped)
 		b.consecutiveFails++
 	}
@@ -71,9 +69,9 @@ func (b *intervalJob) start() {
 func (b *intervalJob) stop() {
 	b.stopLog()
 	if b.IsReady() {
-		log.Tracef("writing to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
-		log.Tracef("wrote to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gorhill/cronexpr"
 
 	"github.com/Axway/agent-sdk/pkg/util/errors"
-	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
 type scheduleJobProps struct {
@@ -75,9 +74,9 @@ func (b *scheduleJob) start() {
 func (b *scheduleJob) stop() {
 	b.stopLog()
 	if b.IsReady() {
-		log.Tracef("writing to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
-		log.Tracef("wrote to %s stop channel", b.GetName())
+		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 	} else {
 		b.stopReadyChan <- nil
 	}

--- a/pkg/watchmanager/options.go
+++ b/pkg/watchmanager/options.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent/events"
+	"github.com/Axway/agent-sdk/pkg/harvester"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 
@@ -48,8 +49,9 @@ type watchOptions struct {
 	singleEntryAddr  string
 	keepAlive        keepAliveOption
 	loggerEntry      *logrus.Entry
-	sequenceProvider events.SequenceProvider
+	sequence         events.SequenceProvider
 	onEventSyncError eventSyncCb
+	harvester        harvester.Harvest
 }
 
 // newWatchOptions returns the default watchOptions
@@ -107,10 +109,11 @@ func WithLogger(loggerEntry *logrus.Entry) Option {
 	})
 }
 
-// WithSyncEvents allows using the harvester client to sync events on watch registration
-func WithSyncEvents(sequenceGetter events.SequenceProvider) Option {
+// WithHarvester allows using the harvester client to sync events on watch registration
+func WithHarvester(harvester harvester.Harvest, sequence events.SequenceProvider) Option {
 	return funcOption(func(o *watchOptions) {
-		o.sequenceProvider = sequenceGetter
+		o.sequence = sequence
+		o.harvester = harvester
 	})
 }
 

--- a/pkg/watchmanager/options_test.go
+++ b/pkg/watchmanager/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,7 +24,7 @@ func TestWatchOptions(t *testing.T) {
 		WithTLSConfig(nil),
 		WithKeepAlive(1*time.Second, 1*time.Second),
 		WithLogger(entry),
-		WithSyncEvents(&testSequenceProvider{}),
+		WithHarvester(&mockHarvester{}, &testSequenceProvider{}),
 		WithProxy("http://proxy"),
 		WithSingleEntryAddr("single-entry"),
 	}
@@ -38,7 +39,19 @@ func TestWatchOptions(t *testing.T) {
 	assert.Equal(t, entry, options.loggerEntry)
 	assert.Equal(t, 1*time.Second, options.keepAlive.timeout)
 	assert.Equal(t, 1*time.Second, options.keepAlive.time)
-	assert.NotNil(t, options.sequenceProvider)
+	assert.NotNil(t, options.sequence)
 	assert.Equal(t, "http://proxy", options.proxyURL)
 	assert.Equal(t, "single-entry", options.singleEntryAddr)
+}
+
+type mockHarvester struct{}
+
+func (m mockHarvester) EventCatchUp(link string, events chan *proto.Event) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (m mockHarvester) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, eventCh chan *proto.Event) (int64, error) {
+	// TODO implement me
+	panic("implement me")
 }

--- a/samples/watchclient/pkg/client/client.go
+++ b/samples/watchclient/pkg/client/client.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
 	"github.com/Axway/agent-sdk/pkg/cache"
+	corecfg "github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/harvester"
 
 	"github.com/sirupsen/logrus"
 
@@ -59,9 +61,26 @@ func NewWatchClient(config *Config, logger logrus.FieldLogger) (*WatchClient, er
 	if config.Insecure {
 		watchOptions = append(watchOptions, wm.WithTLSConfig(nil))
 	}
-	watchOptions = append(watchOptions, wm.WithSyncEvents(getSequenceManager()))
-
 	ta := auth.NewTokenAuth(config.Auth, config.TenantID)
+
+	ccfg := &corecfg.CentralConfiguration{
+		URL:           config.Host,
+		ClientTimeout: 15,
+		ProxyURL:      "",
+		TenantID:      config.TenantID,
+		TLS:           nil,
+		GRPCCfg: corecfg.GRPCConfig{
+			Enabled:  true,
+			Insecure: config.Insecure,
+			FetchOnStartup: corecfg.FetchOnStartup{
+				Enabled: false,
+			},
+		},
+	}
+
+	hCfg := harvester.NewConfig(ccfg, ta, getSequenceManager())
+	hClient := harvester.NewClient(hCfg)
+	watchOptions = append(watchOptions, wm.WithHarvester(hClient, getSequenceManager()))
 
 	cfg := &wm.Config{
 		Host:        config.Host,


### PR DESCRIPTION
- Created a new component for syncing the cache and starting the stream/poll client.
- Fetch latest sequence ID before the client starts, and before the cache is initialized.
- Updated stream and poll client to take a list of option funcs to reduce the number of defined params