### PR TITLE
APIGOV-23080 - Fix for setting app bucket identifier

### DIFF
--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -254,7 +254,8 @@ func (c *collector) updateMetric(detail Detail) *APIMetric {
 	}
 
 	subscriptionID := subRef.ID
-	appID := c.getApplicationID(managedApp)
+	appDetail := c.createAppDetail(managedApp)
+	appID := appDetail.ID
 	statusCode := detail.StatusCode
 
 	histogram := c.getOrRegisterHistogram("consumer." + subscriptionID + "." + appID + "." + apiID + "." + statusCode)
@@ -282,7 +283,7 @@ func (c *collector) updateMetric(detail Detail) *APIMetric {
 		// setup the start time to be used for reporting metric event
 		statusMap[statusCode] = &APIMetric{
 			Subscription:    c.createSubscriptionDetail(subRef),
-			App:             c.createAppDetail(managedApp),
+			App:             appDetail,
 			API:             c.createAPIDetail(detail.APIDetails, accessRequest),
 			StatusCode:      statusCode,
 			Status:          c.getStatusText(statusCode),
@@ -345,13 +346,6 @@ func (c *collector) createSubscriptionDetail(subRef v1.Reference) SubscriptionDe
 		detail.Name = subRef.Name
 	}
 	return detail
-}
-
-func (c *collector) getApplicationID(app *v1.ResourceInstance) string {
-	if app == nil {
-		return unknown
-	}
-	return app.Metadata.ID
 }
 
 func (c *collector) createAppDetail(app *v1.ResourceInstance) AppDetails {


### PR DESCRIPTION
- Changes to setup app bucket key with the ID of managed app or catalog app. Previously the managedapp metdata.id was being used however the serialized event contained the catalog app id and dues to this the entries from the app bucket were not getting cleaned up correctly