### PR TITLE
APIGOV-25440 - updates for api transaction and metric defs

### DIFF
--- a/pkg/apic/apiserver/models/api/v1/owner.go
+++ b/pkg/apic/apiserver/models/api/v1/owner.go
@@ -50,12 +50,14 @@ func (o *Owner) MarshalJSON() ([]byte, error) {
 	}
 
 	aux := struct {
-		Type string `json:"type,omitempty"`
-		ID   string `json:"id"`
+		Type         string       `json:"type,omitempty"`
+		ID           string       `json:"id"`
+		Organization Organization `json:"organization,omitempty"`
 	}{}
 
 	aux.Type = t
 	aux.ID = o.ID
+	aux.Organization = o.Organization
 
 	return json.Marshal(aux)
 }
@@ -63,8 +65,9 @@ func (o *Owner) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshalls the owner from JSON to convert the owner type to a string
 func (o *Owner) UnmarshalJSON(bytes []byte) error {
 	aux := struct {
-		Type string `json:"type,omitempty"`
-		ID   string `json:"id"`
+		Type         string       `json:"type,omitempty"`
+		ID           string       `json:"id"`
+		Organization Organization `json:"organization,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(bytes, &aux); err != nil {
@@ -77,6 +80,7 @@ func (o *Owner) UnmarshalJSON(bytes []byte) error {
 	}
 	o.Type = ownerString
 	o.ID = aux.ID
+	o.Organization = aux.Organization
 
 	return nil
 }

--- a/pkg/transaction/eventgenerator.go
+++ b/pkg/transaction/eventgenerator.go
@@ -78,7 +78,7 @@ func (e *Generator) CreateEvent(logEvent LogEvent, eventTime time.Time, metaData
 
 func (e *Generator) trackMetrics(summaryEvent LogEvent, bytes int64) {
 	if e.shouldUseTrafficForAggregation {
-		apiDetails := metric.APIDetails{
+		apiDetails := models.APIDetails{
 			ID:       summaryEvent.TransactionSummary.Proxy.ID,
 			Name:     summaryEvent.TransactionSummary.Proxy.Name,
 			Revision: summaryEvent.TransactionSummary.Proxy.Revision,
@@ -92,7 +92,7 @@ func (e *Generator) trackMetrics(summaryEvent LogEvent, bytes int64) {
 
 		statusCode := summaryEvent.TransactionSummary.StatusDetail
 		duration := summaryEvent.TransactionSummary.Duration
-		appDetails := metric.AppDetails{}
+		appDetails := models.AppDetails{}
 		if summaryEvent.TransactionSummary.Application != nil {
 			appDetails.Name = summaryEvent.TransactionSummary.Application.Name
 			appDetails.ID = strings.TrimLeft(summaryEvent.TransactionSummary.Application.ID, SummaryEventApplicationIDPrefix)

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -27,11 +27,11 @@ const (
 // Detail - holds the details for computing metrics
 // for API and consumer subscriptions
 type Detail struct {
-	APIDetails APIDetails
+	APIDetails models.APIDetails
 	StatusCode string
 	Duration   int64
 	Bytes      int64
-	AppDetails AppDetails
+	AppDetails models.AppDetails
 }
 
 // ResponseMetrics - Holds metrics API response
@@ -48,6 +48,7 @@ type ObservationDetails struct {
 }
 
 // APIDetails - Holds the api details
+// DEPRECATED
 type APIDetails struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
@@ -60,10 +61,10 @@ type APIDetails struct {
 
 // APIMetric - struct to hold metric aggregated for subscription,application,api,statuscode
 type APIMetric struct {
-	Subscription  SubscriptionDetails  `json:"subscription"`
-	App           AppDetails           `json:"application"`
+	Subscription  models.Subscription  `json:"subscription"`
+	App           models.AppDetails    `json:"application"`
 	Product       models.Product       `json:"product,omitempty"`
-	API           APIDetails           `json:"api"`
+	API           models.APIDetails    `json:"api"`
 	AssetResource models.AssetResource `json:"assetResource,omitempty"`
 	ProductPlan   models.ProductPlan   `json:"productPlan,omitempty"`
 	Quota         models.Quota         `json:"quota,omitempty"`
@@ -87,10 +88,10 @@ func (a *APIMetric) GetType() string {
 
 // cachedMetric - struct to hold metric specific that gets cached and used for agent recovery
 type cachedMetric struct {
-	Subscription  SubscriptionDetails  `json:"subscription,omitempty"`
-	App           AppDetails           `json:"app,omitempty"`
+	Subscription  models.Subscription  `json:"subscription,omitempty"`
+	App           models.AppDetails    `json:"app,omitempty"`
 	Product       models.Product       `json:"product,omitempty"`
-	API           APIDetails           `json:"api"`
+	API           models.APIDetails    `json:"api"`
 	AssetResource models.AssetResource `json:"assetResource,omitempty"`
 	ProductPlan   models.ProductPlan   `json:"productPlan,omitempty"`
 	Quota         models.Quota         `json:"quota,omitempty"`
@@ -148,6 +149,7 @@ type LighthouseUsageEvent struct {
 }
 
 // AppDetails - struct for app details to report
+// DEPRECATED
 type AppDetails struct {
 	ID            string `json:"id"`
 	Name          string `json:"name"`
@@ -155,6 +157,7 @@ type AppDetails struct {
 }
 
 // SubscriptionDetails - struct for subscription metric detail
+// DEPRECATED
 type SubscriptionDetails struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -162,18 +165,18 @@ type SubscriptionDetails struct {
 
 // Data - struct for data to report as API Metrics
 type Data struct {
-	APIDetails APIDetails
+	APIDetails models.APIDetails
 	StatusCode string
 	Duration   int64
 	UsageBytes int64
-	AppDetails AppDetails
+	AppDetails models.AppDetails
 	TeamName   string
 }
 
 // AppUsage - struct to hold metric specific for app usage
 type AppUsage struct {
-	App   AppDetails `json:"app"`
-	Count int64      `json:"count"`
+	App   models.AppDetails `json:"app"`
+	Count int64             `json:"count"`
 }
 
 // ISO8601 - time format

--- a/pkg/transaction/metric/definition.go
+++ b/pkg/transaction/metric/definition.go
@@ -47,18 +47,6 @@ type ObservationDetails struct {
 	End   int64 `json:"end,omitempty"`
 }
 
-// APIDetails - Holds the api details
-// DEPRECATED
-type APIDetails struct {
-	ID                 string `json:"id"`
-	Name               string `json:"name"`
-	Revision           int    `json:"revision,omitempty"`
-	TeamID             string `json:"teamId,omitempty"`
-	APIServiceInstance string `json:"apiServiceInstance,omitempty"`
-	Stage              string `json:"-"`
-	Version            string `json:"-"`
-}
-
 // APIMetric - struct to hold metric aggregated for subscription,application,api,statuscode
 type APIMetric struct {
 	Subscription  models.Subscription  `json:"subscription"`
@@ -146,21 +134,6 @@ type LighthouseUsageEvent struct {
 	SchemaID    string                           `json:"schemaId"`
 	Report      map[string]LighthouseUsageReport `json:"report"`
 	Meta        map[string]interface{}           `json:"meta"`
-}
-
-// AppDetails - struct for app details to report
-// DEPRECATED
-type AppDetails struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	ConsumerOrgID string `json:"consumerOrgId,omitempty"`
-}
-
-// SubscriptionDetails - struct for subscription metric detail
-// DEPRECATED
-type SubscriptionDetails struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
 }
 
 // Data - struct for data to report as API Metrics

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -46,7 +46,7 @@ func ExitMetricInit() {
 
 // Collector - interface for collecting metrics
 type Collector interface {
-	AddMetric(apiDetails APIDetails, statusCode string, duration, bytes int64, appName string)
+	AddMetric(apiDetails models.APIDetails, statusCode string, duration, bytes int64, appName string)
 	AddMetricDetail(metricDetail Detail)
 }
 
@@ -221,7 +221,7 @@ func (c *collector) Execute() error {
 }
 
 // AddMetric - add metric for API transaction to collection
-func (c *collector) AddMetric(apiDetails APIDetails, statusCode string, duration, bytes int64, appName string) {
+func (c *collector) AddMetric(apiDetails models.APIDetails, statusCode string, duration, bytes int64, appName string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.batchLock.Lock()
@@ -363,8 +363,8 @@ func (c *collector) getAccessRequestAndManagedApp(cacheManager cache.Manager, de
 	return accessRequest, managedApp
 }
 
-func (c *collector) createSubscriptionDetail(subRef v1.Reference) SubscriptionDetails {
-	detail := SubscriptionDetails{
+func (c *collector) createSubscriptionDetail(subRef v1.Reference) models.Subscription {
+	detail := models.Subscription{
 		ID:   unknown,
 		Name: unknown,
 	}
@@ -376,8 +376,8 @@ func (c *collector) createSubscriptionDetail(subRef v1.Reference) SubscriptionDe
 	return detail
 }
 
-func (c *collector) createAppDetail(app *v1.ResourceInstance) AppDetails {
-	detail := AppDetails{
+func (c *collector) createAppDetail(app *v1.ResourceInstance) models.AppDetails {
+	detail := models.AppDetails{
 		ID:   unknown,
 		Name: unknown,
 	}
@@ -389,8 +389,8 @@ func (c *collector) createAppDetail(app *v1.ResourceInstance) AppDetails {
 	return detail
 }
 
-func (c *collector) createAPIDetail(api APIDetails, accessReq *management.AccessRequest) APIDetails {
-	detail := APIDetails{
+func (c *collector) createAPIDetail(api models.APIDetails, accessReq *management.AccessRequest) models.APIDetails {
+	detail := models.APIDetails{
 		ID:                 api.ID,
 		Name:               api.Name,
 		Revision:           api.Revision,

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/cmd"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/traceability"
+	"github.com/Axway/agent-sdk/pkg/transaction/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -340,11 +341,11 @@ func TestMetricCollector(t *testing.T) {
 				fmt.Printf("\n\nTransaction Info: %+v\n\n", test.apiTransactionCount[l])
 				for i := 0; i < test.apiTransactionCount[l]; i++ {
 					metricDetail := Detail{
-						APIDetails: APIDetails{"111", "111", 1, teamID, "", "", ""},
+						APIDetails: models.APIDetails{"111", "111", 1, teamID, "", "", ""},
 						StatusCode: "200",
 						Duration:   10,
 						Bytes:      10,
-						AppDetails: AppDetails{
+						AppDetails: models.AppDetails{
 							ID:   "111",
 							Name: test.appName,
 						},
@@ -398,13 +399,13 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector := createMetricCollector()
 			metricCollector := myCollector.(*collector)
 
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
 			metricCollector.Execute()
 			metricCollector.publisher.Execute()
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
 
 			// No event generation/publish, store the cache
 			metricCollector.storage.save()
@@ -420,11 +421,11 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector = createMetricCollector()
 			metricCollector = myCollector.(*collector)
 
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
-			metricCollector.AddMetric(APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
+			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
 
 			metricCollector.Execute()
 			metricCollector.publisher.Execute()
@@ -537,7 +538,7 @@ func TestOfflineMetricCollector(t *testing.T) {
 			publisher := metricCollector.publisher
 			for testLoops < test.loopCount {
 				for i := 0; i < test.apiTransactionCount[testLoops]; i++ {
-					metricCollector.AddMetric(APIDetails{"111", "111", 1, "team123", "", "", ""}, "200", 10, 10, "")
+					metricCollector.AddMetric(models.APIDetails{"111", "111", 1, "team123", "", "", ""}, "200", 10, 10, "")
 				}
 				metricCollector.Execute()
 				testLoops++

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -22,6 +22,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	apiDetails1 = models.APIDetails{
+		ID:                 "111",
+		Name:               "111",
+		Revision:           1,
+		TeamID:             teamID,
+		APIServiceInstance: "",
+		Stage:              "",
+		Version:            "",
+	}
+	apiDetails2 = models.APIDetails{
+		ID:                 "111",
+		Name:               "111",
+		Revision:           1,
+		TeamID:             teamID,
+		APIServiceInstance: "",
+		Stage:              "",
+		Version:            "",
+	}
+)
+
 func createCentralCfg(url, env string) *config.CentralConfiguration {
 
 	cfg := config.NewCentralConfig(config.TraceabilityAgent).(*config.CentralConfiguration)
@@ -341,7 +362,7 @@ func TestMetricCollector(t *testing.T) {
 				fmt.Printf("\n\nTransaction Info: %+v\n\n", test.apiTransactionCount[l])
 				for i := 0; i < test.apiTransactionCount[l]; i++ {
 					metricDetail := Detail{
-						APIDetails: models.APIDetails{"111", "111", 1, teamID, "", "", ""},
+						APIDetails: apiDetails1,
 						StatusCode: "200",
 						Duration:   10,
 						Bytes:      10,
@@ -399,13 +420,13 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector := createMetricCollector()
 			metricCollector := myCollector.(*collector)
 
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(apiDetails1, "200", 5, 10, "")
+			metricCollector.AddMetric(apiDetails1, "200", 10, 10, "")
 			metricCollector.Execute()
 			metricCollector.publisher.Execute()
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(apiDetails1, "401", 15, 10, "")
+			metricCollector.AddMetric(apiDetails2, "200", 20, 10, "")
+			metricCollector.AddMetric(apiDetails2, "200", 10, 10, "")
 
 			// No event generation/publish, store the cache
 			metricCollector.storage.save()
@@ -421,11 +442,11 @@ func TestMetricCollectorCache(t *testing.T) {
 			myCollector = createMetricCollector()
 			metricCollector = myCollector.(*collector)
 
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 5, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "200", 10, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"111", "111", 1, teamID, "", "", ""}, "401", 15, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 20, 10, "")
-			metricCollector.AddMetric(models.APIDetails{"222", "222", 1, teamID, "", "", ""}, "200", 10, 10, "")
+			metricCollector.AddMetric(apiDetails1, "200", 5, 10, "")
+			metricCollector.AddMetric(apiDetails1, "200", 10, 10, "")
+			metricCollector.AddMetric(apiDetails1, "401", 15, 10, "")
+			metricCollector.AddMetric(apiDetails2, "200", 20, 10, "")
+			metricCollector.AddMetric(apiDetails2, "200", 10, 10, "")
 
 			metricCollector.Execute()
 			metricCollector.publisher.Execute()
@@ -538,7 +559,7 @@ func TestOfflineMetricCollector(t *testing.T) {
 			publisher := metricCollector.publisher
 			for testLoops < test.loopCount {
 				for i := 0; i < test.apiTransactionCount[testLoops]; i++ {
-					metricCollector.AddMetric(models.APIDetails{"111", "111", 1, "team123", "", "", ""}, "200", 10, 10, "")
+					metricCollector.AddMetric(apiDetails1, "200", 10, 10, "")
 				}
 				metricCollector.Execute()
 				testLoops++

--- a/pkg/transaction/models/definitions.go
+++ b/pkg/transaction/models/definitions.go
@@ -51,4 +51,6 @@ type APIDetails struct {
 	Revision           int    `json:"revision,omitempty"`
 	TeamID             string `json:"teamID,omitempty"`
 	APIServiceInstance string `json:"apiServiceInstance,omitempty"`
+	Stage              string `json:"-"`
+	Version            string `json:"-"`
 }


### PR DESCRIPTION
- fix missing organization id in owner marshal/unmarshal
- use same structs for matching data in transaction and metrics