### PR TITLE
APIGOV-23542 - fixes for instance counting agains services in cache

### DIFF
--- a/pkg/agent/cache/apiservice.go
+++ b/pkg/agent/cache/apiservice.go
@@ -28,6 +28,7 @@ func (c *cacheManager) AddAPIService(svc *v1.ResourceInstance) error {
 		defer c.setCacheUpdated(true)
 		apiName, _ := util.GetAgentDetailsValue(svc, defs.AttrExternalAPIName)
 		primaryKey, _ := util.GetAgentDetailsValue(svc, defs.AttrExternalAPIPrimaryKey)
+		cachedRI, _ := c.GetAPIServiceInstanceByName(apiName)
 		if primaryKey != "" {
 			// Verify secondary key and validate if we need to remove it from the apiMap (cache)
 			if _, err := c.apiMap.Get(apiID); err != nil {
@@ -41,6 +42,11 @@ func (c *cacheManager) AddAPIService(svc *v1.ResourceInstance) error {
 			c.apiMap.SetWithSecondaryKey(apiID, apiName, svc)
 			c.apiMap.SetSecondaryKey(apiID, svc.Name)
 		}
+
+		if cachedRI == nil {
+			c.countCachedInstancesForAPIService(apiID, primaryKey)
+		}
+
 		c.logger.
 			WithField("api-name", apiName).
 			WithField("api-id", apiID).

--- a/pkg/agent/cache/apiservice.go
+++ b/pkg/agent/cache/apiservice.go
@@ -12,8 +12,8 @@ import (
 
 // apiServiceToInstanceCount
 type apiServiceToInstanceCount struct {
-	count         int
-	apiServiceKey string
+	Count         int
+	ApiServiceKey string
 }
 
 // API service cache management
@@ -162,13 +162,13 @@ func (c *cacheManager) addToServiceInstanceCount(apiID, primaryKey string) error
 	svcCount := apiServiceToInstanceCount{}
 	if svcCountI == nil {
 		svcCount = apiServiceToInstanceCount{
-			count:         0,
-			apiServiceKey: svc.Metadata.ID,
+			Count:         0,
+			ApiServiceKey: svc.Metadata.ID,
 		}
 	} else {
 		svcCount = svcCountI.(apiServiceToInstanceCount)
 	}
-	svcCount.count++
+	svcCount.Count++
 
 	c.instanceCountMap.Set(key, svcCount)
 	return nil
@@ -192,7 +192,7 @@ func (c *cacheManager) removeFromServiceInstanceCount(apiID, primaryKey string) 
 	svcCount := apiServiceToInstanceCount{}
 	if svcCountI != nil {
 		svcCount = svcCountI.(apiServiceToInstanceCount)
-		svcCount.count--
+		svcCount.Count--
 	}
 
 	c.instanceCountMap.Set(key, svcCount)
@@ -213,7 +213,7 @@ func (c *cacheManager) GetAPIServiceInstanceCount(svcName string) int {
 	svcCount := apiServiceToInstanceCount{}
 	if svcCountI != nil {
 		svcCount = svcCountI.(apiServiceToInstanceCount)
-		return svcCount.count
+		return svcCount.Count
 	}
 
 	return 0

--- a/pkg/agent/cache/apiserviceinstance.go
+++ b/pkg/agent/cache/apiserviceinstance.go
@@ -101,3 +101,19 @@ func (c *cacheManager) ListAPIServiceInstances() []*v1.ResourceInstance {
 
 	return instances
 }
+
+// countCachedInstancesForAPIService - count any instances in the cache for hte newly added api
+func (c *cacheManager) countCachedInstancesForAPIService(apiID, primaryKey string) {
+	for _, k := range c.instanceMap.GetKeys() {
+		item, _ := c.instanceMap.Get(k)
+		inst, ok := item.(*v1.ResourceInstance)
+		if !ok {
+			continue
+		}
+		instAPIID, _ := util.GetAgentDetailsValue(inst, defs.AttrExternalAPIID)
+		instPrimary, _ := util.GetAgentDetailsValue(inst, defs.AttrExternalAPIPrimaryKey)
+		if apiID == instAPIID || primaryKey == instPrimary {
+			c.addToServiceInstanceCount(apiID, primaryKey)
+		}
+	}
+}

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -234,7 +234,7 @@ func (c *cacheManager) loadPersistedResourceInstanceCache(cacheMap cache.Cache, 
 		// If instance count then use apiServiceToInstanceCount type
 		if cacheKey == instanceCount {
 			ic := apiServiceToInstanceCount{}
-			if json.Unmarshal(rawResource, &ic) == nil {
+			if err := json.Unmarshal(rawResource, &ic); err == nil {
 				riCache.Set(key, ic)
 			}
 		} else {

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -233,8 +233,8 @@ func (c *cacheManager) loadPersistedResourceInstanceCache(cacheMap cache.Cache, 
 		rawResource, _ := json.Marshal(item)
 		// If instance count then use apiServiceToInstanceCount type
 		if cacheKey == instanceCount {
-			ic := &apiServiceToInstanceCount{}
-			if json.Unmarshal(rawResource, ic) == nil {
+			ic := apiServiceToInstanceCount{}
+			if json.Unmarshal(rawResource, &ic) == nil {
 				riCache.Set(key, ic)
 			}
 		} else {

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -15,6 +15,7 @@ import (
 )
 
 const defaultCacheStoragePath = "./data/cache"
+const instanceCount = "instanceCount"
 
 // Manager - interface to manage agent resource
 type Manager interface {
@@ -175,6 +176,7 @@ func (c *cacheManager) initializePersistedCache(cfg config.CentralConfig) {
 		"apiServices":         func(loaded cache.Cache) { c.apiMap = loaded },
 		"apiServiceInstances": func(loaded cache.Cache) { c.instanceMap = loaded },
 		"categories":          func(loaded cache.Cache) { c.categoryMap = loaded },
+		instanceCount:         func(loaded cache.Cache) { c.instanceCountMap = loaded },
 		"credReqDef":          func(loaded cache.Cache) { c.crdMap = loaded },
 		"accReqDef":           func(loaded cache.Cache) { c.ardMap = loaded },
 		"teams":               func(loaded cache.Cache) { c.teams = loaded },
@@ -229,10 +231,19 @@ func (c *cacheManager) loadPersistedResourceInstanceCache(cacheMap cache.Cache, 
 	for _, key := range keys {
 		item, _ := riCache.Get(key)
 		rawResource, _ := json.Marshal(item)
-		ri := &v1.ResourceInstance{}
-		if json.Unmarshal(rawResource, ri) == nil {
-			riCache.Set(key, ri)
+		// If instance count then use apiServiceToInstanceCount type
+		if cacheKey == instanceCount {
+			ic := &apiServiceToInstanceCount{}
+			if json.Unmarshal(rawResource, ic) == nil {
+				riCache.Set(key, ic)
+			}
+		} else {
+			ri := &v1.ResourceInstance{}
+			if json.Unmarshal(rawResource, ri) == nil {
+				riCache.Set(key, ri)
+			}
 		}
+
 	}
 	cacheMap.Set(cacheKey, riCache)
 	return riCache, isNew

--- a/pkg/agent/cache/manager_test.go
+++ b/pkg/agent/cache/manager_test.go
@@ -245,13 +245,13 @@ func TestSequenceCache(t *testing.T) {
 // create manager
 // add items to cache
 // save cache
-// create manager intialized with persisted cache
-// vallidate all original cached items exists
+// create manager initialized with persisted cache
+// validate all original cached items exists
 func TestCachePersistenc(t *testing.T) {
 	m := NewAgentCacheManager(&config.CentralConfiguration{AgentName: "test", GRPCCfg: config.GRPCConfig{Enabled: true}}, true)
 	assert.NotNil(t, m)
 
-	api1 := createAPIService("id1", "api1", "")
+	api1 := createAPIService("id1", "apiID", "")
 	err := m.AddAPIService(api1)
 	assert.Nil(t, err)
 
@@ -278,6 +278,7 @@ func TestCachePersistenc(t *testing.T) {
 	persistedAPI := m2.GetAPIServiceWithAPIID("id1")
 	assert.ElementsMatch(t, m.GetAPIServiceKeys(), m2.GetAPIServiceKeys())
 	assertResourceInstance(t, api1, persistedAPI)
+	assert.Equal(t, 1, m2.GetAPIServiceInstanceCount(api1.Name))
 
 	persistedInstance, err := m2.GetAPIServiceInstanceByID("id1")
 	assert.Nil(t, err)


### PR DESCRIPTION
- Fix persistent cache to correctly save instance count to disk
- When a new service is added to the cache check to see if any instances linking to that service exist in cache