### PR TITLE
APIGOV-23168 - delete credentials that have been marked in Error and CredentialExpired

### DIFF
--- a/pkg/agent/handler/accessrequest_test.go
+++ b/pkg/agent/handler/accessrequest_test.go
@@ -300,6 +300,7 @@ func Test_arReq(t *testing.T) {
 
 type mockClient struct {
 	createSubCalled bool
+	deleteResCalled bool
 	expectedStatus  string
 	getErr          error
 	getARDErr       error
@@ -307,6 +308,7 @@ type mockClient struct {
 	ard             *v1.ResourceInstance
 	isDeleting      bool
 	subError        error
+	delErr          error
 	t               *testing.T
 }
 
@@ -336,6 +338,11 @@ func (m *mockClient) UpdateResourceFinalizer(_ *v1.ResourceInstance, _, _ string
 	return nil, nil
 }
 
+func (m *mockClient) DeleteResourceInstance(ri v1.Interface) error {
+	m.deleteResCalled = true
+	return m.delErr
+}
+
 type mockARProvision struct {
 	expectedAccessDetails map[string]interface{}
 	expectedAPIID         string
@@ -343,6 +350,7 @@ type mockARProvision struct {
 	expectedAppName       string
 	expectedProvType      string
 	expectedStatus        mock.MockRequestStatus
+	statusReasons         []v1.ResourceStatusReason
 	t                     *testing.T
 }
 

--- a/pkg/agent/handler/credential.go
+++ b/pkg/agent/handler/credential.go
@@ -110,7 +110,6 @@ func (h *credentials) getReasonMetaAction(reasons []v1.ResourceStatusReason) str
 
 // shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers
 func (h *credentials) shouldProcessDeleting(status *v1.ResourceStatus, state string, finalizers []v1.Finalizer) bool {
-
 	switch {
 	case len(finalizers) == 0:
 		return false

--- a/pkg/agent/handler/credential.go
+++ b/pkg/agent/handler/credential.go
@@ -108,7 +108,7 @@ func (h *credentials) getReasonMetaAction(reasons []v1.ResourceStatusReason) str
 	return ""
 }
 
-// shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers
+// shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers or when it is in Error and the only reason is CredentialExpired
 func (h *credentials) shouldProcessDeleting(status *v1.ResourceStatus, state string, finalizers []v1.Finalizer) bool {
 	switch {
 	case len(finalizers) == 0:
@@ -230,7 +230,7 @@ func (h *credentials) onDeleting(ctx context.Context, cred *mv1.Credential) {
 		ri, _ := cred.AsInstance()
 		h.client.UpdateResourceFinalizer(ri, crFinalizer, "", false)
 
-		// Delete the resource, since it was not n Deleting State
+		// Delete the resource, since it was not in Deleting State
 		if ri.Metadata.State != v1.ResourceDeleting {
 			h.client.DeleteResourceInstance(ri)
 		}

--- a/pkg/agent/handler/credential.go
+++ b/pkg/agent/handler/credential.go
@@ -27,6 +27,7 @@ type credProv interface {
 }
 
 type credentials struct {
+	marketplaceHandler
 	prov                credProv
 	client              client
 	encryptSchema       encryptSchemaFunc
@@ -49,7 +50,7 @@ func NewCredentialHandler(prov credProv, client client, providerRegistry oauth.P
 // Handle processes grpc events triggered for Credentials
 func (h *credentials) Handle(ctx context.Context, meta *proto.EventMeta, resource *v1.ResourceInstance) error {
 	action := GetActionFromContext(ctx)
-	if resource.Kind != mv1.CredentialGVK().Kind || h.prov == nil || shouldIgnoreSubResourceUpdate(action, meta) {
+	if resource.Kind != mv1.CredentialGVK().Kind || h.prov == nil || h.shouldIgnoreSubResourceUpdate(action, meta) {
 		return nil
 	}
 
@@ -68,7 +69,7 @@ func (h *credentials) Handle(ctx context.Context, meta *proto.EventMeta, resourc
 		return nil
 	}
 
-	if ok := shouldProcessPending(cr.Status.Level, cr.Metadata.State); ok {
+	if ok := h.shouldProcessPending(cr.Status, cr.Metadata.State); ok {
 		log.Trace("processing resource in pending status")
 		ar := h.onPending(ctx, cr)
 		err := h.client.CreateSubResource(cr.ResourceMeta, cr.SubResources)
@@ -86,12 +87,40 @@ func (h *credentials) Handle(ctx context.Context, meta *proto.EventMeta, resourc
 		return err
 	}
 
-	if ok := shouldProcessDeleting(cr.Status.Level, cr.Metadata.State, len(cr.Finalizers)); ok {
+	if ok := h.shouldProcessDeleting(cr.Status, cr.Metadata.State, cr.Finalizers); ok {
 		logger.Trace("processing resource in deleting state")
 		h.onDeleting(ctx, cr)
 	}
 
 	return nil
+}
+
+func (h *credentials) getReasonMetaAction(reasons []v1.ResourceStatusReason) string {
+	if len(reasons) != 1 {
+		return ""
+	}
+	if reasons[0].Meta == nil {
+		return ""
+	}
+	if action, found := reasons[0].Meta["action"]; found {
+		return fmt.Sprintf("%v", action)
+	}
+	return ""
+}
+
+// shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers
+func (h *credentials) shouldProcessDeleting(status *v1.ResourceStatus, state string, finalizers []v1.Finalizer) bool {
+
+	switch {
+	case len(finalizers) == 0:
+		return false
+	case h.marketplaceHandler.shouldProcessDeleting(status, state, finalizers):
+		fallthrough
+	case status.Level == prov.Error.String() && h.getReasonMetaAction(status.Reasons) == "CredentialExpired":
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *credentials) onPending(ctx context.Context, cred *mv1.Credential) *mv1.Credential {
@@ -147,6 +176,7 @@ func (h *credentials) onPending(ctx context.Context, cred *mv1.Credential) *mv1.
 		if err != nil {
 			status = prov.NewRequestStatusBuilder().
 				SetMessage(fmt.Sprintf("error encrypting credential: %s", err.Error())).
+				SetCurrentStatusReasons(cred.Status.Reasons).
 				Failed()
 		} else {
 			cred.Data = data
@@ -200,6 +230,11 @@ func (h *credentials) onDeleting(ctx context.Context, cred *mv1.Credential) {
 
 		ri, _ := cred.AsInstance()
 		h.client.UpdateResourceFinalizer(ri, crFinalizer, "", false)
+
+		// Delete the resource, since it was not n Deleting State
+		if ri.Metadata.State != v1.ResourceDeleting {
+			h.client.DeleteResourceInstance(ri)
+		}
 	} else {
 		err := fmt.Errorf(status.GetMessage())
 		logger.WithError(err).Error("request status was not Success, skipping")
@@ -211,7 +246,7 @@ func (h *credentials) onDeleting(ctx context.Context, cred *mv1.Credential) {
 // onError updates the AccessRequest with an error status
 func (h *credentials) onError(_ context.Context, cred *mv1.Credential, err error) {
 	ps := prov.NewRequestStatusBuilder()
-	status := ps.SetMessage(err.Error()).Failed()
+	status := ps.SetMessage(err.Error()).SetCurrentStatusReasons(cred.Status.Reasons).Failed()
 	cred.Status = prov.NewStatusReason(status)
 	cred.SubResources = map[string]interface{}{
 		"status": cred.Status,

--- a/pkg/agent/handler/credential_test.go
+++ b/pkg/agent/handler/credential_test.go
@@ -623,10 +623,12 @@ type credClient struct {
 	getAppErr       error
 	getCrdErr       error
 	createSubCalled bool
+	deleteResCalled bool
 	subError        error
 	expectedStatus  string
 	t               *testing.T
 	isDeleting      bool
+	delErr          error
 }
 
 func (m *credClient) GetResource(url string) (*v1.ResourceInstance, error) {
@@ -657,6 +659,11 @@ func (m *credClient) UpdateResourceFinalizer(ri *v1.ResourceInstance, _, _ strin
 	}
 
 	return nil, nil
+}
+
+func (m *credClient) DeleteResourceInstance(ri v1.Interface) error {
+	m.deleteResCalled = true
+	return m.delErr
 }
 
 func parsePrivateKey(priv string) *rsa.PrivateKey {

--- a/pkg/agent/handler/handler.go
+++ b/pkg/agent/handler/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
-	prov "github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	corelog "github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 	"github.com/sirupsen/logrus"
@@ -45,6 +44,7 @@ type client interface {
 	GetResource(url string) (*v1.ResourceInstance, error)
 	UpdateResourceFinalizer(ri *v1.ResourceInstance, finalizer, description string, addAction bool) (*v1.ResourceInstance, error)
 	CreateSubResource(rm v1.ResourceMeta, subs map[string]interface{}) error
+	DeleteResourceInstance(ri v1.Interface) error
 }
 
 func isStatusFound(rs *v1.ResourceStatus) bool {
@@ -52,27 +52,6 @@ func isStatusFound(rs *v1.ResourceStatus) bool {
 		return false
 	}
 	return true
-}
-
-func shouldIgnoreSubResourceUpdate(action proto.Event_Type, meta *proto.EventMeta) bool {
-	if meta == nil {
-		return false
-	}
-	return action == proto.Event_SUBRESOURCEUPDATED && meta.Subresource != "status"
-}
-
-// shouldProcessPending returns true when the resource is pending, and is not in a deleting state
-func shouldProcessPending(status, state string) bool {
-	return status == prov.Pending.String() && state != v1.ResourceDeleting
-}
-
-// shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers
-func shouldProcessDeleting(status, state string, finalizerCount int) bool {
-	return status == prov.Success.String() && state == v1.ResourceDeleting && finalizerCount > 0
-}
-
-func shouldProcessForTrace(status, state string) bool {
-	return status == prov.Success.String() && state != v1.ResourceDeleting
 }
 
 // NewEventContext - create a context for the new event

--- a/pkg/agent/handler/marketplacehandler.go
+++ b/pkg/agent/handler/marketplacehandler.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	prov "github.com/Axway/agent-sdk/pkg/apic/provisioning"
+	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
+)
+
+type marketplaceHandler struct{}
+
+func (m *marketplaceHandler) shouldProcessPending(status *v1.ResourceStatus, state string) bool {
+	return status.Level == prov.Pending.String() && state != v1.ResourceDeleting
+}
+
+func (m *marketplaceHandler) shouldIgnoreSubResourceUpdate(action proto.Event_Type, meta *proto.EventMeta) bool {
+	if meta == nil {
+		return false
+	}
+	return action == proto.Event_SUBRESOURCEUPDATED && meta.Subresource != "status"
+}
+
+// shouldProcessDeleting returns true when the resource is in a deleting state and has finalizers
+func (m *marketplaceHandler) shouldProcessDeleting(status *v1.ResourceStatus, state string, finalizers []v1.Finalizer) bool {
+	return status.Level == prov.Success.String() && state == v1.ResourceDeleting && len(finalizers) > 0
+}
+
+func (m *marketplaceHandler) shouldProcessForTrace(status *v1.ResourceStatus, state string) bool {
+	return status.Level == prov.Success.String() && state != v1.ResourceDeleting
+}

--- a/pkg/agent/handler/traceaccessrequest.go
+++ b/pkg/agent/handler/traceaccessrequest.go
@@ -10,6 +10,7 @@ import (
 )
 
 type traceAccessRequestHandler struct {
+	marketplaceHandler
 	cache  agentcache.Manager
 	client client
 }
@@ -44,7 +45,7 @@ func (h *traceAccessRequestHandler) Handle(ctx context.Context, _ *proto.EventMe
 		return nil
 	}
 
-	if shouldProcessForTrace(ar.Status.Level, ar.Metadata.State) {
+	if h.shouldProcessForTrace(ar.Status, ar.Metadata.State) {
 		cachedAccessReq := h.cache.GetAccessRequest(resource.Metadata.ID)
 		if cachedAccessReq == nil {
 			h.cache.AddAccessRequest(resource)

--- a/pkg/agent/handler/tracemanagedapplication.go
+++ b/pkg/agent/handler/tracemanagedapplication.go
@@ -10,6 +10,7 @@ import (
 )
 
 type traceManagedApplication struct {
+	marketplaceHandler
 	cache agentcache.Manager
 }
 
@@ -42,7 +43,7 @@ func (h *traceManagedApplication) Handle(ctx context.Context, _ *proto.EventMeta
 		return nil
 	}
 
-	if shouldProcessForTrace(app.Status.Level, app.Metadata.State) {
+	if h.shouldProcessForTrace(app.Status, app.Metadata.State) {
 		cachedApp := h.cache.GetManagedApplication(resource.Metadata.ID)
 		if cachedApp == nil {
 			h.cache.AddManagedApplication(resource)

--- a/pkg/apic/provisioning/mock/provisioning.go
+++ b/pkg/apic/provisioning/mock/provisioning.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/authz/oauth"
 )
@@ -138,6 +139,7 @@ type MockRequestStatus struct {
 	Msg        string
 	Properties map[string]string
 	Status     provisioning.Status
+	Reasons    []v1.ResourceStatusReason
 }
 
 func (m MockRequestStatus) GetStatus() provisioning.Status {
@@ -150,4 +152,9 @@ func (m MockRequestStatus) GetMessage() string {
 
 func (m MockRequestStatus) GetProperties() map[string]string {
 	return m.Properties
+}
+
+// GetStatus returns the Status level
+func (m MockRequestStatus) GetReasons() []v1.ResourceStatusReason {
+	return m.Reasons
 }

--- a/pkg/apic/provisioning/requeststatus_test.go
+++ b/pkg/apic/provisioning/requeststatus_test.go
@@ -3,18 +3,20 @@ package provisioning_test
 import (
 	"testing"
 
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRequestStatusBuilder(t *testing.T) {
 	tests := []struct {
-		name    string
-		success bool
-		message string
-		propKey string
-		propVal string
-		props   map[string]string
+		name        string
+		success     bool
+		message     string
+		propKey     string
+		propVal     string
+		prevReasons []v1.ResourceStatusReason
+		props       map[string]string
 	}{
 		{
 			name:    "Build Success Status",
@@ -29,12 +31,21 @@ func TestRequestStatusBuilder(t *testing.T) {
 			propKey: "key",
 			propVal: "val",
 			props:   map[string]string{"a": "b"},
+			prevReasons: []v1.ResourceStatusReason{
+				{
+					Type:   "Error",
+					Detail: "detail",
+					Meta: map[string]interface{}{
+						"action": "CredentialExpired",
+					},
+				},
+			},
 			success: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := provisioning.NewRequestStatusBuilder().SetMessage("").AddProperty(tt.propKey, tt.propVal)
+			builder := provisioning.NewRequestStatusBuilder().SetCurrentStatusReasons(tt.prevReasons).SetMessage("").AddProperty(tt.propKey, tt.propVal)
 			if tt.props != nil {
 				builder.SetProperties(tt.props)
 			}
@@ -46,6 +57,16 @@ func TestRequestStatusBuilder(t *testing.T) {
 				req = builder.Failed()
 			}
 
+			assert.EqualValues(t, tt.prevReasons, req.GetReasons())
+			if tt.props != nil {
+				assert.EqualValues(t, tt.props, req.GetProperties())
+			} else {
+				assert.EqualValues(t, map[string]string{tt.propKey: tt.propVal}, req.GetProperties())
+			}
+			assert.NotNil(t, req)
+
+			newReq := provisioning.NewStatusReason(req)
+			assert.EqualValues(t, len(tt.prevReasons)+1, len(newReq.Reasons))
 			assert.NotNil(t, req)
 		})
 	}


### PR DESCRIPTION
- Create base marketplaceHandler to allow the overriding of should* methods
- Add SetCurrentStatusReasons builder method to allow the carry over of previous status reasons
- Add DeleteResourceInstance interface method to to allow handlers to make delete calls