### PR TITLE
APIGOV-25078 - Changes to reduce the status updates on startup healthcheck failures

### DIFF
--- a/pkg/agent/aclupdatejob_test.go
+++ b/pkg/agent/aclupdatejob_test.go
@@ -126,8 +126,8 @@ func TestACLUpdateHandlerJob(t *testing.T) {
 				if strings.Contains(req.RequestURI, "/apis/management/v1alpha1/environments/"+test.envName+"/accesscontrollists") {
 					aclReturn, _ := io.ReadAll(req.Body)
 					switch {
-					case req.Method == http.MethodDelete:
-						resp.WriteHeader(http.StatusNoContent)
+					case req.Method == http.MethodPut:
+						fallthrough
 					case req.Method == http.MethodPost:
 						resp.WriteHeader(http.StatusCreated)
 						resp.Write(aclReturn)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -210,10 +210,6 @@ func handleInitialization() error {
 	}
 
 	if util.IsNotTest() && agent.agentFeaturesCfg.ConnectionToCentralEnabled() {
-		if agent.agentFeaturesCfg.AgentStatusUpdatesEnabled() {
-			StartAgentStatusUpdate()
-		}
-
 		// if credentials can expire and need to be deprovisioned then start the credential checker
 		if agent.cfg.GetCredentialConfig() != nil &&
 			agent.cfg.GetCredentialConfig().GetExpirationDays() > 0 &&
@@ -227,11 +223,6 @@ func handleInitialization() error {
 		err := registerSubscriptionWebhook(agent.cfg.GetAgentType(), agent.apicClient)
 		if err != nil {
 			return errors.Wrap(errors.ErrRegisterSubscriptionWebhook, err.Error())
-		}
-
-		// Set agent running
-		if agent.agentResourceManager != nil && agent.agentFeaturesCfg.AgentStatusUpdatesEnabled() {
-			UpdateStatusWithPrevious(AgentRunning, "", "")
 		}
 	}
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -137,7 +137,7 @@ func NewClientWithTimeout(tlsCfg config.TLSConfig, proxyURL string, timeout time
 
 // NewSingleEntryClient - creates a new HTTP client for single entry point with a timeout
 func NewSingleEntryClient(tlsCfg config.TLSConfig, proxyURL string, timeout time.Duration) Client {
-	log.DeprecationWarningReplace("NewClientWithTimeout", "NewClient and WithSingleURL optional func")
+	log.DeprecationWarningReplace("NewSingleEntryClient", "NewClient and WithSingleURL optional func")
 	return NewClient(tlsCfg, proxyURL, WithTimeout(timeout), WithSingleURL())
 }
 

--- a/pkg/apic/auth/apicauth.go
+++ b/pkg/apic/auth/apicauth.go
@@ -152,10 +152,11 @@ func (ptp *platformTokenGetter) initAxwayIDPClient() error {
 		return err
 	}
 
-	apiClient := api.NewSingleEntryClient(
+	apiClient := api.NewClient(
 		ptp.cfg.GetTLSConfig(),
 		ptp.cfg.GetProxyURL(),
-		ptp.cfg.GetAuthConfig().GetTimeout())
+		api.WithTimeout(ptp.cfg.GetAuthConfig().GetTimeout()),
+		api.WithSingleURL())
 
 	ptp.axwayIDClient, err = oauth.NewAuthClient(ptp.cfg.GetAuthConfig().GetTokenURL(), apiClient,
 		oauth.WithServerName("AxwayId"),

--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -174,7 +174,8 @@ func (c *ServiceClient) GetOrCreateCategory(title string) string {
 // initClient - config change handler
 func (c *ServiceClient) initClient(cfg corecfg.CentralConfig) {
 	c.cfg = cfg
-	c.apiClient = coreapi.NewSingleEntryClient(cfg.GetTLSConfig(), cfg.GetProxyURL(), cfg.GetClientTimeout())
+	c.apiClient = coreapi.NewClient(cfg.GetTLSConfig(), cfg.GetProxyURL(),
+		coreapi.WithTimeout(cfg.GetClientTimeout()), coreapi.WithSingleURL())
 	c.DefaultSubscriptionSchema = NewSubscriptionSchema(cfg.GetEnvironmentName() + SubscriptionSchemaNameSuffix)
 
 	err := c.setTeamCache()
@@ -205,7 +206,8 @@ func (c *ServiceClient) SetTokenGetter(tokenRequester auth.PlatformTokenGetter) 
 // SetConfig - sets the config and apiClient
 func (c *ServiceClient) SetConfig(cfg corecfg.CentralConfig) {
 	c.cfg = cfg
-	c.apiClient = coreapi.NewSingleEntryClient(cfg.GetTLSConfig(), cfg.GetProxyURL(), cfg.GetClientTimeout())
+	c.apiClient = coreapi.NewClient(cfg.GetTLSConfig(), cfg.GetProxyURL(),
+		coreapi.WithTimeout(cfg.GetClientTimeout()), coreapi.WithSingleURL())
 }
 
 // mapToTagsArray -
@@ -560,11 +562,7 @@ func (c *ServiceClient) GetAccessControlList(name string) (*management.AccessCon
 
 // UpdateAccessControlList - removes existing then creates new AccessControlList
 func (c *ServiceClient) UpdateAccessControlList(acl *management.AccessControlList) (*management.AccessControlList, error) {
-	// first delete the existing access control list
-	if _, err := c.deployAccessControl(acl, http.MethodDelete); err != nil {
-		return nil, err
-	}
-	return c.deployAccessControl(acl, http.MethodPost)
+	return c.deployAccessControl(acl, http.MethodPut)
 }
 
 // CreateAccessControlList -

--- a/pkg/authz/oauth/provider.go
+++ b/pkg/authz/oauth/provider.go
@@ -52,7 +52,7 @@ func NewProvider(idp corecfg.IDPConfig, tlsCfg corecfg.TLSConfig, proxyURL strin
 		WithComponent("provider").
 		WithPackage("sdk.agent.authz.oauth")
 
-	apiClient := coreapi.NewClientWithTimeout(tlsCfg, proxyURL, clientTimeout)
+	apiClient := coreapi.NewClient(tlsCfg, proxyURL, coreapi.WithTimeout(clientTimeout))
 	var idpType typedIDP
 	switch idp.GetIDPType() {
 	case TypeOkta:

--- a/pkg/cmd/agentversionjob.go
+++ b/pkg/cmd/agentversionjob.go
@@ -102,7 +102,9 @@ func NewAgentVersionCheckJob(cfg config.CentralConfig) (*AgentVersionCheckJob, e
 	}
 
 	return &AgentVersionCheckJob{
-		apiClient:    coreapi.NewSingleEntryClient(cfg.GetTLSConfig(), cfg.GetProxyURL(), cfg.GetClientTimeout()),
+		apiClient: coreapi.NewClient(cfg.GetTLSConfig(), cfg.GetProxyURL(),
+			coreapi.WithTimeout(cfg.GetClientTimeout()),
+			coreapi.WithSingleURL()),
 		buildVersion: buildVersion,
 		requestBytes: requestBytes,
 		headers: map[string]string{

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -376,6 +376,10 @@ func (c *agentRootCommand) run(cmd *cobra.Command, args []string) (err error) {
 
 			c.healthCheckTicker()
 
+			if util.IsNotTest() && c.agentFeaturesCfg.AgentStatusUpdatesEnabled() {
+				agent.StartAgentStatusUpdate()
+			}
+
 			err = c.commandHandler()
 			if err != nil {
 				log.Error(err.Error())

--- a/pkg/harvester/harvesterclient.go
+++ b/pkg/harvester/harvesterclient.go
@@ -240,5 +240,6 @@ func newSingleEntryClient(cfg *Config) api.Client {
 		clientTimeout = util.DefaultKeepAliveTimeout
 	}
 
-	return api.NewSingleEntryClient(tlsCfg, cfg.ProxyURL, clientTimeout)
+	return api.NewClient(tlsCfg, cfg.ProxyURL,
+		api.WithTimeout(clientTimeout), api.WithSingleURL())
 }

--- a/pkg/transaction/metric/metricspublisher.go
+++ b/pkg/transaction/metric/metricspublisher.go
@@ -104,10 +104,12 @@ func (c *metricPublisher) createFilePart(w *multipart.Writer, filename string) (
 func newMetricPublisher(storage storageCache, report *cacheReport) *metricPublisher {
 	centralCfg := agent.GetCentralConfig()
 	publisher := &metricPublisher{
-		apiClient: api.NewSingleEntryClient(centralCfg.GetTLSConfig(), centralCfg.GetProxyURL(), centralCfg.GetClientTimeout()),
-		storage:   storage,
-		report:    report,
-		offline:   agent.GetCentralConfig().GetUsageReportingConfig().IsOfflineMode(),
+		apiClient: api.NewClient(centralCfg.GetTLSConfig(), centralCfg.GetProxyURL(),
+			api.WithTimeout(centralCfg.GetClientTimeout()),
+			api.WithSingleURL()),
+		storage: storage,
+		report:  report,
+		offline: agent.GetCentralConfig().GetUsageReportingConfig().IsOfflineMode(),
 	}
 
 	publisher.registerReportJob()

--- a/pkg/util/healthcheck/healthchecker.go
+++ b/pkg/util/healthcheck/healthchecker.go
@@ -187,7 +187,7 @@ func (s *Server) startHealthCheckServer() {
 // CheckIsRunning - Checks if another instance is already running by looking at the healthcheck.
 func CheckIsRunning() error {
 	if statusConfig != nil && statusConfig.GetPort() > 0 {
-		apiClient := api.NewClientWithTimeout(nil, "", 5*time.Second)
+		apiClient := api.NewClient(nil, "", api.WithTimeout(5*time.Second))
 		req := api.Request{
 			Method: "GET",
 			URL:    "http://0.0.0.0:" + strconv.Itoa(statusConfig.GetPort()) + "/status",


### PR DESCRIPTION
- Updates to register status update jobs after the startup healthcheck to reduce status update calls due to restarts of the failing agent running as service
- Changes to use the existing subjects on the ACL resource to verify if the ACL needs to be updated.
- Changes to use PUT call for updating the ACL resource instead of DELETE followed by POST