### PR TITLE
APIGOV-21483 - sync error codes with documentation

### DIFF
--- a/errors.md
+++ b/errors.md
@@ -2,91 +2,86 @@
 
 ## Use code 1000s for SDK
 
-| Code | Description                                                                                                 | Code Path                                           |
-|------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-|      | 1000-1099 - for general agent errors                                                                        |                                                     |
-| 1000 | Unsupported agent type                                                                                      | pkg/agent/ErrUnsupportedAgentType                   |
-| 1001 | initialization error checking for dependencies to respond, possibly network or settings                     | pkg/util/errors/ErrInitServicesNotReady             |
-| 1002 | timeout error checking for dependencies to respond, possibly network or settings                            | pkg/util/errors/ErrTimeoutServicesNotReady          |
-| 1003 | periodic health checker or status updater failed.  Services are not ready                                   | pkg/util/ErrPeriodicCheck                           |
-| 1004 | error starting periodic or immediate status update                                                          | pkg/util/ErrStartingAgentStatusUpdate               |
-| 1005 | error starting agent                                                                                        | pkg/util/ErrStartingVersionChecker                  |
-| 1006 | error registering subscription webhook                                                                      | pkg/util/ErrRegisterSubscriptionWebhook             |
-| 1007 | error indicating failure to connect to Amplify Central over gRPC                                            | pkg/util/ErrGrpcConnection                          |
-| 1008 | error indicating the harvestor client is not connected to Amplify Central                                   | pkg/util/ErrHarvesterConnection                     |
-|      | 1100-1299 - for apic package errors                                                                         |                                                     |
-| 1100 | general configuration error in CENTRAL                                                                      | pkg/apic/ErrCentralConfig                           |
-| 1101 | error attempting to query for ENVIRONMENT, check CENTRAL_ENVIRONMENT                                        | pkg/apic/ErrEnvironmentQuery                        |
-| 1102 | could not find specified team in Amplify Central, check CENTRAL_TEAM                                        | pkg/apic/ErrTeamNotFound                            |
-| 1110 | connection to Amplify Central failed, possibly network                                                      | pkg/apic/ErrNetwork                                 |
-| 1120 | request to Amplify Central failed, could be bad value for CENTRAL_ENVIRONMENT                               | pkg/apic/ErrRequestQuery                            |
-| 1130 | request to get authentication token failed, possibly network or CENTAL_AUTH config                          | pkg/apic/ErrAuthenticationCall                      |
-| 1131 | token retrieved but was invalid on request to Amplify Central, likely CENTRAL_AUTH config                   | pkg/apic/ErrAuthentication                          |
-| 1140 | couldn't find a subscriber email address based on the ID in the subscription event                          | pkg/apic/ErrNoAddressFound                          |
-| 1141 | couldn't contact Amplify Central for subscription, possible network error                                   | pkg/apic/ErrSubscriptionQuery                       |
-| 1142 | couldn't get subscription data from Amplify Central, check network and CENTRAL_AUTH                         | pkg/apic/ErrSubscriptionResp                        |
-| 1143 | couldn't create or update subscription schema data, possible Network error                                  | pkg/apic/ErrSubscriptionSchemaCreate                |
-| 1144 | unexpected response when managing subscription schema on Amplify Central, check network and CENTRAL_AUTH    | pkg/apic/ErrSubscriptionSchemaResp                  |
-| 1145 | unable to create webhook                                                                                    | pkg/apic/ErrCreateWebhook                           |
-| 1146 | unable to create secret                                                                                     | pkg/apic/ErrCreateSecret                            |
-| 1147 | error parsing filter in configuration. Syntax error                                                         | pkg/filter/ErrFilterConfiguration                   |
-| 1148 | error parsing filter in configuration. Unrecognized expression                                              | pkg/filter/ErrFilterExpression                      |
-| 1149 | error parsing filter in configuration                                                                       | pkg/filter/ErrFilterGeneralParse                    |
-| 1150 | error parsing filter in configuration. Invalid call argument                                                | pkg/filter/ErrFilterArgument                        |
-| 1151 | error parsing filter in configuration. Invalid selector type                                                | pkg/filter/ErrFilterSelectorType                    |
-| 1152 | error parsing filter in configuration. Invalid selector expression                                          | pkg/filter/ErrFilterSelectorExpr                    |
-| 1153 | error parsing filter in configuration. Invalid operator                                                     | pkg/filter/ErrFilterOperator                        |
-| 1154 | error parsing filter in configuration. Unrecognized condition                                               | pkg/filter/ErrFilterCondition                       |
-| 1155 | error getting subscription definition properties in Amplify Central                                         | pkg/apic/ErrGetSubscriptionDefProperties            |
-| 1156 | error updating subscription definition properties in Amplify Central                                        | pkg/apic/ErrUpdateSubscriptionDefProperties         |
-| 1157 | error getting catalog item API server info properties                                                       | pkg/apic/ErrGetCatalogItemServerInfoProperties      |
-| 1158 | subscription manager is not in a running state                                                              | pkg/apic/ErrSubscriptionManagerDown                 |
-| 1160 | error getting endpoints for the API specification                                                           | pkg/apic/ErrSetSpecEndPoints                        |
-| 1161 | error deleting API Service for catalog item in Amplify Central                                              | pkg/agent/ErrDeletingService                        |
-| 1162 | error deleting catalog item in Amplify Central                                                              | pkg/agent/ErrDeletingCatalogItem                    |
-| 1163 | error retrieving API Service resource instances                                                             | pkg/agent/ErrUnableToGetAPIV1Resources              |
-| 1163 | error retrieving API Service resource instances                                                             | pkg/agent/ErrUnableToGetAPIV1Resources              |
-| 1164 | Amplify Central does not contain a team for the API. The Catalog Item will be assigned to the default       | pkg/apic/ErrTeamMismatch                            |
-| 1165 | error creating category                                                                                     | pkg/apic/ErrCategoryCreate                          |
-|      | 1300-1399 - for subscription notification errors                                                            |                                                     |
-| 1300 | error communicating with server for subscription notifications (SMTP or webhook), check SUBSCRIPTION config | pkg/notify/ErrSubscriptionNotification              |
-| 1301 | subscription notifications not configured, check SUBSCRIPTION config                                        | pkg/notify/ErrSubscriptionNoNotifications           |
-| 1302 | error creating data for sending subscription notification                                                   | pkg/notify/ErrSubscriptionData                      |
-| 1303 | email template not updated because an invalid authType was supplied                                         | pkg/notify/ErrSubscriptionBadAuthtype               |
-| 1304 | no email template found for action                                                                          | pkg/notify/ErrSubscriptionNoTemplateForAction       |
-| 1305 | error sending email to SMTP server                                                                          | pkg/notify/ErrSubscriptionSendEmail                 |
-|      | 1400-1499 - for setting and parsing configuration errors                                                    |                                                     |
-| 1401 | error parsing configuration values                                                                          | pkg/config/ErrBadConfig                             |
-| 1402 | error in overriding configuration using file with environment variables                                     | pkg/config/ErrEnvConfigOverride                     |
-| 1403 | invalid value for statusHealthCheckPeriod. Value must be between 1 and 5 minutes                            | pkg/config/ErrStatusHealthCheckPeriod               |
-| 1404 | invalid value for statusHealthCheckInterval. Value must be between 30 seconds and 5 minutes                 | pkg/config/ErrStatusHealthCheckInterval             |
-| 1405 | a key file could not be read                                                                                | pkg/config/ErrReadingKeyFile                        |
-| 1406 | DOSA and Marketplace provisioning is not supported                                                          | pkg/config/ErrServiceAccount                        |
-| 1410 | invalid configuration settings for the logging setup                                                        | pkg/config/ErrInvalidLogConfig                      |
-| 1411 | invalid secret reference                                                                                    | pkg/cmd/properties/ErrInvalidSecretReference        |
-|      | 1500-1599 - errors related to traceability output transport                                                 |                                                     |
-| 1503 | http transport is not connected                                                                             | pkg/traceability/ErrHTTPNotConnected                |
-| 1504 | failed to encode the json content                                                                           | pkg/traceability/ErrJSONEncodeFailed                |
-| 1505 | invalid traceability config                                                                                 | pkg/traceability/ErrInvalidConfig                   |
-| 1510 | global redaction have not been initialized                                                                  | pkg/traceability/redaction/ErrGlobalRedactionCfg    |
-| 1511 | error while compiling regular expression                                                                    | pkg/traceability/redaction/ErrInvalidRegex          |
-| 1520 | global sampling has not been initialized                                                                    | pkg/traceability/sampling/ErrGlobalSamplingCfg      |
-| 1521 | invalid sampling configuration                                                                              | pkg/traceability/sampling/ErrSamplingCfg            |
-| 1550 | error hit while applying redaction                                                                          | pkg/transaction/ErrInRedactions                     |
-|      | 1600-1610 - errors in jobs library                                                                          |                                                     |
-| 1600 | error registering job                                                                                       | pkg/jobs/ErrRegisteringJob                          |
-| 1601 | error executing job                                                                                         | pkg/jobs/ErrExecutingJob                            |
-| 1602 | error executing retry job                                                                                   | pkg/jobs/ErrExecutingRetryJob                       |
-|      | 1611-1612 - errors in healthcheck library                                                                   |                                                     |
-| 1611 | error starting periodic health check                                                                        | pkg/util/healthcheck/ErrStartingPeriodicHealthCheck |
-| 1612 | maximum number of consecutive healthcheck errors hit                                                        | pkg/util/healthcheck/ErrMaxconsecutiveErrors        |
-| 1613 | terminating agent, another instance of agent already running                                                | pkg/util/healthcheck/ErrAlreadyRunning              |
-|      | 1900-1910 - errors managing agent service                                                                   |                                                     |
-| 1900 | unsupported system for service installation                                                                 | pkg/cmd/service/daemon/ErrUnsupportedSystem         |
-| 1901 | systemd is required for service installation                                                                | pkg/cmd/service/daemon/ErrNeedSystemd               |
-| 1902 | service management requires root privileges                                                                 | pkg/cmd/service/daemon/ErrRootPrivileges            |
-| 1903 | service has already been installed                                                                          | pkg/cmd/service/daemon/ErrAlreadyInstalled          |
-| 1904 | service is running and cannot be removed until stopped                                                      | pkg/cmd/service/daemon/ErrCurrentlyRunning          |
-| 1905 | service is not yet installed                                                                                | pkg/cmd/service/daemon/ErrNotInstalled              |
-| 1906 | service is already running                                                                                  | pkg/cmd/service/daemon/ErrAlreadyRunning            |
-| 1907 | service is already stopped                                                                                  | pkg/cmd/service/daemon/ErrAlreadyStopped            |
+| Code | Description                                                                                                 | Code Path                                        |
+|------|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+|      | 1000-1099 - for general agent errors                                                                        |                                                  |
+| 1000 | Unsupported agent type                                                                                      | pkg/agent/ErrUnsupportedAgentType                |
+| 1001 | initialization error checking for dependencies to respond, possibly network or settings                     | pkg/util/errors/ErrInitServicesNotReady          |
+| 1004 | error starting periodic or immediate status update                                                          | pkg/util/ErrStartingAgentStatusUpdate            |
+| 1005 | error starting agent                                                                                        | pkg/util/ErrStartingVersionChecker               |
+| 1006 | error registering subscription webhook                                                                      | pkg/util/ErrRegisterSubscriptionWebhook          |
+| 1007 | error indicating failure to connect to Amplify Central over gRPC                                            | pkg/util/ErrGrpcConnection                       |
+| 1008 | error indicating the harvester client is not connected to Amplify Central                                   | pkg/util/ErrHarvesterConnection                  |
+|      | 1100-1299 - for apic package errors                                                                         |                                                  |
+| 1100 | general configuration error in CENTRAL                                                                      | pkg/apic/ErrCentralConfig                        |
+| 1101 | error attempting to query for ENVIRONMENT, check CENTRAL_ENVIRONMENT                                        | pkg/apic/ErrEnvironmentQuery                     |
+| 1102 | could not find specified team in Amplify Central, check CENTRAL_TEAM                                        | pkg/apic/ErrTeamNotFound                         |
+| 1110 | connection to Amplify Central failed, possibly network                                                      | pkg/apic/ErrNetwork                              |
+| 1120 | request to Amplify Central failed, could be bad value for CENTRAL_ENVIRONMENT                               | pkg/apic/ErrRequestQuery                         |
+| 1130 | request to get authentication token failed, possibly network or CENTAL_AUTH config                          | pkg/apic/ErrAuthenticationCall                   |
+| 1131 | token retrieved but was invalid on request to Amplify Central, likely CENTRAL_AUTH config                   | pkg/apic/ErrAuthentication                       |
+| 1139 | couldn't find a subscriber email address based on the ID in the subscription event                          | pkg/apic/ErrNoAddressFound                       |
+| 1140 | couldn't contact Amplify Central for subscription, possible network error                                   | pkg/apic/ErrSubscriptionQuery                    |
+| 1141 | couldn't get subscription data from Amplify Central, check network and CENTRAL_AUTH                         | pkg/apic/ErrSubscriptionResp                     |
+| 1142 | couldn't create or update subscription schema data, possible Network error                                  | pkg/apic/ErrSubscriptionSchemaCreate             |
+| 1143 | unexpected response when managing subscription schema on Amplify Central, check network and CENTRAL_AUTH    | pkg/apic/ErrSubscriptionSchemaResp               |
+| 1144 | unable to create webhook                                                                                    | pkg/apic/ErrCreateWebhook                        |
+| 1145 | unable to create secret                                                                                     | pkg/apic/ErrCreateSecret                         |
+| 1146 | unexpected response code (%d) when creating an access request subscription schema                           | pkg/apic/ErrAccessRequestSubscriptionSchemaResp  |
+| 1147 | error parsing filter in configuration. Syntax error                                                         | pkg/filter/ErrFilterConfiguration                |
+| 1148 | error parsing filter in configuration. Unrecognized expression                                              | pkg/filter/ErrFilterExpression                   |
+| 1149 | error parsing filter in configuration                                                                       | pkg/filter/ErrFilterGeneralParse                 |
+| 1150 | error parsing filter in configuration. Invalid call argument                                                | pkg/filter/ErrFilterArgument                     |
+| 1151 | error parsing filter in configuration. Invalid selector type                                                | pkg/filter/ErrFilterSelectorType                 |
+| 1152 | error parsing filter in configuration. Invalid selector expression                                          | pkg/filter/ErrFilterSelectorExpr                 |
+| 1153 | error parsing filter in configuration. Invalid operator                                                     | pkg/filter/ErrFilterOperator                     |
+| 1154 | error parsing filter in configuration. Unrecognized condition                                               | pkg/filter/ErrFilterCondition                    |
+| 1155 | error getting subscription definition properties in Amplify Central                                         | pkg/apic/ErrGetSubscriptionDefProperties         |
+| 1156 | error updating subscription definition properties in Amplify Central                                        | pkg/apic/ErrUpdateSubscriptionDefProperties      |
+| 1157 | error getting catalog item API server info properties                                                       | pkg/apic/ErrGetCatalogItemServerInfoProperties   |
+| 1158 | subscription manager is not in a running state                                                              | pkg/apic/ErrSubscriptionManagerDown              |
+| 1160 | error getting endpoints for the API specification                                                           | pkg/apic/ErrSetSpecEndPoints                     |
+| 1161 | error deleting API Service for catalog item in Amplify Central                                              | pkg/agent/ErrDeletingService                     |
+| 1162 | error deleting catalog item in Amplify Central                                                              | pkg/agent/ErrDeletingCatalogItem                 |
+| 1163 | error retrieving API Service resource instances                                                             | pkg/agent/ErrUnableToGetAPIV1Resources           |
+| 1164 | error creating category                                                                                     | pkg/apic/ErrCategoryCreate                       |
+|      | 1300-1399 - for subscription notification errors                                                            |                                                  |
+| 1300 | error communicating with server for subscription notifications (SMTP or webhook), check SUBSCRIPTION config | pkg/notify/ErrSubscriptionNotification           |
+| 1301 | subscription notifications not configured, check SUBSCRIPTION config                                        | pkg/notify/ErrSubscriptionNoNotifications        |
+| 1302 | error creating data for sending subscription notification                                                   | pkg/notify/ErrSubscriptionData                   |
+| 1303 | email template not updated because an invalid authType was supplied                                         | pkg/notify/ErrSubscriptionBadAuthtype            |
+| 1304 | no email template found for action                                                                          | pkg/notify/ErrSubscriptionNoTemplateForAction    |
+| 1305 | error sending email to SMTP server                                                                          | pkg/notify/ErrSubscriptionSendEmail              |
+|      | 1400-1499 - for setting and parsing configuration errors                                                    |                                                  |
+| 1401 | error parsing configuration values                                                                          | pkg/config/ErrBadConfig                          |
+| 1402 | error in overriding configuration using file with environment variables                                     | pkg/config/ErrEnvConfigOverride                  |
+| 1403 | invalid value for statusHealthCheckPeriod. Value must be between 1 and 5 minutes                            | pkg/config/ErrStatusHealthCheckPeriod            |
+| 1404 | invalid value for statusHealthCheckInterval. Value must be between 30 seconds and 5 minutes                 | pkg/config/ErrStatusHealthCheckInterval          |
+| 1405 | a key file could not be read                                                                                | pkg/config/ErrReadingKeyFile                     |
+| 1406 | DOSA and Marketplace provisioning is not supported                                                          | pkg/config/ErrServiceAccount                     |
+| 1410 | invalid configuration settings for the logging setup                                                        | pkg/config/ErrInvalidLogConfig                   |
+| 1411 | invalid secret reference                                                                                    | pkg/cmd/properties/ErrInvalidSecretReference     |
+|      | 1500-1599 - errors related to traceability output transport                                                 |                                                  |
+| 1503 | http transport is not connected                                                                             | pkg/traceability/ErrHTTPNotConnected             |
+| 1504 | failed to encode the json content                                                                           | pkg/traceability/ErrJSONEncodeFailed             |
+| 1505 | invalid traceability config                                                                                 | pkg/traceability/ErrInvalidConfig                |
+| 1510 | global redaction have not been initialized                                                                  | pkg/traceability/redaction/ErrGlobalRedactionCfg |
+| 1511 | error while compiling regular expression                                                                    | pkg/traceability/redaction/ErrInvalidRegex       |
+| 1520 | global sampling has not been initialized                                                                    | pkg/traceability/sampling/ErrGlobalSamplingCfg   |
+| 1521 | invalid sampling configuration                                                                              | pkg/traceability/sampling/ErrSamplingCfg         |
+| 1550 | error hit while applying redaction                                                                          | pkg/transaction/ErrInRedactions                  |
+|      | 1600-1610 - errors in jobs library                                                                          |                                                  |
+| 1600 | error registering job                                                                                       | pkg/jobs/ErrRegisteringJob                       |
+| 1601 | error executing job                                                                                         | pkg/jobs/ErrExecutingJob                         |
+| 1602 | error executing retry job                                                                                   | pkg/jobs/ErrExecutingRetryJob                    |
+|      | 1613 - errors in healthcheck library                                                                        |                                                  |
+| 1613 | terminating agent, another instance of agent already running                                                | pkg/util/healthcheck/ErrAlreadyRunning           |
+|      | 1900-1910 - errors managing agent service                                                                   |                                                  |
+| 1900 | unsupported system for service installation                                                                 | pkg/cmd/service/daemon/ErrUnsupportedSystem      |
+| 1901 | systemd is required for service installation                                                                | pkg/cmd/service/daemon/ErrNeedSystemd            |
+| 1902 | service management requires root privileges                                                                 | pkg/cmd/service/daemon/ErrRootPrivileges         |
+| 1903 | service has already been installed                                                                          | pkg/cmd/service/daemon/ErrAlreadyInstalled       |
+| 1904 | service is running and cannot be removed until stopped                                                      | pkg/cmd/service/daemon/ErrCurrentlyRunning       |
+| 1905 | service is not yet installed                                                                                | pkg/cmd/service/daemon/ErrNotInstalled           |
+| 1906 | service is already running                                                                                  | pkg/cmd/service/daemon/ErrAlreadyRunning         |
+| 1907 | service is already stopped                                                                                  | pkg/cmd/service/daemon/ErrAlreadyStopped         |

--- a/pkg/apic/errors.go
+++ b/pkg/apic/errors.go
@@ -15,27 +15,25 @@ var (
 
 // Errors hit when calling different Amplify APIs
 var (
-	ErrNoAddressFound = errors.Newf(1140, "could not find the subscriber (%s) email address")
+	ErrNoAddressFound = errors.Newf(1139, "could not find the subscriber (%s) email address")
 	// Subscription APIs
-	ErrSubscriptionQuery                   = errors.New(1141, "error connecting to Amplify Central for subscriptions")
-	ErrSubscriptionResp                    = errors.Newf(1142, "unexpected response code (%d) from Amplify Central for subscription")
-	ErrSubscriptionSchemaCreate            = errors.New(1143, "error creating/updating subscription schema in Amplify Central")
-	ErrSubscriptionSchemaResp              = errors.Newf(1144, "unexpected response code (%d) when creating a subscription schema in Amplify Central")
-	ErrAccessRequestSubscriptionSchemaResp = errors.Newf(1147, "unexpected response code (%d) when creating an acceess request subscription schema in Amplify Central")
-
+	ErrSubscriptionQuery        = errors.New(1140, "error connecting to Amplify Central for subscriptions")
+	ErrSubscriptionResp         = errors.Newf(1141, "unexpected response code (%d) from Amplify Central for subscription")
+	ErrSubscriptionSchemaCreate = errors.New(1142, "error creating/updating subscription schema in Amplify Central")
+	ErrSubscriptionSchemaResp   = errors.Newf(1143, "unexpected response code (%d) when creating a subscription schema in Amplify Central")
 	// APIs related to webhooks
-	ErrCreateWebhook = errors.New(1145, "unable to create webhook")
-	ErrCreateSecret  = errors.New(1146, "unable to create secret")
+	ErrCreateWebhook                       = errors.New(1144, "unable to create webhook")
+	ErrCreateSecret                        = errors.New(1145, "unable to create secret")
+	ErrAccessRequestSubscriptionSchemaResp = errors.Newf(1146, "unexpected response code (%d) when creating an access request subscription schema in Amplify Central")
 
 	ErrGetSubscriptionDefProperties       = errors.New(1155, "error getting subscription definition properties in Amplify Central")
 	ErrUpdateSubscriptionDefProperties    = errors.New(1156, "error updating subscription definition properties in Amplify Central")
 	ErrGetCatalogItemServerInfoProperties = errors.New(1157, "error getting catalog item API server info properties")
 	ErrSubscriptionManagerDown            = errors.New(1158, "subscription manager is not running")
-	ErrGetAPIServiceInstanceByName        = errors.New(1159, "error getting api service instance by name")
 
 	// Service body builder
 	ErrSetSpecEndPoints = errors.New(1160, "error getting endpoints for the API specification")
 
 	// Category
-	ErrCategoryCreate = errors.Newf(1165, "error creating category %s")
+	ErrCategoryCreate = errors.Newf(1164, "error creating category %s")
 )

--- a/pkg/traceability/sampling/globalsampling.go
+++ b/pkg/traceability/sampling/globalsampling.go
@@ -1,7 +1,6 @@
 package sampling
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/publisher"
@@ -42,7 +41,7 @@ func SetupSampling(cfg Sampling, offlineMode bool) error {
 
 	// Validate the config to make sure it is not out of bounds
 	if cfg.Percentage < 0 || cfg.Percentage > countMax {
-		return fmt.Errorf("sampling percentage must be between 0 and 100")
+		return ErrSamplingCfg
 	}
 	agentSamples = &sample{
 		config:        cfg,

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -3,8 +3,6 @@ package errors
 // Generic Agent Errors
 var (
 	ErrInitServicesNotReady        = New(1001, "failed to initialize. Services are not ready")
-	ErrTimeoutServicesNotReady     = New(1002, "failed with timeout error.  Services are not ready")
-	ErrPeriodicCheck               = Newf(1003, "%s failed.  Services are not ready")
 	ErrStartingAgentStatusUpdate   = Newf(1004, "error starting %s update")
 	ErrStartingVersionChecker      = Newf(1005, "%s. No version to compare for upgrade")
 	ErrRegisterSubscriptionWebhook = New(1006, "unable to register subscription webhook")

--- a/pkg/util/healthcheck/error.go
+++ b/pkg/util/healthcheck/error.go
@@ -4,7 +4,5 @@ import "github.com/Axway/agent-sdk/pkg/util/errors"
 
 //Healthcheck errors
 var (
-	ErrStartingPeriodicHealthCheck = errors.New(1611, "error starting periodic healthcheck")
-	ErrMaxconsecutiveErrors        = errors.Newf(1612, "healthchecks failed %v consecutive times, pausing execution")
-	ErrAlreadyRunning              = errors.New(1613, "terminating agent, another instance of agent already running")
+	ErrAlreadyRunning = errors.New(1613, "terminating agent, another instance of agent already running")
 )


### PR DESCRIPTION
1. Check that error var is being used in md
2. Check that error var is in code
3. Check that error code exists in docs.axway tips-troubleshooting-mitigation pages
4. If error var wasn't being used in code, remove from md and equivalent pages in docs.axway

related ticket for docs.axway - https://jira.axway.com/browse/APIGOV-23248

