### PR TITLE
APIGOV-23428 - check migration complete

### DIFF
--- a/pkg/migrate/marketplacemigration.go
+++ b/pkg/migrate/marketplacemigration.go
@@ -124,6 +124,7 @@ func (m *MarketplaceMigration) UpdateService(ri *apiv1.ResourceInstance) error {
 	return nil
 }
 
+// InstanceAlreadyMigrated - check to see if apiservice already migrated
 func (m *MarketplaceMigration) InstanceAlreadyMigrated(ri *apiv1.ResourceInstance) bool {
 
 	// get x-agent-details and determine if we need to process this apiservice for marketplace provisioning

--- a/pkg/migrate/marketplacemigration.go
+++ b/pkg/migrate/marketplacemigration.go
@@ -64,26 +64,7 @@ func (m *MarketplaceMigration) Migrate(ri *apiv1.ResourceInstance) (*apiv1.Resou
 		return ri, nil
 	}
 
-	// check resource to see if this apiservice has already been run through migration
-	apiSvc, err := ri.AsInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	// get x-agent-details and determine if we need to process this apiservice for marketplace provisioning
-	if isMigrationCompleted(ri, definitions.MarketplaceMigration) {
-		// migration ran already
-		m.logger.
-			WithField(serviceName, apiSvc.Name).
-			Debugf("marketplace provision migration already completed")
-		return ri, nil
-	}
-
-	m.logger.
-		WithField(serviceName, ri.Name).
-		Tracef("perform marketplace provision")
-
-	m.UpdateService(ri)
+	err := m.UpdateService(ri)
 
 	if err != nil {
 		return ri, fmt.Errorf("migration marketplace provisioning failed: %s", err)
@@ -141,6 +122,20 @@ func (m *MarketplaceMigration) UpdateService(ri *apiv1.ResourceInstance) error {
 	}
 
 	return nil
+}
+
+func (m *MarketplaceMigration) InstanceAlreadyMigrated(ri *apiv1.ResourceInstance) bool {
+
+	// get x-agent-details and determine if we need to process this apiservice for marketplace provisioning
+	if isMigrationCompleted(ri, definitions.MarketplaceMigration) {
+		return true
+	}
+
+	m.logger.
+		WithField(serviceName, ri.Name).
+		Tracef("perform marketplace provision")
+
+	return false
 }
 
 func (m *MarketplaceMigration) updateSvcInstance(


### PR DESCRIPTION
Do not attempt to migrate marketplace provisioning, if marketplace provision migration had previously taken place.  When marketplace provision migration is complete x-agent-details marketplace migration should read complete

1. Moved check for migration completion to its own func
2. Call specific check to apiservice, to validate if marketplace migration has already completed
3. If not, run migration on the apiserviceinstance
4. If already migrated, skip migrationfor that apiserviceinstance

For the life of me, I have no idea this was still failing.  Could have sworn it was working... 

Tested
1. start with non MP v7 agent
2. discover APIs
3. apis have no migration ran on them for marketplace
4. add MP configs and start v7 agent
5. already discovered APIs ran through marketplace migration
6. API's tagged with marketplace complete for x-agent-details
7. verify as well request definitions
8. stop agent
9. start agent and verified marketplace provision migration not ran again