### PR TITLE
APIGOV-24232 - updates on processing of services in an Unpublished state

### DIFF
--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -236,6 +236,10 @@ func (h *accessRequestHandler) getARD(ctx context.Context, ar *management.Access
 
 	// now get the access request definition from the instance
 	ard := management.NewAccessRequestDefinition(svcInst.Spec.AccessRequestDefinition, ar.Metadata.Scope.Name)
+	if ard.Spec.Provision == nil {
+		return nil, fmt.Errorf("no access request definitions are defined for service instance %s", svcInst.Name)
+	}
+
 	ri, err := h.client.GetResource(ard.GetSelfLink())
 	if err != nil {
 		return nil, err

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -229,16 +229,18 @@ func (h *accessRequestHandler) getARD(ctx context.Context, ar *management.Access
 		return nil, err
 	}
 	svcInst := management.NewAPIServiceInstance(instance.Name, instance.Metadata.Scope.Name)
+
 	err = svcInst.FromInstance(instance)
 	if err != nil {
 		return nil, err
 	}
+	// verify that the service instance has an access request definition
+	if svcInst.Spec.AccessRequestDefinition == "" {
+		return nil, fmt.Errorf("failed to provision access for service instance %s. Please contact your administrator for further assistance", svcInst.Name)
+	}
 
 	// now get the access request definition from the instance
 	ard := management.NewAccessRequestDefinition(svcInst.Spec.AccessRequestDefinition, ar.Metadata.Scope.Name)
-	if ard.Spec.Provision == nil {
-		return nil, fmt.Errorf("no access request definitions are defined for service instance %s", svcInst.Name)
-	}
 
 	ri, err := h.client.GetResource(ard.GetSelfLink())
 	if err != nil {

--- a/pkg/agent/handler/accessrequest.go
+++ b/pkg/agent/handler/accessrequest.go
@@ -236,7 +236,7 @@ func (h *accessRequestHandler) getARD(ctx context.Context, ar *management.Access
 	}
 	// verify that the service instance has an access request definition
 	if svcInst.Spec.AccessRequestDefinition == "" {
-		return nil, fmt.Errorf("failed to provision access for service instance %s. Please contact your administrator for further assistance", svcInst.Name)
+		return nil, fmt.Errorf("failed to provision access for service instance %s. Please contact your system administrator for further assistance", svcInst.Name)
 	}
 
 	// now get the access request definition from the instance

--- a/pkg/agent/handler/accessrequest_test.go
+++ b/pkg/agent/handler/accessrequest_test.go
@@ -92,7 +92,7 @@ func TestAccessRequestHandler(t *testing.T) {
 		{
 			action:         proto.Event_CREATED,
 			inboundStatus:  prov.Pending.String(),
-			name:           "should handle an error when retrieving the accress request definition, and set a failed status",
+			name:           "should handle an error when retrieving the access request definition, and set a failed status",
 			outboundStatus: prov.Error.String(),
 			references:     accessReq.Metadata.References,
 			getARDErr:      fmt.Errorf("could not get access request definition"),

--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -226,13 +226,15 @@ func (c *ServiceClient) getAPIServiceByPrimaryKey(primaryKey string) (*managemen
 }
 
 func (c *ServiceClient) getAPIServiceFromCache(serviceBody *ServiceBody) (*management.APIService, error) {
-	if serviceBody.PrimaryKey != "" {
-		apiService, err := c.getAPIServiceByPrimaryKey(serviceBody.PrimaryKey)
-		if apiService != nil && err == nil {
-			return apiService, err
-		}
+	apiService, err := c.getAPIServiceByExternalAPIID(serviceBody.RestAPIID)
+	if apiService != nil && err == nil {
+		return apiService, nil
 	}
-	return c.getAPIServiceByExternalAPIID(serviceBody.RestAPIID)
+
+	if serviceBody.PrimaryKey != "" {
+		apiService, err = c.getAPIServiceByPrimaryKey(serviceBody.PrimaryKey)
+	}
+	return apiService, err
 }
 
 // rollbackAPIService - if the process to add api/revision/instance fails, delete the api that was created

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -50,6 +50,8 @@ func (c *ServiceClient) checkCredentialRequestDefinitions(serviceBody *ServiceBo
 				knownCRDs = append(knownCRDs, crd)
 			}
 		}
+	} else {
+		log.Warnf("removed existing credential request definitions for instance %s. Contact your system administrator", serviceBody.APIName)
 	}
 
 	return knownCRDs
@@ -63,6 +65,8 @@ func (c *ServiceClient) checkAccessRequestDefinition(serviceBody *ServiceBody) {
 		if def, err := c.caches.GetAccessRequestDefinitionByName(ard); err == nil && def != nil {
 			return
 		}
+	} else {
+		log.Warnf("removed existing access request definitions for instance %s. Contact your system administrator", serviceBody.APIName)
 	}
 
 	serviceBody.ardName = ""

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -43,9 +43,12 @@ func (c *ServiceClient) checkCredentialRequestDefinitions(serviceBody *ServiceBo
 
 	// remove any crd not in the cache
 	knownCRDs := make([]string, 0)
-	for _, crd := range crds {
-		if def, err := c.caches.GetCredentialRequestDefinitionByName(crd); err == nil && def != nil {
-			knownCRDs = append(knownCRDs, crd)
+	// Check if request definitions are allowed. False would indicate the service is Unpublished
+	if serviceBody.RequestDefinitionsAllowed {
+		for _, crd := range crds {
+			if def, err := c.caches.GetCredentialRequestDefinitionByName(crd); err == nil && def != nil {
+				knownCRDs = append(knownCRDs, crd)
+			}
 		}
 	}
 
@@ -55,8 +58,11 @@ func (c *ServiceClient) checkCredentialRequestDefinitions(serviceBody *ServiceBo
 func (c *ServiceClient) checkAccessRequestDefinition(serviceBody *ServiceBody) {
 	ard := serviceBody.ardName
 
-	if def, err := c.caches.GetAccessRequestDefinitionByName(ard); err == nil && def != nil {
-		return
+	// Check if request definitions are allowed. False would indicate the service is Unpublished
+	if serviceBody.RequestDefinitionsAllowed {
+		if def, err := c.caches.GetAccessRequestDefinitionByName(ard); err == nil && def != nil {
+			return
+		}
 	}
 
 	serviceBody.ardName = ""

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -44,7 +44,7 @@ func (c *ServiceClient) checkCredentialRequestDefinitions(serviceBody *ServiceBo
 	// remove any crd not in the cache
 	knownCRDs := make([]string, 0)
 	// Check if request definitions are allowed. False would indicate the service is Unpublished
-	if serviceBody.RequestDefinitionsAllowed {
+	if serviceBody.requestDefinitionsAllowed {
 		for _, crd := range crds {
 			if def, err := c.caches.GetCredentialRequestDefinitionByName(crd); err == nil && def != nil {
 				knownCRDs = append(knownCRDs, crd)
@@ -61,7 +61,7 @@ func (c *ServiceClient) checkAccessRequestDefinition(serviceBody *ServiceBody) {
 	ard := serviceBody.ardName
 
 	// Check if request definitions are allowed. False would indicate the service is Unpublished
-	if serviceBody.RequestDefinitionsAllowed {
+	if serviceBody.requestDefinitionsAllowed {
 		if def, err := c.caches.GetAccessRequestDefinitionByName(ard); err == nil && def != nil {
 			return
 		}

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -51,7 +51,7 @@ func (c *ServiceClient) checkCredentialRequestDefinitions(serviceBody *ServiceBo
 			}
 		}
 	} else {
-		log.Warnf("removed existing credential request definitions for instance %s. Contact your system administrator", serviceBody.APIName)
+		log.Warnf("removed existing credential request definitions for instance %s. Contact your system administrator for further assistance", serviceBody.APIName)
 	}
 
 	return knownCRDs
@@ -66,7 +66,7 @@ func (c *ServiceClient) checkAccessRequestDefinition(serviceBody *ServiceBody) {
 			return
 		}
 	} else {
-		log.Warnf("removed existing access request definitions for instance %s. Contact your system administrator", serviceBody.APIName)
+		log.Warnf("removed existing access request definitions for instance %s. Contact your system administrator for further assistance", serviceBody.APIName)
 	}
 
 	serviceBody.ardName = ""

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -17,6 +17,7 @@ type ServiceBody struct {
 	APIName                   string
 	RestAPIID                 string
 	PrimaryKey                string
+	RequestDefinitionsAllowed bool
 	URL                       string
 	Stage                     string
 	StageDescriptor           string

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -17,7 +17,6 @@ type ServiceBody struct {
 	APIName                   string
 	RestAPIID                 string
 	PrimaryKey                string
-	RequestDefinitionsAllowed bool
 	URL                       string
 	Stage                     string
 	StageDescriptor           string
@@ -57,6 +56,7 @@ type ServiceBody struct {
 	specHash                  string
 	accessRequestDefinition   *management.AccessRequestDefinition
 	specHashes                map[string]interface{} // map of hash values to revision names
+	requestDefinitionsAllowed bool                   // used to validate if the instance can have request definitions or not. Use case example - v7 unpublished, remove request definitions
 }
 
 // SetAccessRequestDefinitionName - set the name of the access request definition for this service body

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -16,6 +16,7 @@ const (
 type ServiceBuilder interface {
 	SetID(ID string) ServiceBuilder
 	SetPrimaryKey(key string) ServiceBuilder
+	SetRequestDefinitionsAllowed(previouslyPublished bool) ServiceBuilder
 	SetTitle(title string) ServiceBuilder
 	SetAPIName(apiName string) ServiceBuilder
 	SetURL(url string) ServiceBuilder
@@ -93,6 +94,11 @@ func (b *serviceBodyBuilder) SetID(ID string) ServiceBuilder {
 
 func (b *serviceBodyBuilder) SetPrimaryKey(key string) ServiceBuilder {
 	b.serviceBody.PrimaryKey = key
+	return b
+}
+
+func (b *serviceBodyBuilder) SetRequestDefinitionsAllowed(key bool) ServiceBuilder {
+	b.serviceBody.RequestDefinitionsAllowed = key
 	return b
 }
 

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -98,7 +98,7 @@ func (b *serviceBodyBuilder) SetPrimaryKey(key string) ServiceBuilder {
 }
 
 func (b *serviceBodyBuilder) SetRequestDefinitionsAllowed(key bool) ServiceBuilder {
-	b.serviceBody.RequestDefinitionsAllowed = key
+	b.serviceBody.requestDefinitionsAllowed = key
 	return b
 }
 

--- a/pkg/apic/servicebuilder_test.go
+++ b/pkg/apic/servicebuilder_test.go
@@ -50,6 +50,7 @@ func TestServiceBodySetters(t *testing.T) {
 		SetAPIName("testAPI").
 		SetID("1234").
 		SetPrimaryKey("PrimaryKey").
+		SetRequestDefinitionsAllowed(true).
 		SetStage("teststage").
 		SetURL("https://1234.execute-api.us-region.amazonaws.com/teststage").
 		SetDescription(longDescription).


### PR DESCRIPTION
1.  First discover only published proxies, ignoring unpublished

2.  Cycle through all unpublished proxies and if the ID is found in the cache, meaning it had been published, update the instance of the API that has an AccessRequestDefinition/CredentialRequestDefininition attached (to be removed), not able to be subscribed to.
3.  Ignore all other unpublished APIs
4.  Continue the grouping by the primary key and the revision logic for multiple proxies with the same primary key as we do today (NOTE : on the v7 side, we are not formatting the logical key with 'vhost')

Additionally the handling of an access request should check the status of the front end proxy, if it is unpublished the returned error for display in the UI should be friendly. (ex. Access can not be granted at this time, the service is no longer published on the gateway)