### PR TITLE
APIGOV-23312 - Changes to report error message on unhealthy status

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -180,10 +180,6 @@ func InitializeWithAgentFeatures(centralCfg config.CentralConfig, agentFeaturesC
 		agent.publishingGroup = sync.WaitGroup{}
 		agent.validatingGroup = sync.WaitGroup{}
 		setupSignalProcessor()
-		// only do the periodic health check stuff if NOT in unit tests and running binary agents
-		if util.IsNotTest() && !isRunningInDockerContainer() {
-			hc.StartPeriodicHealthCheck()
-		}
 
 		if util.IsNotTest() && agent.agentFeaturesCfg.ConnectionToCentralEnabled() {
 			if agent.agentFeaturesCfg.AgentStatusUpdatesEnabled() {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -180,6 +180,10 @@ func InitializeWithAgentFeatures(centralCfg config.CentralConfig, agentFeaturesC
 		agent.publishingGroup = sync.WaitGroup{}
 		agent.validatingGroup = sync.WaitGroup{}
 		setupSignalProcessor()
+		// only do the periodic health check stuff if NOT in unit tests and running binary agents
+		if util.IsNotTest() && !isRunningInDockerContainer() {
+			hc.StartPeriodicHealthCheck()
+		}
 
 		if util.IsNotTest() && agent.agentFeaturesCfg.ConnectionToCentralEnabled() {
 			if agent.agentFeaturesCfg.AgentStatusUpdatesEnabled() {

--- a/pkg/agent/discovery.go
+++ b/pkg/agent/discovery.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Axway/agent-sdk/pkg/apic"
 	apiV1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
-	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
@@ -181,15 +180,6 @@ func publishAccessRequestDefinition(serviceBody *apic.ServiceBody) (*apiV1.Resou
 // RegisterAPIValidator - Registers callback for validating the API on gateway
 func RegisterAPIValidator(apiValidator APIValidator) {
 	agent.apiValidator = apiValidator
-
-	if agent.instanceValidatorJobID == "" && apiValidator != nil {
-		validator := newInstanceValidator()
-		jobID, err := jobs.RegisterIntervalJobWithName(validator, agent.cfg.GetPollInterval(), "API service instance validator")
-		agent.instanceValidatorJobID = jobID
-		if err != nil {
-			log.Error(err)
-		}
-	}
 }
 
 // RegisterDeleteServiceValidator - DEPRECATED Registers callback for validating if the service should be deleted

--- a/pkg/agent/eventsjob.go
+++ b/pkg/agent/eventsjob.go
@@ -38,7 +38,7 @@ type eventProcessorJob struct {
 func newEventProcessorJob(eventJob eventsJob, name string) jobs.Job {
 	streamJob := &eventProcessorJob{
 		streamer:      eventJob,
-		stop:          make(chan interface{}),
+		stop:          make(chan interface{}, 1),
 		retryInterval: defaultRetryInterval,
 		numRetry:      0,
 		name:          name,

--- a/pkg/agent/hcjob.go
+++ b/pkg/agent/hcjob.go
@@ -33,7 +33,7 @@ func (c *centralHealthCheckJob) Status() error {
 }
 
 func (c *centralHealthCheckJob) Ready() bool {
-	return c.check() == nil
+	return true
 }
 
 func (c *centralHealthCheckJob) check() error {

--- a/pkg/agent/instancevalidator.go
+++ b/pkg/agent/instancevalidator.go
@@ -10,6 +10,7 @@ import (
 	apiV1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	"github.com/Axway/agent-sdk/pkg/jobs"
 	utilErrors "github.com/Axway/agent-sdk/pkg/util/errors"
+	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
@@ -24,7 +25,8 @@ func newInstanceValidator() *instanceValidator {
 
 // Ready -
 func (j *instanceValidator) Ready() bool {
-	return true
+	status := hc.GetStatus(util.CentralHealthCheckEndpoint)
+	return status == hc.OK
 }
 
 // Status -

--- a/pkg/agent/poller/options.go
+++ b/pkg/agent/poller/options.go
@@ -30,7 +30,7 @@ func WithOnClientStop(cb func()) ClientOpt {
 func WithOnConnect() ClientOpt {
 	return func(pc *PollClient) {
 		pc.onStreamConnection = func() {
-			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
+			hc.RegisterHealthcheck(util.AmplifyCentral, util.CentralHealthCheckEndpoint, pc.Healthcheck)
 		}
 	}
 }

--- a/pkg/agent/statusupdate.go
+++ b/pkg/agent/statusupdate.go
@@ -190,7 +190,6 @@ func (su *agentStatusUpdate) getJobPoolStatus(ctx context.Context) string {
 // getHealthcheckStatus
 func (su *agentStatusUpdate) getHealthcheckStatus(ctx context.Context) (string, string) {
 	log := ctx.Value(ctxLogger).(log.FieldLogger)
-	hc.RunChecks()
 	hcStatus, hcStatusDetail := hc.GetGlobalStatus()
 	log.
 		WithField("status", hcStatus).

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -157,12 +157,13 @@ func (s *StreamerClient) Start() error {
 	listenCh := s.listener.Listen()
 
 	_, err = s.manager.RegisterWatch(s.topicSelfLink, eventCh, eventErrorCh)
-	if err != nil {
-		return err
-	}
-
 	if s.onStreamConnection != nil {
 		s.onStreamConnection()
+	}
+
+	if err != nil {
+		s.listener.Stop()
+		return err
 	}
 
 	select {

--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -145,6 +145,7 @@ func (s *StreamerClient) Start() error {
 		s.sequence,
 		s.handlers...,
 	)
+	defer s.listener.Stop()
 
 	manager, err := s.newManager(s.watchCfg, s.watchOpts...)
 	if err != nil {
@@ -168,9 +169,9 @@ func (s *StreamerClient) Start() error {
 	s.mutex.Unlock()
 
 	if err != nil {
-		s.listener.Stop()
 		return err
 	}
+
 	select {
 	case err := <-listenCh:
 		return err

--- a/pkg/agent/stream/client_test.go
+++ b/pkg/agent/stream/client_test.go
@@ -1,9 +1,10 @@
 package stream
 
 import (
+	"testing"
+
 	agentcache "github.com/Axway/agent-sdk/pkg/agent/cache"
 	"github.com/Axway/agent-sdk/pkg/apic/mock"
-	"testing"
 
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
@@ -60,7 +61,7 @@ func TestNewStreamer(t *testing.T) {
 		return manager, nil
 	}
 
-	assert.NotNil(t, streamer.Status())
+	assert.Nil(t, streamer.Status())
 
 	errCh := make(chan error)
 	go func() {

--- a/pkg/agent/stream/options.go
+++ b/pkg/agent/stream/options.go
@@ -46,7 +46,7 @@ func WithEventSyncError(cb func()) StreamerOpt {
 func WithOnStreamConnection() StreamerOpt {
 	return func(pc *StreamerClient) {
 		pc.onStreamConnection = func() {
-			hc.RegisterHealthcheck(util.AmplifyCentral, "central", pc.Healthcheck)
+			hc.RegisterHealthcheck(util.AmplifyCentral, util.CentralHealthCheckEndpoint, pc.Healthcheck)
 		}
 	}
 }

--- a/pkg/apic/subscriptionmanager.go
+++ b/pkg/apic/subscriptionmanager.go
@@ -242,7 +242,7 @@ func (sm *subscriptionManager) Start() {
 	// clean out the map each time start is called
 	sm.locklist = make(map[string]string)
 
-	if !sm.isRunning {
+	if !sm.isRunning && !sm.apicClient.cfg.IsMarketplaceSubsEnabled() {
 		sm.receiverQuitChannel = make(chan bool)
 
 		sm.ucSubPublishChan = make(chan interface{})

--- a/pkg/jobs/backoff.go
+++ b/pkg/jobs/backoff.go
@@ -28,7 +28,7 @@ func (b *backoff) increaseTimeout() {
 	defer b.backoffMutex.Unlock()
 	b.current = b.current * time.Duration(b.factor)
 	if b.current > b.max {
-		b.current = b.max // use the max timeout
+		b.current = b.base // reset to base timeout
 	}
 }
 

--- a/pkg/jobs/backoff_test.go
+++ b/pkg/jobs/backoff_test.go
@@ -29,10 +29,10 @@ func TestBackoffTimeout(t *testing.T) {
 	newBT.increaseTimeout()
 	assert.Equal(t, start*2*2, newBT.getCurrentTimeout())
 
-	// increase the timeout 2 more times, should be at max
+	// increase the timeout 2 more times to exceed max, should be reset to base
 	newBT.increaseTimeout()
 	newBT.increaseTimeout()
-	assert.Equal(t, max, newBT.getCurrentTimeout())
+	assert.Equal(t, start, newBT.getCurrentTimeout())
 
 	// reset the timeout
 	newBT.reset()

--- a/pkg/jobs/baseJob.go
+++ b/pkg/jobs/baseJob.go
@@ -120,12 +120,9 @@ func (b *baseJob) executeCronJob() {
 
 // getBackoff - get the job backoff
 func (b *baseJob) getBackoff() *backoff {
-	if b.backoff != nil {
-		b.backoffLock.Lock()
-		defer b.backoffLock.Unlock()
-		return b.backoff
-	}
-	return nil
+	b.backoffLock.Lock()
+	defer b.backoffLock.Unlock()
+	return b.backoff
 }
 
 // setBackoff - set the job backoff

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -95,9 +95,9 @@ func (b *channelJob) stop() {
 		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
+		b.UnsetIsReady()
 	} else {
 		b.stopReadyChan <- nil
 	}
 	b.setIsStopped(true)
-	b.UnsetIsReady()
 }

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -1,14 +1,8 @@
 package jobs
 
-import (
-	"sync"
-)
-
 type channelJobProps struct {
-	signalStop  chan interface{}
-	stopChan    chan bool
-	isStopped   bool
-	stoppedLock *sync.Mutex
+	signalStop chan interface{}
+	stopChan   chan bool
 }
 
 type channelJob struct {
@@ -21,9 +15,8 @@ func newDetachedChannelJob(newJob Job, signalStop chan interface{}, name string,
 	thisJob := channelJob{
 		createBaseJob(newJob, failJobChan, name, JobTypeDetachedChannel),
 		channelJobProps{
-			signalStop:  signalStop,
-			stopChan:    make(chan bool),
-			stoppedLock: &sync.Mutex{},
+			signalStop: signalStop,
+			stopChan:   make(chan bool),
 		},
 	}
 
@@ -36,9 +29,8 @@ func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJob
 	thisJob := channelJob{
 		createBaseJob(newJob, failJobChan, name, JobTypeChannel),
 		channelJobProps{
-			signalStop:  signalStop,
-			stopChan:    make(chan bool),
-			stoppedLock: &sync.Mutex{},
+			signalStop: signalStop,
+			stopChan:   make(chan bool),
 		},
 	}
 
@@ -78,18 +70,6 @@ func (b *channelJob) start() {
 	<-b.stopChan
 	b.signalStop <- nil // signal the execution to stop
 	b.SetStatus(JobStatusStopped)
-}
-
-func (b *channelJob) getIsStopped() bool {
-	b.stoppedLock.Lock()
-	defer b.stoppedLock.Unlock()
-	return b.isStopped
-}
-
-func (b *channelJob) setIsStopped(stopped bool) {
-	b.stoppedLock.Lock()
-	defer b.stoppedLock.Unlock()
-	b.isStopped = stopped
 }
 
 //stop - write to the stop channel to stop the execution loop

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -30,7 +30,7 @@ func newChannelJob(newJob Job, signalStop chan interface{}, name string, failJob
 		createBaseJob(newJob, failJobChan, name, JobTypeChannel),
 		channelJobProps{
 			signalStop: signalStop,
-			stopChan:   make(chan bool),
+			stopChan:   make(chan bool, 1),
 		},
 	}
 

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -62,6 +62,14 @@ func (b *channelJob) handleExecution() {
 func (b *channelJob) start() {
 	b.startLog()
 	b.waitForReady()
+
+	// This could happen while rescheduling the job, pool tries to start
+	// and one of the job fails which triggers stop setting the flag to not ready
+	// Return in this case to allow pool to reschedule the job
+	if !b.IsReady() {
+		return
+	}
+
 	go b.handleExecution() // start a single execution in a go routine as it runs forever
 	b.SetStatus(JobStatusRunning)
 	b.setIsStopped(false)

--- a/pkg/jobs/channeljob.go
+++ b/pkg/jobs/channeljob.go
@@ -97,7 +97,7 @@ func (b *channelJob) stop() {
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 		b.UnsetIsReady()
 	} else {
-		b.stopReadyChan <- nil
+		b.stopReadyIfWaiting(0)
 	}
 	b.setIsStopped(true)
 }

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -45,6 +45,13 @@ func (b *intervalJob) start() {
 	b.startLog()
 	b.waitForReady()
 
+	// This could happen while rescheduling the job, pool tries to start
+	// and one of the job fails which triggers stop setting the flag to not ready
+	// Return in this case to allow pool to reschedule the job
+	if !b.IsReady() {
+		return
+	}
+
 	// Execute the job now and then start the interval period
 	b.handleExecution()
 

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -20,7 +20,7 @@ func newIntervalJob(newJob Job, interval time.Duration, name string, failJobChan
 		createBaseJob(newJob, failJobChan, name, JobTypeInterval),
 		intervalJobProps{
 			interval: interval,
-			stopChan: make(chan bool),
+			stopChan: make(chan bool, 1),
 		},
 	}
 

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -72,8 +72,8 @@ func (b *intervalJob) stop() {
 		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
+		b.UnsetIsReady()
 	} else {
 		b.stopReadyChan <- nil
 	}
-	b.UnsetIsReady()
 }

--- a/pkg/jobs/intervaljob.go
+++ b/pkg/jobs/intervaljob.go
@@ -74,6 +74,6 @@ func (b *intervalJob) stop() {
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 		b.UnsetIsReady()
 	} else {
-		b.stopReadyChan <- nil
+		b.stopReadyIfWaiting(0)
 	}
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -20,7 +20,7 @@ func UpdateDurations(retryInterval time.Duration, executionTimeout time.Duration
 	durationsMutex.Lock()
 	defer durationsMutex.Unlock()
 	executionTimeLimit = executionTimeout
-	globalPool.backoff = newBackoffTimeout(retryInterval, 10*time.Minute, 2)
+	globalPool.setBackoff(newBackoffTimeout(retryInterval, 10*time.Minute, 2))
 	statusCheckInterval = retryInterval
 }
 

--- a/pkg/jobs/pool.go
+++ b/pkg/jobs/pool.go
@@ -329,6 +329,7 @@ func (p *Pool) waitStartStop(jobStatus JobStatus) bool {
 			}
 			if running {
 				done <- true
+				break
 			}
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/pkg/jobs/retryjob.go
+++ b/pkg/jobs/retryjob.go
@@ -49,7 +49,6 @@ func (b *retryJob) start() {
 //stop - noop
 func (b *retryJob) stop() {
 	b.stopLog()
-	return
 }
 
 func (b *retryJob) setExecutionRetryError() {

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -54,6 +54,13 @@ func (b *scheduleJob) start() {
 	b.startLog()
 	b.waitForReady()
 
+	// This could happen while rescheduling the job, pool tries to start
+	// and one of the job fails which triggers stop setting the flag to not ready
+	// Return in this case to allow pool to reschedule the job
+	if !b.IsReady() {
+		return
+	}
+
 	ticker := time.NewTicker(b.getNextExecution())
 	defer ticker.Stop()
 	b.SetStatus(JobStatusRunning)

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -33,7 +33,7 @@ func newScheduledJob(newJob Job, schedule, name string, failJobChan chan string)
 		scheduleJobProps{
 			cronExp:  exp,
 			schedule: schedule,
-			stopChan: make(chan bool),
+			stopChan: make(chan bool, 1),
 		},
 		&sync.Mutex{},
 	}

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -84,6 +84,6 @@ func (b *scheduleJob) stop() {
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
 		b.UnsetIsReady()
 	} else {
-		b.stopReadyChan <- nil
+		b.stopReadyIfWaiting(0)
 	}
 }

--- a/pkg/jobs/scheduledjob.go
+++ b/pkg/jobs/scheduledjob.go
@@ -82,8 +82,8 @@ func (b *scheduleJob) stop() {
 		b.baseJob.logger.Tracef("writing to %s stop channel", b.GetName())
 		b.stopChan <- true
 		b.baseJob.logger.Tracef("wrote to %s stop channel", b.GetName())
+		b.UnsetIsReady()
 	} else {
 		b.stopReadyChan <- nil
 	}
-	b.UnsetIsReady()
 }

--- a/pkg/util/healthcheck/definitions.go
+++ b/pkg/util/healthcheck/definitions.go
@@ -9,11 +9,12 @@ const defaultCheckInterval = 30 * time.Second
 
 // healthChecker - info about the service
 type healthChecker struct {
-	Name       string                  `json:"name"`
-	Version    string                  `json:"version,omitempty"`
-	Status     StatusLevel             `json:"status"`
-	Checks     map[string]*statusCheck `json:"statusChecks"`
-	registered bool
+	Name         string                  `json:"name"`
+	Version      string                  `json:"version,omitempty"`
+	Status       StatusLevel             `json:"status"`
+	StatusDetail string                  `json:"-"`
+	Checks       map[string]*statusCheck `json:"statusChecks"`
+	registered   bool
 }
 
 // Status - the status of this healthcheck

--- a/pkg/util/healthcheck/healthchecker.go
+++ b/pkg/util/healthcheck/healthchecker.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Axway/agent-sdk/pkg/api"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
-	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/google/uuid"
@@ -35,16 +34,6 @@ func init() {
 		WithComponent("healthChecker")
 }
 
-// StartPeriodicHealthCheck - starts a job that runs the periodic health checks
-func StartPeriodicHealthCheck() {
-	interval := defaultCheckInterval
-	if GetStatusConfig() != nil {
-		interval = GetStatusConfig().GetHealthCheckInterval()
-	}
-	periodicHealthCheckJob := &periodicHealthCheck{interval: interval}
-	jobs.RegisterIntervalJobWithName(periodicHealthCheckJob, periodicHealthCheckJob.interval, "Periodic Health Check")
-}
-
 // SetNameAndVersion - sets the name and version of the globalHealthChecker
 func SetNameAndVersion(name, version string) {
 	globalHealthChecker.Name = name
@@ -54,7 +43,7 @@ func SetNameAndVersion(name, version string) {
 // RegisterHealthcheck - register a new dependency with this service
 func RegisterHealthcheck(name, endpoint string, check CheckStatus) (string, error) {
 	if _, ok := globalHealthChecker.Checks[endpoint]; ok {
-		return "", fmt.Errorf("A check with the endpoint of %s already exists", endpoint)
+		return "", fmt.Errorf("a check with the endpoint of %s already exists", endpoint)
 	}
 
 	newID, _ := uuid.NewUUID()
@@ -110,20 +99,16 @@ func GetStatus(endpoint string) StatusLevel {
 
 // RunChecks - loop through all
 func RunChecks() StatusLevel {
-	passed := true
-
+	status := Status{Result: OK}
 	for _, check := range globalHealthChecker.Checks {
 		check.executeCheck()
-		if check.Status.Result == FAIL {
-			globalHealthChecker.Status = FAIL
-			passed = false
+		if check.Status.Result == FAIL && status.Result == OK {
+			status = *check.Status
 		}
 	}
 
-	// Only return to OK when all health checks pass
-	if passed {
-		globalHealthChecker.Status = OK
-	}
+	globalHealthChecker.Status = status.Result
+	globalHealthChecker.StatusDetail = status.Details
 	return globalHealthChecker.Status
 }
 
@@ -191,8 +176,8 @@ func CheckIsRunning() error {
 }
 
 // GetGlobalStatus - return the status of the global health checker
-func GetGlobalStatus() string {
-	return string(globalHealthChecker.Status)
+func GetGlobalStatus() (string, string) {
+	return string(globalHealthChecker.Status), globalHealthChecker.StatusDetail
 }
 
 // GetHealthcheckOutput - query the http endpoint and return the body
@@ -201,26 +186,26 @@ func GetHealthcheckOutput(url string) (string, error) {
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return "", fmt.Errorf("Could not query for the status")
+		return "", fmt.Errorf("could not query for the status")
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("Could not read the body of the response")
+		return "", fmt.Errorf("could not read the body of the response")
 	}
 
 	// Marshall the body to the interface sent in
 	var statusResp healthChecker
 	err = json.Unmarshal(body, &statusResp)
 	if err != nil {
-		return "", fmt.Errorf("Could not marshall into the expected type")
+		return "", fmt.Errorf("could not marshall into the expected type")
 	}
 	// Close the response body and the server
 	resp.Body.Close()
 
 	output, err := json.MarshalIndent(statusResp, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("Error formatting the Status Check into Indented JSON")
+		return "", fmt.Errorf("error formatting the Status Check into Indented JSON")
 	}
 
 	return string(output), nil

--- a/pkg/util/healthcheck/healthchecker.go
+++ b/pkg/util/healthcheck/healthchecker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Axway/agent-sdk/pkg/api"
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/jobs"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/google/uuid"
@@ -32,6 +33,16 @@ func init() {
 	logger = log.NewFieldLogger().
 		WithPackage("sdk.util.healthcheck").
 		WithComponent("healthChecker")
+}
+
+// StartPeriodicHealthCheck - starts a job that runs the periodic health checks
+func StartPeriodicHealthCheck() {
+	interval := defaultCheckInterval
+	if GetStatusConfig() != nil {
+		interval = GetStatusConfig().GetHealthCheckInterval()
+	}
+	periodicHealthCheckJob := &periodicHealthCheck{interval: interval}
+	jobs.RegisterDetachedIntervalJobWithName(periodicHealthCheckJob, periodicHealthCheckJob.interval, "Periodic Health Check")
 }
 
 // SetNameAndVersion - sets the name and version of the globalHealthChecker

--- a/pkg/util/healthcheck/periodichealthcheck.go
+++ b/pkg/util/healthcheck/periodichealthcheck.go
@@ -1,7 +1,6 @@
 package healthcheck
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/jobs"
@@ -23,7 +22,7 @@ func (sm *periodicHealthCheck) Status() error {
 func (sm *periodicHealthCheck) Execute() error {
 	status := RunChecks()
 	if status != OK {
-		return fmt.Errorf("periodicHealthCheck status is not OK. Received status %s", status)
+		logger.WithField("status", status).Warn("periodicHealthCheck status is not OK")
 	}
 	return nil
 }

--- a/pkg/util/healthcheck/periodichealthcheck.go
+++ b/pkg/util/healthcheck/periodichealthcheck.go
@@ -7,11 +7,8 @@ import (
 	"github.com/Axway/agent-sdk/pkg/jobs"
 )
 
-const maxConsecutiveErr = 3
-
 type periodicHealthCheck struct {
 	jobs.Job
-	errCount int
 	interval time.Duration
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,7 +33,8 @@ import (
 
 const (
 	// AmplifyCentral amplify central
-	AmplifyCentral = "Amplify Central"
+	AmplifyCentral             = "Amplify Central"
+	CentralHealthCheckEndpoint = "central"
 )
 
 // ComputeHash - get the hash of the byte array sent in

--- a/pkg/watchmanager/client.go
+++ b/pkg/watchmanager/client.go
@@ -86,7 +86,7 @@ func (c *watchClient) processRequest() error {
 	var err error
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-
+	wait := true
 	go func() {
 		for {
 			select {
@@ -98,12 +98,14 @@ func (c *watchClient) processRequest() error {
 				return
 			case <-c.timer.C:
 				err = c.send()
-				wg.Done()
+				if wait {
+					wg.Done()
+					wait = false
+				}
 				if err != nil {
 					c.handleError(err)
 					return
 				}
-
 			}
 		}
 	}()

--- a/pkg/watchmanager/client.go
+++ b/pkg/watchmanager/client.go
@@ -82,7 +82,11 @@ func (c *watchClient) recv() error {
 }
 
 // processRequest sends a message to the client when the timer expires, and handles when the stream is closed.
-func (c *watchClient) processRequest() {
+func (c *watchClient) processRequest() error {
+	var err error
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
 	go func() {
 		for {
 			select {
@@ -93,14 +97,19 @@ func (c *watchClient) processRequest() {
 				c.handleError(c.stream.Context().Err())
 				return
 			case <-c.timer.C:
-				err := c.send()
+				err = c.send()
+				wg.Done()
 				if err != nil {
 					c.handleError(err)
 					return
 				}
+
 			}
 		}
 	}()
+
+	wg.Wait()
+	return err
 }
 
 // send a message with a new token to the grpc server and returns the expiration time


### PR DESCRIPTION
- Changes to increase the retry interval for watch client connection
- Changes to update the agent status with the healthcheck failure message
- Change to reset the backoff interval for job pool to initial interval when current interval exceeds max
- Fix in watch client to report healthcheck failure on initial connection error
- Fix in stream client to register central healthcheck on initial connection failure