### PR TITLE
APIGOV-23450 - remove services with 0 instances

### DIFF
--- a/pkg/agent/aclupdatejob_test.go
+++ b/pkg/agent/aclupdatejob_test.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -124,7 +124,7 @@ func TestACLUpdateHandlerJob(t *testing.T) {
 					resp.Write([]byte(token))
 				}
 				if strings.Contains(req.RequestURI, "/apis/management/v1alpha1/environments/"+test.envName+"/accesscontrollists") {
-					aclReturn, _ := ioutil.ReadAll(req.Body)
+					aclReturn, _ := io.ReadAll(req.Body)
 					switch {
 					case req.Method == http.MethodDelete:
 						resp.WriteHeader(http.StatusNoContent)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -346,7 +345,7 @@ func isRunningInDockerContainer() bool {
 	// Within the cgroup file, if you are not in a docker container all entries are like these devices:/
 	// If in a docker container, entries are like this: devices:/docker/xxxxxxxxx.
 	// So, all we need to do is see if ":/docker" exists somewhere in the file.
-	bytes, err := ioutil.ReadFile("/proc/1/cgroup")
+	bytes, err := os.ReadFile("/proc/1/cgroup")
 	if err != nil {
 		return false
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -68,6 +69,8 @@ type agentData struct {
 	marketplaceMigration   migrate.Migrator
 	streamer               *stream.StreamerClient
 	authProviderRegistry   oauth.ProviderRegistry
+	publishingGroup        sync.WaitGroup
+	validatingGroup        sync.WaitGroup
 
 	// profiling
 	profileDone chan struct{}
@@ -174,6 +177,8 @@ func InitializeWithAgentFeatures(centralCfg config.CentralConfig, agentFeaturesC
 	}
 
 	if !agent.isInitialized {
+		agent.publishingGroup = sync.WaitGroup{}
+		agent.validatingGroup = sync.WaitGroup{}
 		setupSignalProcessor()
 		// only do the periodic health check stuff if NOT in unit tests and running binary agents
 		if util.IsNotTest() && !isRunningInDockerContainer() {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -69,8 +69,8 @@ type agentData struct {
 	marketplaceMigration   migrate.Migrator
 	streamer               *stream.StreamerClient
 	authProviderRegistry   oauth.ProviderRegistry
-	publishingGroup        sync.WaitGroup
-	validatingGroup        sync.WaitGroup
+	publishingGroup        sync.WaitGroup // wait group to block validator from publishing is happening
+	validatingGroup        sync.WaitGroup // wait group to block publishing while validator is running
 
 	// profiling
 	profileDone chan struct{}

--- a/pkg/agent/cache/accessrequest_test.go
+++ b/pkg/agent/cache/accessrequest_test.go
@@ -55,6 +55,9 @@ func TestAccessRequestCache(t *testing.T) {
 	m.AddAccessRequest(ar1ri)
 	m.AddAccessRequest(ar2ri)
 
+	keys := m.GetAccessRequestCacheKeys()
+	assert.ElementsMatch(t, []string{"ac1", "ac2"}, keys)
+
 	cachedAccessReq = m.GetAccessRequest("ac1")
 	assert.Equal(t, ar1ri, cachedAccessReq)
 

--- a/pkg/agent/cache/apiservice.go
+++ b/pkg/agent/cache/apiservice.go
@@ -71,6 +71,7 @@ func (c *cacheManager) GetAPIServiceWithAPIID(apiID string) *v1.ResourceInstance
 	api, _ := c.apiMap.Get(apiID)
 	if api == nil {
 		api, _ = c.apiMap.GetBySecondaryKey(apiID)
+		api, _ = c.apiMap.GetBySecondaryKey(apiID)
 	}
 
 	if api != nil {
@@ -146,10 +147,14 @@ func (c *cacheManager) DeleteAPIService(key string) error {
 	return err
 }
 
-func (c *cacheManager) addToServiceInstanceCount(primaryKey string) error {
+func (c *cacheManager) addToServiceInstanceCount(apiID, primaryKey string) error {
 	svc := c.GetAPIServiceWithPrimaryKey(primaryKey)
 	if svc == nil {
-		return nil
+		svc = c.GetAPIServiceWithAPIID(apiID)
+		if svc == nil {
+			// can't increment a count for a service we can't find
+			return nil
+		}
 	}
 	key := fmt.Sprintf("count-%v", svc.Name)
 
@@ -169,10 +174,14 @@ func (c *cacheManager) addToServiceInstanceCount(primaryKey string) error {
 	return nil
 }
 
-func (c *cacheManager) removeFromServiceInstanceCount(primaryKey string) error {
+func (c *cacheManager) removeFromServiceInstanceCount(apiID, primaryKey string) error {
 	svc := c.GetAPIServiceWithPrimaryKey(primaryKey)
 	if svc == nil {
-		return nil
+		svc = c.GetAPIServiceWithAPIID(apiID)
+		if svc == nil {
+			// can't decrement a count for a service we can't find
+			return nil
+		}
 	}
 	key := fmt.Sprintf("count-%v", svc.Name)
 

--- a/pkg/agent/cache/apiserviceinstance.go
+++ b/pkg/agent/cache/apiserviceinstance.go
@@ -12,10 +12,14 @@ import (
 func (c *cacheManager) AddAPIServiceInstance(resource *v1.ResourceInstance) {
 	defer c.setCacheUpdated(true)
 
+	cachedRI, _ := c.GetAPIServiceInstanceByID(resource.Metadata.ID)
 	c.instanceMap.SetWithSecondaryKey(resource.Metadata.ID, resource.Name, resource)
 
-	primaryKey, _ := util.GetAgentDetailsValue(resource, defs.AttrExternalAPIPrimaryKey)
-	c.addToServiceInstanceCount(primaryKey)
+	if cachedRI == nil {
+		apiID, _ := util.GetAgentDetailsValue(resource, defs.AttrExternalAPIID)
+		primaryKey, _ := util.GetAgentDetailsValue(resource, defs.AttrExternalAPIPrimaryKey)
+		c.addToServiceInstanceCount(apiID, primaryKey)
+	}
 }
 
 // GetAPIServiceInstanceKeys - returns keys for APIServiceInstance cache
@@ -62,8 +66,9 @@ func (c *cacheManager) DeleteAPIServiceInstance(id string) error {
 
 	ri, _ := c.GetAPIServiceInstanceByID(id)
 	if ri != nil {
+		apiID, _ := util.GetAgentDetailsValue(ri, defs.AttrExternalAPIID)
 		primaryKey, _ := util.GetAgentDetailsValue(ri, defs.AttrExternalAPIPrimaryKey)
-		c.removeFromServiceInstanceCount(primaryKey)
+		c.removeFromServiceInstanceCount(apiID, primaryKey)
 	}
 
 	return c.instanceMap.Delete(id)

--- a/pkg/agent/cache/apiserviceinstance.go
+++ b/pkg/agent/cache/apiserviceinstance.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
+	"github.com/Axway/agent-sdk/pkg/util"
 )
 
 // API service instance management
@@ -11,6 +13,9 @@ func (c *cacheManager) AddAPIServiceInstance(resource *v1.ResourceInstance) {
 	defer c.setCacheUpdated(true)
 
 	c.instanceMap.SetWithSecondaryKey(resource.Metadata.ID, resource.Name, resource)
+
+	primaryKey, _ := util.GetAgentDetailsValue(resource, defs.AttrExternalAPIPrimaryKey)
+	c.addToServiceInstanceCount(primaryKey)
 }
 
 // GetAPIServiceInstanceKeys - returns keys for APIServiceInstance cache
@@ -55,6 +60,12 @@ func (c *cacheManager) GetAPIServiceInstanceByName(name string) (*v1.ResourceIns
 func (c *cacheManager) DeleteAPIServiceInstance(id string) error {
 	defer c.setCacheUpdated(true)
 
+	ri, _ := c.GetAPIServiceInstanceByID(id)
+	if ri != nil {
+		primaryKey, _ := util.GetAgentDetailsValue(ri, defs.AttrExternalAPIPrimaryKey)
+		c.removeFromServiceInstanceCount(primaryKey)
+	}
+
 	return c.instanceMap.Delete(id)
 }
 
@@ -62,6 +73,7 @@ func (c *cacheManager) DeleteAPIServiceInstance(id string) error {
 func (c *cacheManager) DeleteAllAPIServiceInstance() {
 	defer c.setCacheUpdated(true)
 
+	c.deleteAllServiceInstanceCounts()
 	c.instanceMap.Flush()
 }
 

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -31,6 +31,7 @@ type Manager interface {
 	GetAPIServiceWithAPIID(apiID string) *v1.ResourceInstance
 	GetAPIServiceWithPrimaryKey(primaryKey string) *v1.ResourceInstance
 	GetAPIServiceWithName(apiName string) *v1.ResourceInstance
+	GetAPIServiceInstanceCount(apiName string) int
 	GetTeamsIDsInAPIServices() []string
 	DeleteAPIService(apiID string) error
 
@@ -112,6 +113,7 @@ type cacheManager struct {
 	jobs.Job
 	logger                  log.FieldLogger
 	apiMap                  cache.Cache
+	instanceCountMap        cache.Cache
 	instanceMap             cache.Cache
 	categoryMap             cache.Cache
 	managedApplicationMap   cache.Cache
@@ -139,6 +141,7 @@ func NewAgentCacheManager(cfg config.CentralConfig, persistCacheEnabled bool) Ma
 		WithPackage("sdk.agent.cache")
 	m := &cacheManager{
 		apiMap:                  cache.New(),
+		instanceCountMap:        cache.New(),
 		instanceMap:             cache.New(),
 		categoryMap:             cache.New(),
 		managedApplicationMap:   cache.New(),

--- a/pkg/agent/errors.go
+++ b/pkg/agent/errors.go
@@ -4,7 +4,7 @@ import "github.com/Axway/agent-sdk/pkg/util/errors"
 
 // Errors hit when validating Amplify Central connectivity
 var (
-	ErrDeletingService           = errors.Newf(1161, "error deleting API Service for catalog item %s in Amplify Central")
-	ErrDeletingCatalogItem       = errors.Newf(1162, "error deleting catalog item %s in Amplify Central")
-	ErrUnableToGetAPIV1Resources = errors.Newf(1163, "error retrieving API Service resource instances for %s")
+	ErrDeletingService             = errors.Newf(1161, "error deleting API Service %s in Amplify Central")
+	ErrDeletingServiceInstanceItem = errors.Newf(1162, "error deleting API Service Instance %s in Amplify Central")
+	ErrUnableToGetAPIV1Resources   = errors.Newf(1163, "error retrieving API Service resource instances for %s")
 )

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -95,7 +95,7 @@ func (j *instanceValidator) deleteServiceInstance(ri *apiV1.ResourceInstance, pr
 }
 
 func (j *instanceValidator) deleteService(ri *apiV1.ResourceInstance) {
-	log.Infof("API no longer exists on the dataplane; deleting the API Service %s", ri.Title)
+	log.Infof("API Service no longer has a service instance; deleting the API Service %s", ri.Title)
 
 	// deleting the service will delete all associated resources, including the consumerInstance
 	err := agent.apicClient.DeleteServiceByName(ri.Name)

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -42,7 +42,7 @@ func (j *instanceValidator) validateAPIOnDataplane() {
 	j.cacheLock.Lock()
 	defer j.cacheLock.Unlock()
 
-	log.Debug("validating api service instance on dataplane")
+	log.Debug("validating api service instances on dataplane")
 	// Validate the API on dataplane.  If API is not valid, mark the consumer instance as "DELETED"
 	for _, key := range agent.cacheManager.GetAPIServiceInstanceKeys() {
 		instance, err := agent.cacheManager.GetAPIServiceInstanceByID(key)
@@ -60,71 +60,47 @@ func (j *instanceValidator) validateAPIOnDataplane() {
 		// - externalAPIID should not be empty
 		// - externalAPIStage could be empty for dataplanes that do not support it
 		if externalAPIID != "" && !agent.apiValidator(externalAPIID, externalAPIStage) {
-			j.deleteServiceInstanceOrService(instance, externalPrimaryKey, externalAPIID)
+			j.deleteServiceInstance(instance, externalPrimaryKey, externalAPIID)
+		}
+	}
+
+	log.Debug("validating api services have at least one instance on dataplane")
+	for _, key := range agent.cacheManager.GetAPIServiceKeys() {
+		service := agent.cacheManager.GetAPIServiceWithPrimaryKey(key)
+		if service == nil {
+			continue
+		}
+
+		if agent.cacheManager.GetAPIServiceInstanceCount(service.Name) == 0 {
+			j.deleteService(service)
 		}
 	}
 }
 
-func (j *instanceValidator) shouldDeleteService(primaryKey, apiID string) bool {
-	count := 0
-	if primaryKey != "" {
-		count = j.getServiceInstanceCount(defs.AttrExternalAPIPrimaryKey, primaryKey)
-		log.Tracef("Query instances with externalPrimaryKey attribute : %s", primaryKey)
-	} else {
-		count = j.getServiceInstanceCount(defs.AttrExternalAPIID, apiID)
-		log.Tracef("Query instances with externalAPIID attribute : %s", apiID)
-	}
-
-	log.Tracef("Instances count : %d", count)
-
-	return count == 0
-}
-
-func (j *instanceValidator) getServiceInstanceCount(attName, attValue string) int {
-	count := 0
-	for _, key := range agent.cacheManager.GetAPIServiceInstanceKeys() {
-		instance, _ := agent.cacheManager.GetAPIServiceInstanceByID(key)
-		if instance != nil {
-			v, _ := util.GetAgentDetailsValue(instance, attName)
-			if attValue == v {
-				count++
-			}
-		}
-	}
-	return count
-}
-
-func (j *instanceValidator) deleteServiceInstanceOrService(ri *apiV1.ResourceInstance, primaryKey, apiID string) {
+func (j *instanceValidator) deleteServiceInstance(ri *apiV1.ResourceInstance, primaryKey, apiID string) {
 	// delete if it is an api service instance
-	log.Infof("API no longer exists on the dataplane, deleting the catalog item %s", ri.Title)
-	msg := "Deleted catalog item %s from Amplify Central"
+	log.Infof("API no longer exists on the dataplane, deleting the API Service Instance %s", ri.Title)
 
 	err := agent.apicClient.DeleteAPIServiceInstance(ri.Name)
 	if err != nil {
-		log.Error(utilErrors.Wrap(ErrDeletingCatalogItem, err.Error()).FormatError(ri.Title))
+		log.Error(utilErrors.Wrap(ErrDeletingServiceInstanceItem, err.Error()).FormatError(ri.Title))
 		return
 	}
 	agent.cacheManager.DeleteAPIServiceInstance(ri.Metadata.ID)
 
-	// delete if it is an api service
-	if j.shouldDeleteService(primaryKey, apiID) {
-		log.Infof("API no longer exists on the dataplane; deleting the API Service and corresponding catalog item %s", ri.Title)
-		msg = "Deleted API Service for catalog item %s from Amplify Central"
+	log.Debugf("Deleted API Service Instance item %s from Amplify Central", ri.Title)
+}
 
-		svc := agent.cacheManager.GetAPIServiceWithAPIID(apiID)
-		if svc == nil {
-			log.Errorf("api service %s not found in cache. unable to delete it from central", apiID)
-			return
-		}
+func (j *instanceValidator) deleteService(ri *apiV1.ResourceInstance) {
+	log.Infof("API no longer exists on the dataplane; deleting the API Service %s", ri.Title)
 
-		// deleting the service will delete all associated resources, including the consumerInstance
-		err = agent.apicClient.DeleteServiceByName(svc.Name)
-		agent.cacheManager.DeleteAPIService(apiID)
-		if err != nil {
-			log.Error(utilErrors.Wrap(ErrDeletingService, err.Error()).FormatError(ri.Title))
-			return
-		}
+	// deleting the service will delete all associated resources, including the consumerInstance
+	err := agent.apicClient.DeleteServiceByName(ri.Name)
+	if err != nil {
+		log.Error(utilErrors.Wrap(ErrDeletingService, err.Error()).FormatError(ri.Title))
+		return
 	}
+	agent.cacheManager.DeleteAPIService(ri.Name)
 
-	log.Debugf(msg, ri.Title)
+	log.Debugf("Deleted API Service %s from Amplify Central", ri.Title)
 }

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -34,6 +34,9 @@ func (j *instanceValidator) Status() error {
 
 // Execute -
 func (j *instanceValidator) Execute() error {
+	agent.publishingGroup.Wait()
+	agent.validatingGroup.Add(1)
+	defer agent.validatingGroup.Done()
 	j.validateAPIOnDataplane()
 	return nil
 }

--- a/pkg/agent/instancevalidator_test.go
+++ b/pkg/agent/instancevalidator_test.go
@@ -109,6 +109,7 @@ func TestValidatorAPIDoesExistsDeleteInstance(t *testing.T) {
 	setupCache("12345", "test")
 	instance := &v1.ResourceInstance{
 		ResourceMeta: v1.ResourceMeta{
+			Name: "instance123456",
 			Metadata: v1.Metadata{
 				ID: "instance-" + "123456",
 			},

--- a/pkg/agent/instancevalidator_test.go
+++ b/pkg/agent/instancevalidator_test.go
@@ -17,6 +17,7 @@ import (
 func setupCache(externalAPIID, externalAPIName string) (*v1.ResourceInstance, *v1.ResourceInstance) {
 	svc := &v1.ResourceInstance{
 		ResourceMeta: v1.ResourceMeta{
+			Name: "service",
 			Metadata: v1.Metadata{
 				ID: "svc-" + externalAPIID,
 			},
@@ -31,6 +32,7 @@ func setupCache(externalAPIID, externalAPIName string) (*v1.ResourceInstance, *v
 	}
 	instance := &v1.ResourceInstance{
 		ResourceMeta: v1.ResourceMeta{
+			Name: "instance",
 			Metadata: v1.Metadata{
 				ID: "instance-" + externalAPIID,
 			},
@@ -45,8 +47,8 @@ func setupCache(externalAPIID, externalAPIName string) (*v1.ResourceInstance, *v
 	}
 
 	agent.cacheManager = agentcache.NewAgentCacheManager(&config.CentralConfiguration{}, false)
-	agent.cacheManager.AddAPIServiceInstance(instance)
 	agent.cacheManager.AddAPIService(svc)
+	agent.cacheManager.AddAPIServiceInstance(instance)
 	return svc, instance
 }
 

--- a/pkg/agent/provisioning.go
+++ b/pkg/agent/provisioning.go
@@ -36,7 +36,7 @@ func createOrUpdateDefinition(data v1.Interface, marketplaceMigration migrate.Mi
 	}
 
 	if marketplaceMigration != nil {
-		_, err = migrateMarketPlace(marketplaceMigration, ri)
+		migrateMarketPlace(marketplaceMigration, ri)
 	}
 
 	return ri, nil

--- a/pkg/agent/teamcache_test.go
+++ b/pkg/agent/teamcache_test.go
@@ -127,7 +127,6 @@ func TestTeamCache(t *testing.T) {
 			agent.teamMap = nil
 			err := Initialize(cfg)
 			assert.Nil(t, err)
-			assert.NotNil(t, agent)
 			assert.NotNil(t, agent.apicClient)
 
 			job := centralTeamsCache{}

--- a/pkg/api/mockhttpclient.go
+++ b/pkg/api/mockhttpclient.go
@@ -72,6 +72,9 @@ func (c *MockHTTPClient) Send(request Request) (*Response, error) {
 	defer c.Unlock()
 
 	c.Requests = append(c.Requests, request)
+
+	fmt.Printf("%v - %v\n", request.Method, request.URL)
+
 	if c.Responses != nil && len(c.Responses) > 0 {
 		return c.sendMultiple(request)
 	}

--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -169,6 +169,9 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*management.AP
 			return nil, errors.New(err.Error() + e.Error())
 		}
 	}
+
+	ri, _ := svc.AsInstance()
+	c.caches.AddAPIService(ri)
 	return svc, err
 }
 

--- a/pkg/apic/apiservice_test.go
+++ b/pkg/apic/apiservice_test.go
@@ -274,7 +274,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/apiservice.json", // for call to update the service subresource
+			FileName: "./testdata/servicerevision.json", // for call to update the service subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -282,15 +282,11 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision subresource
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceRevision subresource
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/serviceinstance.json", // for call to update the serviceInstance
-			RespCode: http.StatusOK,
-		},
-		{
-			FileName: "./testdata/serviceinstance.json", // for call to update the serviceInstance subresource
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceRevision subresource
 			RespCode: http.StatusOK,
 		},
 		{
@@ -313,6 +309,8 @@ func TestUpdateService(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, apiSvc)
 
+	fmt.Println("*********************")
+
 	// tests for updating existing instance with same endpoint
 	httpClient.SetResponses([]api.MockResponse{
 		{
@@ -324,7 +322,7 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/apiservice.json", // for call to update the service subresource
+			FileName: "./testdata/servicerevision.json", // for call to update the serviceRevision
 			RespCode: http.StatusOK,
 		},
 		{
@@ -340,7 +338,15 @@ func TestUpdateService(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
+			FileName: "./testdata/serviceinstance.json", // for call to update the serviceinstance
+			RespCode: http.StatusOK,
+		},
+		{
 			FileName: "./testdata/serviceinstance.json", // for call to update the serviceinstance subresource
+			RespCode: http.StatusOK,
+		},
+		{
+			FileName: "./testdata/consumerinstance.json", // for call to update the consumerInstance
 			RespCode: http.StatusOK,
 		},
 		{
@@ -618,10 +624,6 @@ func TestUnstructuredConsumerInstanceData(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
-			RespCode: http.StatusOK,
-		},
-		{
 			FileName: "./testdata/servicerevision.json", // this for call to create the serviceRevision
 			RespCode: http.StatusCreated,
 		},
@@ -679,6 +681,7 @@ func TestUnstructuredConsumerInstanceData(t *testing.T) {
 	assert.Equal(t, contentType, consInst.Spec.UnstructuredDataProperties.ContentType)
 	assert.Equal(t, filename, consInst.Spec.UnstructuredDataProperties.FileName)
 
+	fmt.Println("*************************")
 	// this should be a full go right path
 	httpClient.SetResponses([]api.MockResponse{
 		{
@@ -690,7 +693,7 @@ func TestUnstructuredConsumerInstanceData(t *testing.T) {
 			RespCode: http.StatusOK,
 		},
 		{
-			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
+			FileName: "./testdata/servicerevision.json", // this for call to create the serviceRevision
 			RespCode: http.StatusOK,
 		},
 		{
@@ -703,10 +706,18 @@ func TestUnstructuredConsumerInstanceData(t *testing.T) {
 		},
 		{
 			FileName: "./testdata/serviceinstance.json", // this for call to create the serviceInstance
+			RespCode: http.StatusOK,
+		},
+		{
+			FileName: "./testdata/serviceinstance.json", // this for call to create the serviceInstance
 			RespCode: http.StatusCreated,
 		},
 		{
 			FileName: "./testdata/agent-details-sr.json", // this for call to create the service
+			RespCode: http.StatusOK,
+		},
+		{
+			FileName: "./testdata/consumerinstance.json", // this for call to create the consumerInstance
 			RespCode: http.StatusOK,
 		},
 		{

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -11,7 +11,6 @@ import (
 	coreapi "github.com/Axway/agent-sdk/pkg/api"
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
-	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	utilerrors "github.com/Axway/agent-sdk/pkg/util/errors"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
@@ -158,22 +157,6 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 			}
 		}
 		return err
-	}
-
-	if err == nil && len(instance.SubResources) > 0 {
-		ri.SubResources = instance.SubResources // add the subresources to the instance that will be cached
-		if xAgentDetail, ok := instance.SubResources[defs.XAgentDetails]; ok {
-			subResources := map[string]interface{}{
-				defs.XAgentDetails: xAgentDetail,
-			}
-			err = c.CreateSubResource(instance.ResourceMeta, subResources)
-			if err != nil {
-				_, rollbackErr := c.rollbackAPIService(serviceBody.serviceContext.serviceName)
-				if rollbackErr != nil {
-					return errors.New(err.Error() + rollbackErr.Error())
-				}
-			}
-		}
 	}
 
 	c.caches.AddAPIServiceInstance(ri)


### PR DESCRIPTION
- After validating instances validate services have at least 1 instance
- Update cache to track instance count in services
- Add more tests for coverage in cache package
- Add wait groups so validator and publishing do not run at the same time
- Remove code that cleans AccessRequests during publishing, no longer needed
- Move API Service cache update to apic package, service added to cache before instance
- Add API Service name as secondary key
- Remove extra call to update agent details of service instance
