### PR TITLE
APIGOV-24414 - Updated harvester client to manage purged sequences 

### DIFF
--- a/pkg/agent/poller/poller.go
+++ b/pkg/agent/poller/poller.go
@@ -61,7 +61,7 @@ func (m *pollExecutor) RegisterWatch(eventChan chan *proto.Event, errChan chan e
 		return
 	}
 
-	if m.sequence.GetSequence() == 0 {
+	if m.sequence.GetSequence() < 0 {
 		m.onHarvesterErr()
 		go func() {
 			m.Stop()

--- a/pkg/agent/poller/poller.go
+++ b/pkg/agent/poller/poller.go
@@ -101,19 +101,29 @@ func (m *pollExecutor) sync(topicSelfLink string, eventChan chan *proto.Event) e
 	}
 }
 
-func (m *pollExecutor) tick(topicSelfLink string, eventChan chan *proto.Event) error {
+func (m *pollExecutor) tick(topicSelfLink string, eventChan chan *proto.Event) (ret error) {
 	sequence := m.sequence.GetSequence()
 	logger := m.logger.WithField("sequence-id", sequence)
 	logger.Debug("retrieving harvester events")
 
-	if _, err := m.harvester.ReceiveSyncEvents(topicSelfLink, sequence, eventChan); err != nil {
+	defer func() {
+		if ret == nil {
+			m.timer.Reset(m.interval)
+		}
+	}()
+
+	if lastSeqID, err := m.harvester.ReceiveSyncEvents(topicSelfLink, sequence, eventChan); err != nil {
+		if _, ok := err.(*harvester.ErrSeqGone); ok {
+			m.sequence.SetSequence(lastSeqID)
+			return
+		}
+
 		logger.WithError(err).Error("harvester returned an error when syncing events")
 		m.onHarvesterErr()
-		return err
+		ret = err
 	}
 
-	m.timer.Reset(m.interval)
-	return nil
+	return
 }
 
 func (m *pollExecutor) onHarvesterErr() {

--- a/pkg/harvester/harvesterclient.go
+++ b/pkg/harvester/harvesterclient.go
@@ -23,6 +23,13 @@ const (
 	defaultEventPageSize = 100
 )
 
+type errSeqGone struct {
+}
+
+func (e *errSeqGone) Error() string {
+	return "sequence purged"
+}
+
 // Harvest is an interface for retrieving harvester events
 type Harvest interface {
 	EventCatchUp(link string, events chan *proto.Event) error
@@ -132,8 +139,20 @@ func (h *Client) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, event
 			return lastID, err
 		}
 
-		if res.Code != http.StatusOK {
+		if res.Code != http.StatusOK && res.Code != http.StatusGone {
 			return lastID, fmt.Errorf("expected a 200 response but received %d", res.Code)
+		}
+
+		// requested sequence is purged get the current max sequence
+		if lastID == 0 && res.Code == http.StatusGone {
+			maxSeqId, ok := res.Headers["X-Axway-Max-Sequence-Id"]
+			if ok && len(maxSeqId) > 0 {
+				lastID, err = strconv.ParseInt(maxSeqId[0], 10, 64)
+				if err != nil {
+					return lastID, err
+				}
+				return lastID, &errSeqGone{}
+			}
 		}
 
 		pagedEvents := make([]*resourceEntryExternalEvent, 0)
@@ -189,6 +208,11 @@ func (h *Client) EventCatchUp(link string, events chan *proto.Event) error {
 		var err error
 		lastSequenceID, err := h.ReceiveSyncEvents(link, sequenceID, events)
 		if err != nil {
+			if _, ok := err.(*errSeqGone); ok {
+				// Set the max sequence returned from 410 to sequence provider as processed
+				h.Cfg.SequenceProvider.SetSequence(lastSequenceID)
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/harvester/harvesterclient.go
+++ b/pkg/harvester/harvesterclient.go
@@ -23,10 +23,11 @@ const (
 	defaultEventPageSize = 100
 )
 
-type errSeqGone struct {
+// ErrSeqGone - error for purged sequence
+type ErrSeqGone struct {
 }
 
-func (e *errSeqGone) Error() string {
+func (e *ErrSeqGone) Error() string {
 	return "sequence purged"
 }
 
@@ -151,7 +152,7 @@ func (h *Client) ReceiveSyncEvents(topicSelfLink string, sequenceID int64, event
 				if err != nil {
 					return lastID, err
 				}
-				return lastID, &errSeqGone{}
+				return lastID, &ErrSeqGone{}
 			}
 		}
 
@@ -208,7 +209,7 @@ func (h *Client) EventCatchUp(link string, events chan *proto.Event) error {
 		var err error
 		lastSequenceID, err := h.ReceiveSyncEvents(link, sequenceID, events)
 		if err != nil {
-			if _, ok := err.(*errSeqGone); ok {
+			if _, ok := err.(*ErrSeqGone); ok {
 				// Set the max sequence returned from 410 to sequence provider as processed
 				h.Cfg.SequenceProvider.SetSequence(lastSequenceID)
 				return nil

--- a/pkg/watchmanager/manager.go
+++ b/pkg/watchmanager/manager.go
@@ -148,7 +148,7 @@ func (m *watchManager) RegisterWatch(link string, events chan *proto.Event, erro
 	subscriptionID, _ := uuid.NewUUID()
 	subID := subscriptionID.String()
 
-	if m.options.sequence != nil && m.options.sequence.GetSequence() == 0 {
+	if m.options.sequence != nil && m.options.sequence.GetSequence() < 0 {
 		err := fmt.Errorf("do not have a sequence id, stopping watch manager")
 		m.logger.Error(err.Error())
 		m.CloseWatch(subID)


### PR DESCRIPTION
- Changes to process 410 response from harvester and use the sequence to watch for following events.
- Fix in watch manager to initialize with no sequence 