### PR TITLE
APIGOV-23227 - allow implementer the option of setting a lower and upper limit range for a configuration

### DIFF
--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
+	"github.com/Axway/agent-sdk/pkg/cmd/properties"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -59,7 +60,6 @@ func assertDurationCmdFlag(t *testing.T, cmd AgentRootCmd, propertyName, flagNam
 type agentConfig struct {
 	bProp                 bool
 	dProp                 time.Duration
-	rProp                 time.Duration
 	iProp                 int
 	sProp                 string
 	sPropExt              string
@@ -874,7 +874,6 @@ func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
 				agentValidationCalled: false,
 				bProp:                 rootCmd.GetProperties().BoolPropertyValue("agent.bool"),
 				dProp:                 rootCmd.GetProperties().DurationPropertyValue("agent.duration"),
-				rProp:                 rootCmd.GetProperties().DurationPropertyValue("agent.duration.range"),
 				iProp:                 rootCmd.GetProperties().IntPropertyValue("agent.int"),
 				sProp:                 rootCmd.GetProperties().StringPropertyValue("agent.string"),
 				ssProp:                rootCmd.GetProperties().StringSlicePropertyValue("agent.stringSlice"),
@@ -889,14 +888,13 @@ func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
 	os.Setenv("CENTRAL_AUTH_URL", s.URL)
 	os.Setenv("CENTRAL_URL", s.URL)
 	os.Setenv("CENTRAL_SINGLEURL", s.URL)
-	os.Setenv("AGENT_DURATION_RANGE", "5s")
+	os.Setenv("AGENT_DURATION", "15s")
 
 	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", initConfigHandler, nil, corecfg.DiscoveryAgent)
 	viper.AddConfigPath("./testdata")
 
 	rootCmd.GetProperties().AddBoolProperty("agent.bool", false, "Agent Bool Property")
-	rootCmd.GetProperties().AddDurationProperty("agent.duration", 10*time.Second, "Agent Duration Property")
-	rootCmd.GetProperties().AddDurationRangeProperty("agent.duration.range", 10*time.Second, "Agent Duration Property", 11*time.Second, 15*time.Second)
+	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(20*time.Second), properties.WithUpperLimit(30*time.Second))
 	rootCmd.GetProperties().AddIntProperty("agent.int", 0, "Agent Int Property")
 	rootCmd.GetProperties().AddStringProperty("agent.string", "", "Agent String Property")
 	rootCmd.GetProperties().AddStringSliceProperty("agent.stringSlice", nil, "Agent String Slice Property")

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -862,19 +862,21 @@ func newTestServer() *httptest.Server {
 
 func TestLowerAndUpperLimitDurations(t *testing.T) {
 	testCases := []struct {
-		name            string
-		defaultDuration time.Duration
-		description     string
-		lowerLimit      time.Duration
-		upperLimit      time.Duration
+		name             string
+		durationProperty string
+		defaultDuration  time.Duration
+		description      string
+		lowerLimit       time.Duration
+		upperLimit       time.Duration
 	}{
 		{
 			// valid range
-			name:            "agent.duration",
-			defaultDuration: 25 * time.Second,
-			description:     "Agent Duration Property - valid range",
-			lowerLimit:      20 * time.Second,
-			upperLimit:      40 * time.Second,
+			name:             "Agent Duration Property - valid range",
+			durationProperty: "agent.duration",
+			defaultDuration:  25 * time.Second,
+			description:      "Agent Duration Property - valid range",
+			lowerLimit:       20 * time.Second,
+			upperLimit:       40 * time.Second,
 		},
 		{
 			// lower limit is invalid
@@ -882,12 +884,12 @@ func TestLowerAndUpperLimitDurations(t *testing.T) {
 				{"level":"warning","message":"value 30s is lower than the supported lower limit (40s) for configuration agentDuration","time":"2022-07-26T14:42:54-07:00"}
 				{"level":"warning","message":"config agentDuration has been set to the the default value of 25s.","time":"2022-07-26T14:42:54-07:00"}
 			*/
-
-			name:            "agent.duration",
-			defaultDuration: 25 * time.Second,
-			description:     "Agent Duration Property - invalid lower limit",
-			lowerLimit:      40 * time.Second,
-			upperLimit:      50 * time.Second,
+			name:             "Agent Duration Property - invalid lower limit",
+			durationProperty: "agent.duration",
+			defaultDuration:  25 * time.Second,
+			description:      "Agent Duration Property - invalid lower limit",
+			lowerLimit:       40 * time.Second,
+			upperLimit:       50 * time.Second,
 		},
 		{
 			// upper limit is invalid
@@ -895,11 +897,12 @@ func TestLowerAndUpperLimitDurations(t *testing.T) {
 				{"level":"warning","message":"value 30s is higher than the supported higher limit (20s) for configuration agentDuration","time":"2022-07-26T14:42:54-07:00"}
 				{"level":"warning","message":"config agentDuration has been set to the the default value of 30s.","time":"2022-07-26T14:42:54-07:00"}
 			*/
-			name:            "agent.duration",
-			defaultDuration: 30 * time.Second,
-			description:     "Agent Duration Property - invalid upper limit",
-			lowerLimit:      10 * time.Second,
-			upperLimit:      20 * time.Second,
+			name:             "Agent Duration Property - invalid upper limit",
+			durationProperty: "agent.duration",
+			defaultDuration:  30 * time.Second,
+			description:      "Agent Duration Property - invalid upper limit",
+			lowerLimit:       10 * time.Second,
+			upperLimit:       20 * time.Second,
 		},
 	}
 
@@ -932,7 +935,7 @@ func TestLowerAndUpperLimitDurations(t *testing.T) {
 
 			rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", initConfigHandler, nil, corecfg.DiscoveryAgent)
 			viper.AddConfigPath("./testdata")
-			rootCmd.GetProperties().AddDurationProperty(test.name, test.defaultDuration, test.description, properties.WithLowerLimit(test.lowerLimit), properties.WithUpperLimit(test.upperLimit))
+			rootCmd.GetProperties().AddDurationProperty(test.durationProperty, test.defaultDuration, test.description, properties.WithLowerLimit(test.lowerLimit), properties.WithUpperLimit(test.upperLimit))
 			_ = rootCmd.Execute()
 		})
 	}

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -894,7 +894,7 @@ func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
 	viper.AddConfigPath("./testdata")
 
 	rootCmd.GetProperties().AddBoolProperty("agent.bool", false, "Agent Bool Property")
-	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(20*time.Second), properties.WithUpperLimit(30*time.Second))
+	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(5*time.Second), properties.WithUpperLimit(19*time.Second))
 	rootCmd.GetProperties().AddIntProperty("agent.int", 0, "Agent Int Property")
 	rootCmd.GetProperties().AddStringProperty("agent.string", "", "Agent String Property")
 	rootCmd.GetProperties().AddStringSliceProperty("agent.stringSlice", nil, "Agent String Slice Property")

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -860,7 +860,7 @@ func newTestServer() *httptest.Server {
 	return s
 }
 
-func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
+func TestRootCmdAgentValidDuration(t *testing.T) {
 	s := newTestServer()
 	defer s.Close()
 
@@ -872,11 +872,7 @@ func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
 			CentralCfg:             centralConfig,
 			AgentCfg: &agentConfig{
 				agentValidationCalled: false,
-				bProp:                 rootCmd.GetProperties().BoolPropertyValue("agent.bool"),
 				dProp:                 rootCmd.GetProperties().DurationPropertyValue("agent.duration"),
-				iProp:                 rootCmd.GetProperties().IntPropertyValue("agent.int"),
-				sProp:                 rootCmd.GetProperties().StringPropertyValue("agent.string"),
-				ssProp:                rootCmd.GetProperties().StringSlicePropertyValue("agent.stringSlice"),
 			},
 		}
 		return cfg, nil
@@ -893,12 +889,86 @@ func TestRootCmdAgentConfigValidationNotInDurationRange(t *testing.T) {
 	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", initConfigHandler, nil, corecfg.DiscoveryAgent)
 	viper.AddConfigPath("./testdata")
 
-	rootCmd.GetProperties().AddBoolProperty("agent.bool", false, "Agent Bool Property")
-	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(5*time.Second), properties.WithUpperLimit(19*time.Second))
-	rootCmd.GetProperties().AddIntProperty("agent.int", 0, "Agent Int Property")
-	rootCmd.GetProperties().AddStringProperty("agent.string", "", "Agent String Property")
-	rootCmd.GetProperties().AddStringSliceProperty("agent.stringSlice", nil, "Agent String Slice Property")
+	// duration range is valid
+	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(10*time.Second), properties.WithUpperLimit(20*time.Second))
+	_ = rootCmd.Execute()
 
+}
+
+func TestRootCmdAgentInvalidLowerLimit(t *testing.T) {
+	s := newTestServer()
+	defer s.Close()
+
+	var rootCmd AgentRootCmd
+	var cfg *configWithValidation
+	initConfigHandler := func(centralConfig corecfg.CentralConfig) (interface{}, error) {
+		cfg = &configWithValidation{
+			configValidationCalled: false,
+			CentralCfg:             centralConfig,
+			AgentCfg: &agentConfig{
+				agentValidationCalled: false,
+				dProp:                 rootCmd.GetProperties().DurationPropertyValue("agent.duration"),
+			},
+		}
+		return cfg, nil
+	}
+
+	os.Setenv("CENTRAL_AUTH_PRIVATEKEY", "../transaction/testdata/private_key.pem")
+	os.Setenv("CENTRAL_AUTH_PUBLICKEY", "../transaction/testdata/public_key")
+	os.Setenv("CENTRAL_AUTH_CLIENTID", "serviceaccount_1234")
+	os.Setenv("CENTRAL_AUTH_URL", s.URL)
+	os.Setenv("CENTRAL_URL", s.URL)
+	os.Setenv("CENTRAL_SINGLEURL", s.URL)
+	os.Setenv("AGENT_DURATION", "30s")
+
+	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", initConfigHandler, nil, corecfg.DiscoveryAgent)
+	viper.AddConfigPath("./testdata")
+
+	// duration range is invalid.  Lower limit is greater than configured value
+	/*
+		{"level":"warning","message":"value 30s is lower than the supported lower limit (40s) for configuration agentDuration","time":"2022-07-26T11:16:41-07:00"}
+		{"level":"warning","message":"config agentDuration has been set to the the default value of 25s.","time":"2022-07-26T11:16:41-07:00"}
+	*/
+	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithLowerLimit(40*time.Second))
+	_ = rootCmd.Execute()
+
+}
+
+func TestRootCmdAgentInvalidUpperLimit(t *testing.T) {
+	s := newTestServer()
+	defer s.Close()
+
+	var rootCmd AgentRootCmd
+	var cfg *configWithValidation
+	initConfigHandler := func(centralConfig corecfg.CentralConfig) (interface{}, error) {
+		cfg = &configWithValidation{
+			configValidationCalled: false,
+			CentralCfg:             centralConfig,
+			AgentCfg: &agentConfig{
+				agentValidationCalled: false,
+				dProp:                 rootCmd.GetProperties().DurationPropertyValue("agent.duration"),
+			},
+		}
+		return cfg, nil
+	}
+
+	os.Setenv("CENTRAL_AUTH_PRIVATEKEY", "../transaction/testdata/private_key.pem")
+	os.Setenv("CENTRAL_AUTH_PUBLICKEY", "../transaction/testdata/public_key")
+	os.Setenv("CENTRAL_AUTH_CLIENTID", "serviceaccount_1234")
+	os.Setenv("CENTRAL_AUTH_URL", s.URL)
+	os.Setenv("CENTRAL_URL", s.URL)
+	os.Setenv("CENTRAL_SINGLEURL", s.URL)
+	os.Setenv("AGENT_DURATION", "30s")
+
+	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", initConfigHandler, nil, corecfg.DiscoveryAgent)
+	viper.AddConfigPath("./testdata")
+
+	// duration range is invalid.  Upper limit is less than configured value
+	/*
+		{"level":"warning","message":"value 30s is higher than the supported higher limit (20s) for configuration agentDuration","time":"2022-07-26T11:15:48-07:00"}
+		{"level":"warning","message":"config agentDuration has been set to the the default value of 25s.","time":"2022-07-26T11:15:48-07:00"}
+	*/
+	rootCmd.GetProperties().AddDurationProperty("agent.duration", 25*time.Second, "Agent Duration Property", properties.WithUpperLimit(20*time.Second))
 	_ = rootCmd.Execute()
 
 }

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -194,7 +194,7 @@ func (p *properties) AddDurationProperty(name string, defaultVal time.Duration, 
 	}
 }
 
-// AddDurationProperty - add duration property to the config
+// AddDurationRangeProperty - add duration property to the config
 // defaultVal - when not set by configs, the default value of the duration
 // lowerLimitVal - lower range of the duration
 // upperLimitVal - upper range of the duration

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -41,6 +41,7 @@ type Properties interface {
 	AddStringPersistentFlag(name string, defaultVal string, description string)
 	AddStringFlag(name string, description string)
 	AddDurationProperty(name string, defaultVal time.Duration, description string)
+	AddDurationRangeProperty(name string, defaultVal time.Duration, description string, lowerLimit, upperLimit time.Duration)
 	AddIntProperty(name string, defaultVal int, description string)
 	AddBoolProperty(name string, defaultVal bool, description string)
 	AddBoolFlag(name, description string)
@@ -369,6 +370,7 @@ func (p *properties) DurationPropertyValue(name string) time.Duration {
 		if !p.isInDurationRange(d, flagName) {
 			// If its not in duration range, set value to default
 			d, _ = time.ParseDuration(flag.DefValue)
+			log.Warnf("config %s has been set to the the default value of %s.", flagName, d)
 		}
 	} else {
 		// AddDurationProperty was implemented for this property value
@@ -380,7 +382,7 @@ func (p *properties) DurationPropertyValue(name string) time.Duration {
 			if d >= lowerLimit {
 				// if defaultValue is > 30s, then just set the lower limit
 				d = lowerLimit
-				log.Warnf("config %s has been set to the lower limit value of %s. Please update this value greater than the lower limit if necessary", name, d)
+				log.Warnf("Configuration %s has been set to the lower limit value of %s. Please update this value greater than the lower limit if necessary", name, d)
 			}
 		}
 	}
@@ -400,6 +402,7 @@ func (p *properties) isDurationRangeImplemented(duration time.Duration, flagName
 
 	if (lowerLimitFlag != nil) && (upperLimitFlag) != nil {
 		// duration range set
+		log.Tracef("Duration range has been set for property %s", flagName)
 		return true
 	}
 
@@ -423,7 +426,7 @@ func (p *properties) isInDurationRange(duration time.Duration, flagName string) 
 	}
 
 	// Warn that the user set value is out of range, and return false to set default value
-	log.Warnf("config %s has been set to the the default value of %s. The current value does not fall between the config range of the lower limit %s and upper limit of %s.", flagName, duration, lowerLimitDuration, upperLimitDuration)
+	log.Warnf("The configuration value for %s does not fall between the lower limit of %s and upper limit of %s.", flagName, lowerLimitDuration, upperLimitDuration)
 	return false
 }
 

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -41,7 +41,6 @@ type Properties interface {
 	AddStringPersistentFlag(name string, defaultVal string, description string)
 	AddStringFlag(name string, description string)
 	AddDurationProperty(name string, defaultVal time.Duration, description string, options ...durationOpt)
-	AddDurationRangeProperty(name string, defaultVal time.Duration, description string, lowerLimit, upperLimit time.Duration)
 	AddIntProperty(name string, defaultVal int, description string)
 	AddBoolProperty(name string, defaultVal bool, description string)
 	AddBoolFlag(name, description string)
@@ -68,7 +67,7 @@ type Properties interface {
 	SetAliasKeyPrefix(aliasKeyPrefix string)
 }
 
-// durationOpt - options passed into AddDurationProperty
+// durationOpt are options passed into AddDurationProperty
 type durationOpt func(prop *properties)
 
 // WithLowerLimit - lower limit of the duration range
@@ -375,7 +374,7 @@ func (p *properties) DurationPropertyValue(name string) time.Duration {
 	flagName := p.nameToFlagName(name)
 	flag := p.rootCmd.Flag(flagName)
 
-	// Check if AddDurationRangeProperty was implemented for this property value
+	// Check if optional duration range funcs were implemented for this property value
 	if p.isDurationRangeImplemented(d, flagName) {
 		if !p.isInDurationRange(d, flagName) {
 			// If its not in duration range, set value to default
@@ -401,7 +400,7 @@ func (p *properties) DurationPropertyValue(name string) time.Duration {
 	return d
 }
 
-// Check to see if the user set a lower limit and upper limit range by implementing AddDurationRangeProperty
+// Check to see if the user set a lower limit and upper limit range by implementing options duration range funcs
 func (p *properties) isDurationRangeImplemented(duration time.Duration, flagName string) bool {
 	// range values
 	lowerLimitName := fmt.Sprintf(lowerLimitName, flagName)

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -393,26 +393,21 @@ func (p *properties) validateLowerAndUpperLimits(duration time.Duration, flagNam
 	lowerLimitFlag := p.rootCmd.Flag(fmt.Sprintf(lowerLimitName, flagName))
 	upperLimitFlag := p.rootCmd.Flag(fmt.Sprintf(upperLimitName, flagName))
 
-	var lowerLimitDuration time.Duration
-	var upperLimitDuration time.Duration
-
 	if lowerLimitFlag != nil {
-		lowerLimitDuration, _ = time.ParseDuration(lowerLimitFlag.Value.String())
+		lowerLimitDuration, _ := time.ParseDuration(lowerLimitFlag.Value.String())
+		// validate that lower limit is greater than zero and less than configured duration
+		if lowerLimitDuration > 0 && lowerLimitDuration > duration {
+			log.Warnf(lowerLimitFlag.Usage, duration, lowerLimitDuration, flagName)
+			return false
+		}
 	}
 	if upperLimitFlag != nil {
-		upperLimitDuration, _ = time.ParseDuration(upperLimitFlag.Value.String())
-	}
-
-	// validate that lower limit is greater than zero and less than configured duration
-	if lowerLimitDuration > 0 && lowerLimitDuration > duration {
-		log.Warnf(lowerLimitFlag.Usage, duration, lowerLimitDuration, flagName)
-		return false
-	}
-
-	// validate that upper limit is greater than zero and greater than configured duration
-	if upperLimitDuration > 0 && upperLimitDuration < duration {
-		log.Warnf(upperLimitFlag.Usage, duration, upperLimitDuration, flagName)
-		return false
+		upperLimitDuration, _ := time.ParseDuration(upperLimitFlag.Value.String())
+		// validate that upper limit is greater than zero and greater than configured duration
+		if upperLimitDuration > 0 && upperLimitDuration < duration {
+			log.Warnf(upperLimitFlag.Usage, duration, upperLimitDuration, flagName)
+			return false
+		}
 	}
 
 	log.Tracef("Duration range has been set for property %s", flagName)

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -68,14 +68,17 @@ type Properties interface {
 	SetAliasKeyPrefix(aliasKeyPrefix string)
 }
 
+// durationOpt - options passed into AddDurationProperty
 type durationOpt func(prop *properties)
 
+// WithLowerLimit - lower limit of the duration range
 func WithLowerLimit(lowerLimit time.Duration) durationOpt {
 	return func(prop *properties) {
 		prop.lowerLimit = lowerLimit
 	}
 }
 
+// WithUpperLimit - upper limit of the duration range
 func WithUpperLimit(upperLimit time.Duration) durationOpt {
 	return func(prop *properties) {
 		prop.upperLimit = upperLimit

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -391,7 +391,7 @@ func (p *properties) DurationPropertyValue(name string) time.Duration {
 	return d
 }
 
-// Check to see if the user set duration is between the lower limit and upper limit range by implementing AddDurationRangeProperty
+// Check to see if the user set a lower limit and upper limit range by implementing AddDurationRangeProperty
 func (p *properties) isDurationRangeImplemented(duration time.Duration, flagName string) bool {
 	// range values
 	lowerLimitName := fmt.Sprintf(lowerLimitName, flagName)
@@ -409,6 +409,7 @@ func (p *properties) isDurationRangeImplemented(duration time.Duration, flagName
 	return false
 }
 
+// Check to see if the user configured duration is between the lower limit and upper limit
 func (p *properties) isInDurationRange(duration time.Duration, flagName string) bool {
 	// range values
 	lowerLimitName := fmt.Sprintf(lowerLimitName, flagName)

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -40,7 +40,7 @@ type Properties interface {
 	AddStringProperty(name string, defaultVal string, description string)
 	AddStringPersistentFlag(name string, defaultVal string, description string)
 	AddStringFlag(name string, description string)
-	AddDurationProperty(name string, defaultVal time.Duration, description string, options ...durationOpt)
+	AddDurationProperty(name string, defaultVal time.Duration, description string, options ...DurationOpt)
 	AddIntProperty(name string, defaultVal int, description string)
 	AddBoolProperty(name string, defaultVal bool, description string)
 	AddBoolFlag(name, description string)
@@ -67,18 +67,18 @@ type Properties interface {
 	SetAliasKeyPrefix(aliasKeyPrefix string)
 }
 
-// durationOpt are options passed into AddDurationProperty
-type durationOpt func(prop *properties)
+// DurationOpt are duration range options passed into AddDurationProperty
+type DurationOpt func(prop *properties)
 
 // WithLowerLimit - lower limit of the duration range
-func WithLowerLimit(lowerLimit time.Duration) durationOpt {
+func WithLowerLimit(lowerLimit time.Duration) DurationOpt {
 	return func(prop *properties) {
 		prop.lowerLimit = lowerLimit
 	}
 }
 
 // WithUpperLimit - upper limit of the duration range
-func WithUpperLimit(upperLimit time.Duration) durationOpt {
+func WithUpperLimit(upperLimit time.Duration) DurationOpt {
 	return func(prop *properties) {
 		prop.upperLimit = upperLimit
 	}
@@ -203,7 +203,7 @@ func (p *properties) AddStringSliceProperty(name string, defaultVal []string, de
 	}
 }
 
-func (p *properties) AddDurationProperty(name string, defaultVal time.Duration, description string, options ...durationOpt) {
+func (p *properties) AddDurationProperty(name string, defaultVal time.Duration, description string, options ...DurationOpt) {
 	if p.rootCmd != nil {
 		flagName := p.nameToFlagName(name)
 


### PR DESCRIPTION
1.  Add new options WithXXXLimit to func AddDurationProperty.  It takes a lower limit and upper limit time.Duration range

2. When implemented, a duration property will contain a lower limit and upper limit function.  It will only be added as a property if the lower limit is less than the upper limit.  And neither of the limits are zero.  When added, new property name and flags will be created for this range

3. DOES not remove logic for - qaEnforceDurationLowerLimit = "QA_ENFORCE_DURATION_LOWER_LIMIT"

4. Validation checks to see if the user entered config is between range

5. If it is, NOP

6. If it is not, then warn user that the set config is not within range and pick up DEFAULT setting

7. Update tests (to check warning).  Function does not return error