### PR TITLE
APIGOV-24074 - remove notating env of agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -19,9 +19,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/api"
 	"github.com/Axway/agent-sdk/pkg/apic"
 	apiV1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
-	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/auth"
-	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/authz/oauth"
 	"github.com/Axway/agent-sdk/pkg/cache"
@@ -261,7 +259,6 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	if err != nil {
 		return err
 	}
-	updateEnvAgentDetails(env, client)
 
 	cfg.SetAxwayManaged(env.Spec.AxwayManaged)
 	if cfg.GetEnvironmentID() == "" {
@@ -283,33 +280,6 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	}
 
 	return nil
-}
-
-func updateEnvAgentDetails(env *management.Environment, client apic.Client) {
-	if agent.cfg != nil {
-		xAgentDetail, update := setEnvAgentDetail(env)
-		if update {
-			client.CreateSubResource(env.ResourceMeta, map[string]interface{}{defs.XAgentDetails: xAgentDetail})
-		}
-	}
-}
-
-func setEnvAgentDetail(env *management.Environment) (xAgentDetail map[string]interface{}, updated bool) {
-	xAgentDetail = util.GetAgentDetails(env)
-	keyPrefix := agent.cfg.GetAgentType().ToString()
-	// Ignore setting x-agent-details for generic services
-	if keyPrefix != "" {
-		// update x-agent-detail if no x-agent-detail present or agent-type-enabled property not set
-		if xAgentDetail == nil {
-			xAgentDetail = map[string]interface{}{keyPrefix + "-enabled": "true"}
-			util.SetAgentDetails(env, xAgentDetail)
-			updated = true
-		} else if _, ok := xAgentDetail[keyPrefix+"-enabled"]; !ok {
-			util.SetAgentDetailsKey(env, keyPrefix+"-enabled", "true")
-			updated = true
-		}
-	}
-	return
 }
 
 func checkRunningAgent() error {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Axway/agent-sdk/pkg/apic"
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/apic/mock"
-	"github.com/Axway/agent-sdk/pkg/util"
 
 	"github.com/Axway/agent-sdk/pkg/util/log"
 
@@ -271,24 +270,18 @@ func TestInitEnvironment(t *testing.T) {
 	defer resetResources()
 	err := initEnvResources(agent.cfg, apiClient)
 	assert.Nil(t, err)
-	xAgentDetail := util.GetAgentDetails(environmentRes)
-	assert.Nil(t, xAgentDetail)
 
 	cfg = createCentralCfg(s.URL, "v7")
 	cfg.AgentType = config.DiscoveryAgent
 	agent.cfg = cfg
 	err = initEnvResources(agent.cfg, apiClient)
 	assert.Nil(t, err)
-	xAgentDetail = util.GetAgentDetails(environmentRes)
-	assert.NotNil(t, xAgentDetail)
 
 	cfg = createCentralCfg(s.URL, "v7")
 	cfg.AgentType = config.TraceabilityAgent
 	agent.cfg = cfg
 	err = initEnvResources(agent.cfg, apiClient)
 	assert.Nil(t, err)
-	xAgentDetail = util.GetAgentDetails(environmentRes)
-	assert.NotNil(t, xAgentDetail)
 }
 
 func TestAgentConfigOverride(t *testing.T) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -281,7 +281,6 @@ func TestInitEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 	xAgentDetail = util.GetAgentDetails(environmentRes)
 	assert.NotNil(t, xAgentDetail)
-	assert.Equal(t, "true", xAgentDetail[config.DiscoveryAgent.ToString()+"-enabled"])
 
 	cfg = createCentralCfg(s.URL, "v7")
 	cfg.AgentType = config.TraceabilityAgent
@@ -290,8 +289,6 @@ func TestInitEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 	xAgentDetail = util.GetAgentDetails(environmentRes)
 	assert.NotNil(t, xAgentDetail)
-	assert.Equal(t, "true", xAgentDetail[config.DiscoveryAgent.ToString()+"-enabled"])
-	assert.Equal(t, "true", xAgentDetail[config.TraceabilityAgent.ToString()+"-enabled"])
 }
 
 func TestAgentConfigOverride(t *testing.T) {

--- a/pkg/config/usagereportingconfig_test.go
+++ b/pkg/config/usagereportingconfig_test.go
@@ -166,7 +166,7 @@ func TestUsageReportingConfigProperties(t *testing.T) {
 	assert.NotNil(t, err)
 	cfg.(*UsageReportingConfiguration).UsageSchedule = "0,15,30,45,55 * * * *"
 	err = validateUsageReporting(cfg)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	cfg.(*UsageReportingConfiguration).UsageSchedule = currentUsageSchedule
 
 	// QA UsageSchedule override

--- a/pkg/config/usagereportingconfig_test.go
+++ b/pkg/config/usagereportingconfig_test.go
@@ -166,7 +166,7 @@ func TestUsageReportingConfigProperties(t *testing.T) {
 	assert.NotNil(t, err)
 	cfg.(*UsageReportingConfiguration).UsageSchedule = "0,15,30,45,55 * * * *"
 	err = validateUsageReporting(cfg)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	cfg.(*UsageReportingConfiguration).UsageSchedule = currentUsageSchedule
 
 	// QA UsageSchedule override


### PR DESCRIPTION
No longer have SDK annotate environment of agents running on the Environment, this will be handled on the SaaS side. 