### PR TITLE
APIGOV-23150 - Changes to create/update watch topic with custom filters 

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -442,6 +442,7 @@ func newHandlers() []handler.Handler {
 		handler.NewAPISvcHandler(agent.cacheManager),
 		handler.NewInstanceHandler(agent.cacheManager),
 		handler.NewAgentResourceHandler(agent.agentResourceManager),
+		handler.NewWatchResourceHandler(agent.cacheManager, agent.cfg),
 		agent.proxyResourceHandler,
 	}
 

--- a/pkg/agent/cache/accessrequest.go
+++ b/pkg/agent/cache/accessrequest.go
@@ -28,12 +28,9 @@ func (c *cacheManager) AddAccessRequest(ri *v1.ResourceInstance) {
 
 	appName := ar.Spec.ManagedApplication
 	instID := ""
-	for _, ref := range ar.Metadata.References {
-		if ref.Name == ar.Spec.ApiServiceInstance {
-			instID = ref.ID
-			break
-		}
-	}
+
+	instRef := ar.GetReferenceByGVK(management.APIServiceInstanceGVK())
+	instID = instRef.ID
 
 	instance, _ := c.GetAPIServiceInstanceByID(instID)
 	apiID := ""

--- a/pkg/agent/cache/accessrequest_test.go
+++ b/pkg/agent/cache/accessrequest_test.go
@@ -16,8 +16,8 @@ func createAccessRequest(id, name, appName, instanceID, instanceName string) *ma
 				ID: id,
 				References: []v1.Reference{
 					{
-						Group: mv1.APIServiceInstanceGVK().Group,
-						Kind:  mv1.APIServiceInstanceGVK().Kind,
+						Group: management.APIServiceInstanceGVK().Group,
+						Kind:  management.APIServiceInstanceGVK().Kind,
 						ID:    instanceID,
 						Name:  instanceName,
 					},

--- a/pkg/agent/cache/accessrequest_test.go
+++ b/pkg/agent/cache/accessrequest_test.go
@@ -16,8 +16,10 @@ func createAccessRequest(id, name, appName, instanceID, instanceName string) *ma
 				ID: id,
 				References: []v1.Reference{
 					{
-						ID:   instanceID,
-						Name: instanceName,
+						Group: mv1.APIServiceInstanceGVK().Group,
+						Kind:  mv1.APIServiceInstanceGVK().Kind,
+						ID:    instanceID,
+						Name:  instanceName,
 					},
 				},
 			},

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -95,6 +95,13 @@ type Manager interface {
 	GetAccessRequest(id string) *v1.ResourceInstance
 	DeleteAccessRequest(id string) error
 
+	GetWatchResourceCacheKeys(group, kind string) []string
+	AddWatchResource(resource *v1.ResourceInstance)
+	GetWatchResourceByKey(key string) *v1.ResourceInstance
+	GetWatchResourceByID(group, kind, id string) *v1.ResourceInstance
+	GetWatchResourceByName(group, kind, name string) *v1.ResourceInstance
+	DeleteWatchResource(group, kind, id string) error
+
 	ApplyResourceReadLock()
 	ReleaseResourceReadLock()
 }
@@ -107,6 +114,7 @@ type cacheManager struct {
 	categoryMap             cache.Cache
 	managedApplicationMap   cache.Cache
 	accessRequestMap        cache.Cache
+	watchResourceMap        cache.Cache
 	subscriptionMap         cache.Cache
 	sequenceCache           cache.Cache
 	fetchOnStartup          cache.Cache
@@ -135,6 +143,7 @@ func NewAgentCacheManager(cfg config.CentralConfig, persistCacheEnabled bool) Ma
 		accessRequestMap:        cache.New(),
 		subscriptionMap:         cache.New(),
 		sequenceCache:           cache.New(),
+		watchResourceMap:        cache.New(),
 		fetchOnStartup:          cache.New(),
 		teams:                   cache.New(),
 		ardMap:                  cache.New(),
@@ -168,6 +177,7 @@ func (c *cacheManager) initializePersistedCache(cfg config.CentralConfig) {
 		"subscriptions":       func(loaded cache.Cache) { c.subscriptionMap = loaded },
 		"accReq":              func(loaded cache.Cache) { c.accessRequestMap = loaded },
 		"watchSequence":       func(loaded cache.Cache) { c.sequenceCache = loaded },
+		"watchResource":       func(loaded cache.Cache) { c.watchResourceMap = loaded },
 		"fetchOnStartup":      func(loaded cache.Cache) { c.fetchOnStartup = loaded },
 	}
 
@@ -311,6 +321,7 @@ func (c *cacheManager) Flush() {
 	c.managedApplicationMap.Flush()
 	c.sequenceCache.Flush()
 	c.subscriptionMap.Flush()
+	c.watchResourceMap.Flush()
 
 	c.SaveCache()
 }

--- a/pkg/agent/cache/watchresource.go
+++ b/pkg/agent/cache/watchresource.go
@@ -1,0 +1,80 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+)
+
+// Custom watch resource cache related methods
+func (c *cacheManager) GetWatchResourceCacheKeys(group, kind string) []string {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+	groupKindKeyPrefix := fmt.Sprintf("%s:%s", group, kind)
+
+	keys := make([]string, 0)
+	for _, key := range c.watchResourceMap.GetKeys() {
+		if strings.HasPrefix(key, groupKindKeyPrefix) {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func (c *cacheManager) getWatchResourceKey(group, kind, key string) string {
+	return fmt.Sprintf("%s:%s:%s", group, kind, key)
+}
+
+func (c *cacheManager) AddWatchResource(ri *v1.ResourceInstance) {
+	if ri == nil {
+		return
+	}
+	group := ri.Group
+	kind := ri.Kind
+
+	c.watchResourceMap.SetWithSecondaryKey(c.getWatchResourceKey(group, kind, ri.Metadata.ID), c.getWatchResourceKey(group, kind, ri.Name), ri)
+}
+
+func (c *cacheManager) GetWatchResourceByKey(key string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
+	resource, _ := c.watchResourceMap.Get(key)
+	if resource != nil {
+		if ri, ok := resource.(*v1.ResourceInstance); ok {
+			return ri
+		}
+	}
+	return nil
+}
+
+func (c *cacheManager) GetWatchResourceByID(group, kind, id string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
+	resource, _ := c.watchResourceMap.Get(c.getWatchResourceKey(group, kind, id))
+	if resource != nil {
+		if ri, ok := resource.(*v1.ResourceInstance); ok {
+			return ri
+		}
+	}
+	return nil
+}
+
+func (c *cacheManager) GetWatchResourceByName(group, kind, name string) *v1.ResourceInstance {
+	c.ApplyResourceReadLock()
+	defer c.ReleaseResourceReadLock()
+
+	resource, _ := c.watchResourceMap.GetBySecondaryKey(c.getWatchResourceKey(group, kind, name))
+	if resource != nil {
+		if ri, ok := resource.(*v1.ResourceInstance); ok {
+			return ri
+		}
+	}
+	return nil
+}
+
+func (c *cacheManager) DeleteWatchResource(group, kind, id string) error {
+	return c.watchResourceMap.Delete(c.getWatchResourceKey(group, kind, id))
+}

--- a/pkg/agent/cache/watchresource_test.go
+++ b/pkg/agent/cache/watchresource_test.go
@@ -1,0 +1,80 @@
+package cache
+
+import (
+	"testing"
+
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func createWatchResource(group, kind, id, name string) *v1.ResourceInstance {
+	return &v1.ResourceInstance{
+		ResourceMeta: v1.ResourceMeta{
+			GroupVersionKind: v1.GroupVersionKind{
+				GroupKind: v1.GroupKind{
+					Group: group,
+					Kind:  kind,
+				},
+			},
+			Metadata: v1.Metadata{
+				ID: id,
+			},
+			Name: name,
+		},
+	}
+}
+
+// add watch resource
+// get watch resource by key
+// get watch resource by id
+// get watch resource by name
+// delete watch resource
+func TestWatchResourceCache(t *testing.T) {
+	m := NewAgentCacheManager(&config.CentralConfiguration{}, false)
+	assert.NotNil(t, m)
+
+	cachedRes := m.GetWatchResourceByKey("group:kind:test-id-1")
+	assert.Nil(t, cachedRes)
+
+	instance1 := createWatchResource("group-1", "kind-1", "test-id-1", "test-name-1")
+	instance2 := createWatchResource("group-2", "kind-2", "test-id-2", "test-name-2")
+	m.AddWatchResource(instance1)
+	m.AddWatchResource(instance2)
+
+	keys := m.GetWatchResourceCacheKeys("group-1", "kind-1")
+	assert.Equal(t, 1, len(keys))
+
+	keys = m.GetWatchResourceCacheKeys("group-2", "kind-2")
+	assert.Equal(t, 1, len(keys))
+
+	cachedRes = m.GetWatchResourceByKey("group-1:kind-1:test-id-1")
+	assert.Equal(t, instance1, cachedRes)
+
+	cachedRes = m.GetWatchResourceByID("dummy-group", "dummy=kind", "test-id-1")
+	assert.Nil(t, cachedRes)
+
+	cachedRes = m.GetWatchResourceByID("group-1", "kind-1", "test-id-1")
+	assert.Equal(t, instance1, cachedRes)
+
+	cachedRes = m.GetWatchResourceByName("group-2", "kind-2", "test-name-2")
+	assert.Equal(t, instance2, cachedRes)
+
+	err := m.DeleteWatchResource("group-2", "kind-2", "test-id-2")
+	assert.Nil(t, err)
+
+	cachedRes = m.GetWatchResourceByID("group-2", "kind-2", "test-id-2")
+	assert.Nil(t, cachedRes)
+
+	cachedRes = m.GetWatchResourceByID("group-1", "kind-1", "test-id-1")
+	assert.NotNil(t, cachedRes)
+
+	err = m.DeleteWatchResource("group-1", "kind-1", "test-id-1")
+	assert.Nil(t, err)
+
+	keys = m.GetWatchResourceCacheKeys("group-1", "kind-1")
+	assert.Equal(t, 0, len(keys))
+
+	keys = m.GetWatchResourceCacheKeys("group-2", "kind-2")
+	assert.Equal(t, 0, len(keys))
+}

--- a/pkg/agent/events/watchtopic.go
+++ b/pkg/agent/events/watchtopic.go
@@ -90,7 +90,7 @@ func getOrCreateWatchTopic(name, scope string, client APIClient, features watchT
 			eventTypes = append(eventTypes, (string(filterEventType)))
 		}
 
-		wf := mv1.WatchTopicSpecFilters{
+		wf := management.WatchTopicSpecFilters{
 			Group: filter.Group,
 			Kind:  filter.Kind,
 			Name:  filter.Name,
@@ -98,7 +98,7 @@ func getOrCreateWatchTopic(name, scope string, client APIClient, features watchT
 		}
 
 		if filter.Scope != nil {
-			wf.Scope = &mv1.WatchTopicSpecScope{
+			wf.Scope = &management.WatchTopicSpecScope{
 				Kind: filter.Scope.Kind,
 				Name: filter.Scope.Name,
 			}

--- a/pkg/agent/events/watchtopic.go
+++ b/pkg/agent/events/watchtopic.go
@@ -28,6 +28,7 @@ var agentTypesMap = map[config.AgentType]string{
 type watchTopicFeatures interface {
 	IsMarketplaceSubsEnabled() bool
 	GetAgentType() config.AgentType
+	GetWatchResourceFilters() []config.ResourceFilter
 }
 
 const (
@@ -80,6 +81,30 @@ func getOrCreateWatchTopic(name, scope string, client APIClient, features watchT
 	newWT, err := parseWatchTopicTemplate(tmplValuesFunc(name, scope, agentResourceGroupKind, features))
 	if err != nil {
 		return nil, err
+	}
+
+	filters := features.GetWatchResourceFilters()
+	for _, filter := range filters {
+		eventTypes := make([]string, 0)
+		for _, filterEventType := range filter.EventTypes {
+			eventTypes = append(eventTypes, (string(filterEventType)))
+		}
+
+		wf := mv1.WatchTopicSpecFilters{
+			Group: filter.Group,
+			Kind:  filter.Kind,
+			Name:  filter.Name,
+			Type:  eventTypes,
+		}
+
+		if filter.Scope != nil {
+			wf.Scope = &mv1.WatchTopicSpecScope{
+				Kind: filter.Scope.Kind,
+				Name: filter.Scope.Name,
+			}
+		}
+
+		newWT.Spec.Filters = append(newWT.Spec.Filters, wf)
 	}
 
 	// if the existing wt has no name then it does not exist yet

--- a/pkg/agent/events/watchtopic_test.go
+++ b/pkg/agent/events/watchtopic_test.go
@@ -188,12 +188,12 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 			},
 			filterList: []config.ResourceFilter{
 				{
-					Group:      mv1.CredentialGVK().Group,
-					Kind:       mv1.CredentialGVK().Kind,
+					Group:      management.CredentialGVK().Group,
+					Kind:       management.CredentialGVK().Kind,
 					Name:       "*",
 					EventTypes: []config.ResourceEventType{"created"},
 					Scope: &config.ResourceScope{
-						Kind: mv1.EnvironmentGVK().Kind,
+						Kind: management.EnvironmentGVK().Kind,
 						Name: "test-env",
 					},
 				},

--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/harvester"
 	"github.com/Axway/agent-sdk/pkg/migrate"
+	"github.com/Axway/agent-sdk/pkg/util"
 )
 
 // EventSync struct for syncing events from central
@@ -141,7 +142,9 @@ func (es *EventSync) startPollMode() error {
 		return fmt.Errorf("could not start the harvester poll client: %s", err)
 	}
 
-	newEventProcessorJob(pc, "Poll Client")
+	if util.IsNotTest() {
+		newEventProcessorJob(pc, "Poll Client")
+	}
 
 	return err
 }
@@ -166,7 +169,10 @@ func (es *EventSync) startStreamMode() error {
 	}
 
 	agent.streamer = sc
-	newEventProcessorJob(sc, "Stream Client")
+
+	if util.IsNotTest() {
+		newEventProcessorJob(sc, "Stream Client")
+	}
 
 	return err
 }

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -245,14 +245,8 @@ func (h *accessRequestHandler) getARD(ctx context.Context, ar *management.Access
 }
 
 func (h *accessRequestHandler) getServiceInstance(_ context.Context, ar *management.AccessRequest) (*apiv1.ResourceInstance, error) {
-	instID := ""
-	for _, ref := range ar.Metadata.References {
-		if ref.Name == ar.Spec.ApiServiceInstance {
-			instID = ref.ID
-			break
-		}
-	}
-
+	instRef := ar.GetReferenceByGVK(management.APIServiceInstanceGVK())
+	instID := instRef.ID
 	instance, err := h.cache.GetAPIServiceInstanceByID(instID)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/handler/accessrequest_test.go
+++ b/pkg/agent/handler/accessrequest_test.go
@@ -415,8 +415,8 @@ var accessReq = management.AccessRequest{
 			ID: "11",
 			References: []v1.Reference{
 				{
-					Group: mv1.APIServiceInstanceGVK().Group,
-					Kind:  mv1.APIServiceInstanceGVK().Kind,
+					Group: management.APIServiceInstanceGVK().Group,
+					Kind:  management.APIServiceInstanceGVK().Kind,
 					ID:    instRefID,
 					Name:  instRefName,
 				},

--- a/pkg/agent/handler/accessrequest_test.go
+++ b/pkg/agent/handler/accessrequest_test.go
@@ -415,8 +415,10 @@ var accessReq = management.AccessRequest{
 			ID: "11",
 			References: []v1.Reference{
 				{
-					ID:   instRefID,
-					Name: instRefName,
+					Group: mv1.APIServiceInstanceGVK().Group,
+					Kind:  mv1.APIServiceInstanceGVK().Kind,
+					ID:    instRefID,
+					Name:  instRefName,
 				},
 			},
 			Scope: v1.MetadataScope{

--- a/pkg/agent/handler/traceaccessrequest_test.go
+++ b/pkg/agent/handler/traceaccessrequest_test.go
@@ -38,8 +38,8 @@ func TestTraceAccessRequestTraceHandler(t *testing.T) {
 					{
 						ID:    "instanceId",
 						Name:  "instance",
-						Group: mv1.APIServiceInstanceGVK().Group,
-						Kind:  mv1.APIServiceInstanceGVK().Kind,
+						Group: management.APIServiceInstanceGVK().Group,
+						Kind:  management.APIServiceInstanceGVK().Kind,
 					},
 				},
 			},

--- a/pkg/agent/handler/traceaccessrequest_test.go
+++ b/pkg/agent/handler/traceaccessrequest_test.go
@@ -36,9 +36,10 @@ func TestTraceAccessRequestTraceHandler(t *testing.T) {
 				ID: "ar",
 				References: []apiv1.Reference{
 					{
-						ID:   "instanceId",
-						Name: "instance",
-						Kind: "APIServiceInstance",
+						ID:    "instanceId",
+						Name:  "instance",
+						Group: mv1.APIServiceInstanceGVK().Group,
+						Kind:  mv1.APIServiceInstanceGVK().Kind,
 					},
 				},
 			},

--- a/pkg/agent/handler/watchresource.go
+++ b/pkg/agent/handler/watchresource.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
+)
+
+type watchResourceHandler struct {
+	agentCacheManager agentcache.Manager
+	watchGroupKindMap map[string]bool
+}
+
+type watchTopicFeatures interface {
+	GetWatchResourceFilters() []config.ResourceFilter
+}
+
+func getWatchResourceKey(group, kind string) string {
+	return fmt.Sprintf("%s:%s", group, kind)
+}
+
+// NewWatchResourceHandler creates a Handler for custom watch resources to store resource in agent cache
+func NewWatchResourceHandler(agentCacheManager agentcache.Manager, feature watchTopicFeatures) Handler {
+	watchGroupKindMap := make(map[string]bool)
+
+	filters := feature.GetWatchResourceFilters()
+	for _, filter := range filters {
+		key := getWatchResourceKey(filter.Group, filter.Kind)
+		watchGroupKindMap[key] = filter.IsCachedResource
+	}
+
+	return &watchResourceHandler{
+		agentCacheManager: agentCacheManager,
+		watchGroupKindMap: watchGroupKindMap,
+	}
+}
+
+func (h *watchResourceHandler) Handle(ctx context.Context, _ *proto.EventMeta, resource *v1.ResourceInstance) error {
+	action := GetActionFromContext(ctx)
+	key := getWatchResourceKey(resource.Group, resource.Kind)
+	ok := h.watchGroupKindMap[key]
+	if !ok {
+		return nil
+	}
+
+	if action == proto.Event_DELETED {
+		h.agentCacheManager.DeleteWatchResource(resource.Group, resource.Kind, resource.Metadata.ID)
+	} else {
+		h.agentCacheManager.AddWatchResource(resource)
+	}
+
+	return nil
+}

--- a/pkg/agent/handler/watchresource_test.go
+++ b/pkg/agent/handler/watchresource_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"testing"
+
+	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockWatchTopicFeatures struct {
+	filterList []config.ResourceFilter
+}
+
+func (m *mockWatchTopicFeatures) GetWatchResourceFilters() []config.ResourceFilter {
+	return m.filterList
+}
+
+func createWatchResource(group, kind, id, name string) *v1.ResourceInstance {
+	return &v1.ResourceInstance{
+		ResourceMeta: v1.ResourceMeta{
+			GroupVersionKind: v1.GroupVersionKind{
+				GroupKind: v1.GroupKind{
+					Group: group,
+					Kind:  kind,
+				},
+			},
+			Metadata: v1.Metadata{
+				ID: id,
+			},
+			Name: name,
+		},
+	}
+}
+
+func TestWatchResourceHandler(t *testing.T) {
+	features := &mockWatchTopicFeatures{filterList: []config.ResourceFilter{
+		{
+			Group:            mv1.CredentialGVK().Group,
+			Kind:             mv1.CredentialGVK().Kind,
+			Name:             "*",
+			IsCachedResource: true,
+			EventTypes:       []config.ResourceEventType{"created"},
+			Scope: &config.ResourceScope{
+				Kind: mv1.EnvironmentGVK().Kind,
+				Name: "test-env",
+			},
+		},
+	}}
+
+	cm := agentcache.NewAgentCacheManager(&config.CentralConfiguration{}, false)
+	handler := NewWatchResourceHandler(cm, features)
+
+	res := createWatchResource(mv1.SecretGVK().Group, mv1.SecretGVK().Kind, "secret-id-1", "secret-name-1")
+	// not cached resource
+	err := handler.Handle(NewEventContext(proto.Event_CREATED, nil, res.Kind, res.Name), nil, res)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, cm.GetWatchResourceCacheKeys(mv1.SecretGVK().Group, mv1.SecretGVK().Kind))
+	cachedRes := cm.GetWatchResourceByID(mv1.SecretGVK().Group, mv1.SecretGVK().Kind, "credential-id-1")
+	assert.Empty(t, cachedRes)
+
+	res = createWatchResource(mv1.CredentialGVK().Group, mv1.CredentialGVK().Kind, "credential-id-1", "credential-name-1")
+	err = handler.Handle(NewEventContext(proto.Event_CREATED, nil, res.Kind, res.Name), nil, res)
+	assert.Nil(t, err)
+	cachedGroupKindKeys := cm.GetWatchResourceCacheKeys(mv1.CredentialGVK().Group, mv1.CredentialGVK().Kind)
+	assert.NotEqual(t, []string{}, cachedGroupKindKeys)
+	cachedRes = cm.GetWatchResourceByID(mv1.CredentialGVK().Group, mv1.CredentialGVK().Kind, "credential-id-1")
+	assert.NotEmpty(t, cachedRes)
+
+	cachedRes = cm.GetWatchResourceByName(mv1.CredentialGVK().Group, mv1.CredentialGVK().Kind, "credential-name-1")
+	assert.NotNil(t, cachedRes)
+
+	err = handler.Handle(NewEventContext(proto.Event_DELETED, nil, res.Kind, res.Name), nil, res)
+	assert.Nil(t, err)
+
+	cachedRes = cm.GetWatchResourceByKey(cachedGroupKindKeys[0])
+	assert.Nil(t, cachedRes)
+}

--- a/pkg/config/resourcefilterconfig.go
+++ b/pkg/config/resourcefilterconfig.go
@@ -3,13 +3,14 @@ package config
 // ResourceEventType - watch filter event types
 type ResourceEventType string
 
+// Resource event types
 const (
 	ResourceEventCreated ResourceEventType = "created"
 	ResourceEventUpdated ResourceEventType = "updated"
 	ResourceEventDeleted ResourceEventType = "deleted"
 )
 
-// ResourceFilterScope -  scope config for watch resource filter
+// ResourceScope -  scope config for watch resource filter
 type ResourceScope struct {
 	Kind string `json:"kind"`
 	Name string `json:"name"`

--- a/pkg/config/resourcefilterconfig.go
+++ b/pkg/config/resourcefilterconfig.go
@@ -1,0 +1,26 @@
+package config
+
+// ResourceEventType - watch filter event types
+type ResourceEventType string
+
+const (
+	ResourceEventCreated ResourceEventType = "created"
+	ResourceEventUpdated ResourceEventType = "updated"
+	ResourceEventDeleted ResourceEventType = "deleted"
+)
+
+// ResourceFilterScope -  scope config for watch resource filter
+type ResourceScope struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+// ResourceFilter - custom watch filter
+type ResourceFilter struct {
+	Group            string              `json:"group"` // remove group ? and default to management or allow filter for other groups as well?
+	Kind             string              `json:"kind"`
+	Name             string              `json:"name"`
+	EventTypes       []ResourceEventType `json:"eventTypes"`
+	Scope            *ResourceScope      `json:"scope"`
+	IsCachedResource bool                `json:"isCachedResource"`
+}

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -246,7 +246,10 @@ func (c *collector) updateMetric(detail Detail) *APIMetric {
 		Name: unknown,
 	}
 	if accessRequest != nil {
-		subRef = accessRequest.GetReferenceByGVK(catalog.SubscriptionGVK())
+		accessReqSub := accessRequest.GetReferenceByGVK(catalog.SubscriptionGVK())
+		if accessReqSub.ID != "" {
+			subRef = accessReqSub
+		}
 	}
 
 	subscriptionID := subRef.ID
@@ -255,7 +258,8 @@ func (c *collector) updateMetric(detail Detail) *APIMetric {
 
 	statusCode := detail.StatusCode
 
-	histogram := c.getOrRegisterHistogram("consumer." + subscriptionID + "." + appID + "." + apiID + "." + statusCode)
+	hAPIID := strings.ReplaceAll(apiID, ".", "#")
+	histogram := c.getOrRegisterHistogram("consumer." + subscriptionID + "." + appID + "." + hAPIID + "." + statusCode)
 
 	appMap, ok := c.metricMap[subscriptionID]
 	if !ok {
@@ -615,7 +619,7 @@ func (c *collector) processMetric(metricName string, metric interface{}) {
 	if len(elements) == 5 {
 		subscriptionID := elements[1]
 		appID := elements[2]
-		apiID := elements[3]
+		apiID := strings.ReplaceAll(elements[3], "#", ".")
 		statusCode := elements[4]
 		if appMap, ok := c.metricMap[subscriptionID]; ok {
 			if apiMap, ok := appMap[appID]; ok {

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -335,9 +335,6 @@ func TestMetricCollector(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cfg.SetAxwayManaged(test.trackVolume)
 			setupMockClient(test.retryBatchCount)
-			if test.appName == "managed-app-2" {
-				test.appName = "managed-app-2"
-			}
 			for l := 0; l < test.loopCount; l++ {
 				for i := 0; i < test.apiTransactionCount[l]; i++ {
 					metricDetail := Detail{


### PR DESCRIPTION
- Updates to setup custom watch filters in central config
- Changes to create/update watch topic with custom filters in addition to the agent type filters
- Create a custom watch resource handler to cache watch resources matching the custom filter
- Updated cache manager to store custom watch filter resources
- Fix to lookup reference for APIServiceInstance in AccessRequest
- Fix in metric collector to address external API IDs with dot characters which caused issues with bucket lookup while processing metrics.