### PR TITLE
APIGOV-23402 migrate api service instances to remove finalizers

### DIFF
--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -37,7 +37,8 @@ func NewEventSync() (*EventSync, error) {
 		attributeMigration := migrate.NewAttributeMigration(agent.apicClient, agent.cfg)
 		ardMigration := migrate.NewArdMigration(agent.apicClient, agent.cfg)
 		apisiMigration := migrate.NewAPISIMigration(agent.apicClient, agent.cfg)
-		migrations = append(migrations, attributeMigration, ardMigration, apisiMigration)
+		instanceMigration := migrate.NewInstanceMigration(agent.apicClient, agent.cfg)
+		migrations = append(migrations, attributeMigration, ardMigration, apisiMigration, instanceMigration)
 
 		if isMpEnabled {
 			// add marketplace migration to migrations

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -99,13 +99,7 @@ func (j *instanceValidator) deleteServiceInstanceOrService(ri *apiV1.ResourceIns
 	log.Infof("API no longer exists on the dataplane, deleting the catalog item %s", ri.Title)
 	msg := "Deleted catalog item %s from Amplify Central"
 
-	var err error
-
-	if len(ri.Finalizers) == 0 {
-		err = agent.apicClient.DeleteAPIServiceInstance(ri.Name)
-	} else {
-		err = agent.apicClient.DeleteAPIServiceInstanceWithFinalizers(ri)
-	}
+	err := agent.apicClient.DeleteAPIServiceInstance(ri.Name)
 	if err != nil {
 		log.Error(utilErrors.Wrap(ErrDeletingCatalogItem, err.Error()).FormatError(ri.Title))
 		return

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -68,13 +68,6 @@ func (c *ServiceClient) buildAPIServiceInstance(
 	name string,
 	endpoints []management.ApiServiceInstanceSpecEndpoint,
 ) *management.APIServiceInstance {
-	finalizer := make([]apiv1.Finalizer, 0)
-	if serviceBody.uniqueARD {
-		finalizer = append(finalizer, apiv1.Finalizer{
-			Name:        AccessRequestDefinitionFinalizer,
-			Description: serviceBody.ardName,
-		})
-	}
 
 	spec := buildAPIServiceInstanceSpec(serviceBody, endpoints)
 	if c.cfg.IsMarketplaceSubsEnabled() {
@@ -90,7 +83,6 @@ func (c *ServiceClient) buildAPIServiceInstance(
 			Title:            serviceBody.NameToPush,
 			Attributes:       util.CheckEmptyMapStringString(serviceBody.InstanceAttributes),
 			Tags:             mapToTagsArray(serviceBody.Tags, c.cfg.GetTagsToPublish()),
-			Finalizers:       finalizer,
 			Metadata: apiv1.Metadata{
 				Scope: apiv1.MetadataScope{
 					Kind: management.EnvironmentGVK().Kind,

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -57,7 +57,6 @@ type Client interface {
 	GetSubscriptionManager() SubscriptionManager
 	GetCatalogItemIDForConsumerInstance(instanceID string) (string, error)
 	DeleteAPIServiceInstance(name string) error
-	DeleteAPIServiceInstanceWithFinalizers(ri *apiv1.ResourceInstance) error
 	DeleteConsumerInstance(name string) error
 	DeleteServiceByName(name string) error
 	GetConsumerInstanceByID(id string) (*management.ConsumerInstance, error)

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -36,8 +36,6 @@ const (
 	CreateTimestampQueryKey = "metadata.audit.createTimestamp"
 
 	DefaultTeamKey = "DefaultTeam"
-
-	AccessRequestDefinitionFinalizer = "agent.cleanup.accessrequestdefinition"
 )
 
 // consts for state

--- a/pkg/apic/mock/mockclient.go
+++ b/pkg/apic/mock/mockclient.go
@@ -21,7 +21,6 @@ type Client struct {
 	GetSubscriptionManagerMock                               func() apic.SubscriptionManager
 	GetCatalogItemIDForConsumerInstanceMock                  func(instanceID string) (string, error)
 	DeleteAPIServiceInstanceMock                             func(name string) error
-	DeleteAPIServiceInstanceWithFinalizersMock               func(ri *v1.ResourceInstance) error
 	DeleteConsumerInstanceMock                               func(name string) error
 	DeleteServiceByNameMock                                  func(name string) error
 	GetConsumerInstanceByIDMock                              func(consumerInstanceID string) (*management.ConsumerInstance, error)
@@ -211,13 +210,6 @@ func (m *Client) DeleteConsumerInstance(instanceName string) error {
 func (m *Client) DeleteAPIServiceInstance(instanceName string) error {
 	if m.DeleteAPIServiceInstanceMock != nil {
 		return m.DeleteAPIServiceInstanceMock(instanceName)
-	}
-	return nil
-}
-
-func (m *Client) DeleteAPIServiceInstanceWithFinalizers(ri *v1.ResourceInstance) error {
-	if m.DeleteAPIServiceInstanceWithFinalizersMock != nil {
-		return m.DeleteAPIServiceInstanceWithFinalizersMock(ri)
 	}
 	return nil
 }

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -142,26 +142,9 @@ func (c *ServiceClient) checkReferencesToAccessRequestDefinition(ard string) int
 
 // DeleteAPIServiceInstanceWithFinalizers deletes an api service instance in central, handling finalizers
 func (c *ServiceClient) DeleteAPIServiceInstanceWithFinalizers(ri *v1.ResourceInstance) error {
+	log.DeprecationWarningReplace("DeleteAPIServiceInstanceWithFinalizers", "DeleteAPIServiceInstance")
 	url := c.cfg.GetInstancesURL() + "/" + ri.Name
-	finalizers := ri.Finalizers
 	ri.Finalizers = make([]v1.Finalizer, 0)
-
-	// handle finalizers
-	for _, f := range finalizers {
-		if f.Name == AccessRequestDefinitionFinalizer {
-			// check if we should remove the accessrequestdefinition
-			if c.checkReferencesToAccessRequestDefinition(f.Description) > 1 {
-				continue // do not add the finalizer back
-			}
-			// 1 or fewer references to the ARD, clean it up
-			tempARD := management.NewAccessRequestDefinition(f.Description, c.cfg.GetEnvironmentName())
-			_, err := c.apiServiceDeployAPI(http.MethodDelete, c.createAPIServerURL(tempARD.GetSelfLink()), nil)
-			if err == nil {
-				continue // do not add the finalizer back
-			}
-		}
-		ri.Finalizers = append(ri.Finalizers, f)
-	}
 
 	// get the full instance
 	currentRI, err := c.executeAPIServiceAPI(http.MethodGet, url, nil)

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -140,33 +140,6 @@ func (c *ServiceClient) checkReferencesToAccessRequestDefinition(ard string) int
 	return count
 }
 
-// DeleteAPIServiceInstanceWithFinalizers deletes an api service instance in central, handling finalizers
-func (c *ServiceClient) DeleteAPIServiceInstanceWithFinalizers(ri *v1.ResourceInstance) error {
-	log.DeprecationWarningReplace("DeleteAPIServiceInstanceWithFinalizers", "DeleteAPIServiceInstance")
-	url := c.cfg.GetInstancesURL() + "/" + ri.Name
-	ri.Finalizers = make([]v1.Finalizer, 0)
-
-	// get the full instance
-	currentRI, err := c.executeAPIServiceAPI(http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	// update the finalizers in the instance from central
-	currentRI.Finalizers = ri.Finalizers
-
-	// update instance
-	updatedInstance, err := json.Marshal(currentRI)
-	if err != nil {
-		return err
-	}
-	_, err = c.apiServiceDeployAPI(http.MethodPut, url, updatedInstance)
-	if err != nil && err.Error() != strconv.Itoa(http.StatusNotFound) {
-		return err
-	}
-
-	return c.DeleteAPIServiceInstance(ri.Name)
-}
-
 // GetConsumerInstanceByID -
 func (c *ServiceClient) GetConsumerInstanceByID(consumerInstanceID string) (*management.ConsumerInstance, error) {
 	return c.getConsumerInstanceByID(consumerInstanceID)

--- a/pkg/migrate/instancemigration.go
+++ b/pkg/migrate/instancemigration.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/config"
 )
 
+// InstanceMigration - migrates api service instances
 type InstanceMigration struct {
 	migration
 }
@@ -20,6 +21,7 @@ func NewInstanceMigration(client client, cfg config.CentralConfig) *InstanceMigr
 	}
 }
 
+// Migrate migrates an api service instance
 func (im *InstanceMigration) Migrate(ri *apiv1.ResourceInstance) (*apiv1.ResourceInstance, error) {
 	if ri.Kind != management.APIServiceInstanceGVK().Kind {
 		return ri, nil

--- a/pkg/migrate/instancemigration.go
+++ b/pkg/migrate/instancemigration.go
@@ -27,6 +27,10 @@ func (im *InstanceMigration) Migrate(ri *apiv1.ResourceInstance) (*apiv1.Resourc
 		return ri, nil
 	}
 
+	if len(ri.Finalizers) == 0 {
+		return ri, nil
+	}
+
 	ri.Finalizers = make([]apiv1.Finalizer, 0)
 
 	return im.migration.client.UpdateResourceInstance(ri)

--- a/pkg/migrate/instancemigration.go
+++ b/pkg/migrate/instancemigration.go
@@ -1,0 +1,31 @@
+package migrate
+
+import (
+	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/config"
+)
+
+type InstanceMigration struct {
+	migration
+}
+
+// NewInstanceMigration -
+func NewInstanceMigration(client client, cfg config.CentralConfig) *InstanceMigration {
+	return &InstanceMigration{
+		migration: migration{
+			client: client,
+			cfg:    cfg,
+		},
+	}
+}
+
+func (im *InstanceMigration) Migrate(ri *apiv1.ResourceInstance) (*apiv1.ResourceInstance, error) {
+	if ri.Kind != management.APIServiceInstanceGVK().Kind {
+		return ri, nil
+	}
+
+	ri.Finalizers = make([]apiv1.Finalizer, 0)
+
+	return im.migration.client.UpdateResourceInstance(ri)
+}


### PR DESCRIPTION
- Remove finalizers on existing instances
- Do not add a finalizer to new instances