### PR TITLE
APIGOV-23866 - check for nil

### DIFF
--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -109,9 +109,16 @@ var globalMetricCollector Collector
 
 // GetMetricCollector - Create metric collector
 func GetMetricCollector() Collector {
+	// There are beat params on execution that doesn't require central config to be instantiated
+	if agent.GetCentralConfig() == nil {
+		// if this is the case, check central config and if not instantiated, return nil
+		return nil
+	}
+
 	if globalMetricCollector == nil && util.IsNotTest() {
 		globalMetricCollector = createMetricCollector()
 	}
+
 	return globalMetricCollector
 }
 


### PR DESCRIPTION
The beat library allows the following sub commands to be used
- traceability-agent.exe run --N
- traceability-agent.exe export template
- traceability-agent.exe export config
- traceability-agent.exe keystore list

Unfortunately, we have little control over these subcommands, as far as I can see.  I don't see a way to suppress them at this time.  So, instead of attacking it on that end, I decided to handle the nil pointer on the create metrics side.  With this change, it at least gets to the beats subcommand and executes them correctly.

Tested this and now these subcommands show successfully.