### PR TITLE
APIGOV-23982 - Register agent resource on agent initialization

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -19,7 +19,9 @@ import (
 	"github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic"
 	apiV1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
+	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/authz/oauth"
 	"github.com/Axway/agent-sdk/pkg/cache"
@@ -273,6 +275,7 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	if err != nil {
 		return err
 	}
+	updateEnvAgentDetails(env)
 
 	cfg.SetAxwayManaged(env.Spec.AxwayManaged)
 	if cfg.GetEnvironmentID() == "" {
@@ -290,6 +293,33 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	}
 
 	return nil
+}
+
+func updateEnvAgentDetails(env *management.Environment) {
+	if agent.cfg != nil {
+		xAgentDetail, update := setEnvAgentDetail(env)
+		if update {
+			agent.apicClient.CreateSubResource(env.ResourceMeta, map[string]interface{}{defs.XAgentDetails: xAgentDetail})
+		}
+	}
+}
+
+func setEnvAgentDetail(env *management.Environment) (xAgentDetail map[string]interface{}, updated bool) {
+	xAgentDetail = util.GetAgentDetails(env)
+	keyPrefix := agent.cfg.GetAgentType().ToString()
+	// Ignore setting x-agent-details for generic services
+	if keyPrefix != "" {
+		// update x-agent-detail if no x-agent-detail present or agent-type-enabled property not set
+		if xAgentDetail == nil {
+			xAgentDetail = map[string]interface{}{keyPrefix + "-enabled": "true"}
+			util.SetAgentDetails(env, xAgentDetail)
+			updated = true
+		} else if _, ok := xAgentDetail[keyPrefix+"-enabled"]; !ok {
+			util.SetAgentDetailsKey(env, keyPrefix+"-enabled", "true")
+			updated = true
+		}
+	}
+	return
 }
 
 func checkRunningAgent() error {

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -27,6 +27,26 @@ const (
 	GenericService
 )
 
+var agentTypeNamesMap = map[AgentType]string{
+	DiscoveryAgent:    "discoveryagent",
+	TraceabilityAgent: "traceabilityagent",
+	GovernanceAgent:   "governanceagent",
+}
+
+var agentTypeShortNamesMap = map[AgentType]string{
+	DiscoveryAgent:    "da",
+	TraceabilityAgent: "ta",
+	GovernanceAgent:   "ga",
+}
+
+func (agentType AgentType) ToString() string {
+	return agentTypeNamesMap[agentType]
+}
+
+func (agentType AgentType) ToShortString() string {
+	return agentTypeShortNamesMap[agentType]
+}
+
 // subscription approval types
 const (
 	ManualApproval  string = "manual"
@@ -841,6 +861,9 @@ func ParseCentralConfig(props properties.Properties, agentType AgentType) (Centr
 		cfg.SubscriptionConfiguration = subscriptionConfig
 		cfg.MigrationSettings = ParseMigrationConfig(props)
 		cfg.CredentialConfig = ParseCredentialConfig(props)
+	}
+	if cfg.AgentName == "" && cfg.Environment != "" && agentType.ToShortString() != "" {
+		cfg.AgentName = cfg.Environment + "-" + agentType.ToShortString()
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
- Updates to create agent resource based on the agent type if resource does not exists
- Derive the agent name based on the environment name suffixed with short name for agent type
- Changes to update x-agent-detail sub resource on Environment resource to indicate the specific agent type is enabled in the environment