### PR TITLE
APIGOV-11111 - justify displaying trace if range duration is set

### DIFF
--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -393,12 +393,17 @@ func (p *properties) validateLowerAndUpperLimits(duration time.Duration, flagNam
 	lowerLimitFlag := p.rootCmd.Flag(fmt.Sprintf(lowerLimitName, flagName))
 	upperLimitFlag := p.rootCmd.Flag(fmt.Sprintf(upperLimitName, flagName))
 
+	var floorSet bool
+	var ceilingSet bool
+
 	if lowerLimitFlag != nil {
 		lowerLimitDuration, _ := time.ParseDuration(lowerLimitFlag.Value.String())
 		// validate that lower limit is greater than zero and less than configured duration
 		if lowerLimitDuration > 0 && lowerLimitDuration > duration {
 			log.Warnf(lowerLimitFlag.Usage, duration, lowerLimitDuration, flagName)
 			return false
+		} else {
+			floorSet = true
 		}
 	}
 	if upperLimitFlag != nil {
@@ -407,10 +412,15 @@ func (p *properties) validateLowerAndUpperLimits(duration time.Duration, flagNam
 		if upperLimitDuration > 0 && upperLimitDuration < duration {
 			log.Warnf(upperLimitFlag.Usage, duration, upperLimitDuration, flagName)
 			return false
+		} else {
+			ceilingSet = true
 		}
 	}
 
-	log.Tracef("Duration range has been set for property %s", flagName)
+	if floorSet && ceilingSet {
+		log.Tracef("Duration range has been set for property %s", flagName)
+	}
+
 	return true
 }
 

--- a/pkg/cmd/properties/properties.go
+++ b/pkg/cmd/properties/properties.go
@@ -402,9 +402,8 @@ func (p *properties) validateLowerAndUpperLimits(duration time.Duration, flagNam
 		if lowerLimitDuration > 0 && lowerLimitDuration > duration {
 			log.Warnf(lowerLimitFlag.Usage, duration, lowerLimitDuration, flagName)
 			return false
-		} else {
-			floorSet = true
 		}
+		floorSet = true
 	}
 	if upperLimitFlag != nil {
 		upperLimitDuration, _ := time.ParseDuration(upperLimitFlag.Value.String())
@@ -412,9 +411,8 @@ func (p *properties) validateLowerAndUpperLimits(duration time.Duration, flagNam
 		if upperLimitDuration > 0 && upperLimitDuration < duration {
 			log.Warnf(upperLimitFlag.Usage, duration, upperLimitDuration, flagName)
 			return false
-		} else {
-			ceilingSet = true
 		}
+		ceilingSet = true
 	}
 
 	if floorSet && ceilingSet {


### PR DESCRIPTION
I could have just removed the trace statement.
But, put quick checks to see if a floor and ceiling was created for the duration range.  If yeah, then display trace... and return true.

If it's overkill, i'll revert and remove the trace statement.