### PR TITLE
APIGOV-24403 - Support for requesting token with scope and mTLS connection with IdP

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -236,10 +236,14 @@ func InitializeProfiling(cpuProfile, memProfile string) {
 func registerExternalIDPs() {
 	if agent.cfg.GetAgentType() != config.TraceabilityAgent {
 		idPCfg := agent.agentFeaturesCfg.GetExternalIDPConfig()
-		tlsCfg := agent.cfg.GetTLSConfig()
+
 		proxy := agent.cfg.GetProxyURL()
 		timeout := agent.cfg.GetClientTimeout()
 		for _, idp := range idPCfg.GetIDPList() {
+			tlsCfg := idp.GetTLSConfig()
+			if idp.GetTLSConfig() == nil {
+				tlsCfg = agent.cfg.GetTLSConfig()
+			}
 			registerCredentialProvider(idp, tlsCfg, proxy, timeout)
 		}
 	}

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -193,11 +193,17 @@ func (c *ServiceClient) UpdateSubscriptionDefinitionPropertiesForCatalogItem(cat
 // Update description and title after updating or creating APIService to include the stage name if it exists
 func (c *ServiceClient) postAPIServiceUpdate(serviceBody *ServiceBody) {
 	if serviceBody.Stage != "" {
-		addDescription := fmt.Sprintf("%s: %s", serviceBody.StageDescriptor, serviceBody.Stage)
+		stageDescription := fmt.Sprintf("%s: %s", serviceBody.StageDescriptor, serviceBody.Stage)
 		if len(serviceBody.Description) > 0 {
-			serviceBody.Description = fmt.Sprintf("%s, %s", serviceBody.Description, addDescription)
+			stageDescription = fmt.Sprintf(", %s", stageDescription)
+			if len(serviceBody.Description)+len(stageDescription) >= maxDescriptionLength {
+				description := serviceBody.Description[0 : maxDescriptionLength-len(strEllipsis)-len(stageDescription)]
+				serviceBody.Description = fmt.Sprintf("%s%s%s", description, strEllipsis, stageDescription)
+			} else {
+				serviceBody.Description = fmt.Sprintf("%s%s", serviceBody.Description, stageDescription)
+			}
 		} else {
-			serviceBody.Description = addDescription
+			serviceBody.Description = stageDescription
 		}
 		serviceBody.NameToPush = fmt.Sprintf("%v (%s: %v)", serviceBody.NameToPush, serviceBody.StageDescriptor, serviceBody.Stage)
 	} else if c.cfg.GetAppendEnvironmentToTitle() {

--- a/pkg/authz/oauth/authclient.go
+++ b/pkg/authz/oauth/authclient.go
@@ -80,11 +80,12 @@ func WithServerName(serverName string) AuthClientOption {
 }
 
 // WithClientSecretAuth - sets up to use client secret authenticator
-func WithClientSecretAuth(clientID, clientSecret string) AuthClientOption {
+func WithClientSecretAuth(clientID, clientSecret, scope string) AuthClientOption {
 	return func(opt *authClientOptions) {
 		opt.authenticator = &clientSecretAuthenticator{
 			clientID,
 			clientSecret,
+			scope,
 		}
 	}
 }
@@ -160,6 +161,7 @@ func (c *authClient) getOAuthTokens() (*tokenResponse, error) {
 			WithField("server", c.options.serverName).
 			WithField("url", c.tokenURL).
 			WithField("status", resp.Code).
+			WithField("body", string(resp.Body)).
 			WithError(err).
 			Debug(err.Error())
 		return nil, err

--- a/pkg/authz/oauth/authclient_test.go
+++ b/pkg/authz/oauth/authclient_test.go
@@ -66,7 +66,7 @@ func TestGetPlatformTokensHttpError(t *testing.T) {
 	s.SetTokenResponse("", 0, http.StatusBadRequest)
 	ac, err := NewAuthClient(s.GetTokenURL(), apiClient,
 		WithServerName("testServer"),
-		WithClientSecretAuth("invalid_client", "invalid-secrt"))
+		WithClientSecretAuth("invalid_client", "invalid-secrt", ""))
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
 
@@ -106,7 +106,7 @@ func TestGetPlatformTokensTimeout(t *testing.T) {
 	apiClient := api.NewClientWithTimeout(config.NewTLSConfig(), "", time.Second)
 	ac, err := NewAuthClient(s.URL, apiClient,
 		WithServerName("testServer"),
-		WithClientSecretAuth("invalid_client", "invalid-secrt"))
+		WithClientSecretAuth("invalid_client", "invalid-secrt", ""))
 
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)

--- a/pkg/authz/oauth/clientsecretauthenticator.go
+++ b/pkg/authz/oauth/clientsecretauthenticator.go
@@ -5,12 +5,21 @@ import "net/url"
 type clientSecretAuthenticator struct {
 	clientID     string
 	clientSecret string
+	scope        string
 }
 
 func (p *clientSecretAuthenticator) prepareRequest() (url.Values, error) {
-	return url.Values{
-		metaGrantType:    []string{grantClientCredentials},
-		metaClientID:     []string{p.clientID},
-		metaClientSecret: []string{p.clientSecret},
-	}, nil
+	v := url.Values{
+		metaGrantType: []string{grantClientCredentials},
+		metaClientID:  []string{p.clientID},
+	}
+
+	if p.clientSecret != "" {
+		v.Add(metaClientSecret, p.clientSecret)
+	}
+
+	if p.scope != "" {
+		v.Add(metaScope, p.scope)
+	}
+	return v, nil
 }

--- a/pkg/authz/oauth/constants.go
+++ b/pkg/authz/oauth/constants.go
@@ -41,6 +41,7 @@ const (
 	metaGrantType           = "grant_type"
 	metaClientID            = "client_id"
 	metaClientSecret        = "client_secret"
+	metaScope               = "scope"
 	metaClientAssertionType = "client_assertion_type"
 	metaClientAssertion     = "client_assertion"
 )

--- a/pkg/authz/oauth/provider.go
+++ b/pkg/authz/oauth/provider.go
@@ -85,7 +85,7 @@ func NewProvider(idp corecfg.IDPConfig, tlsCfg corecfg.TLSConfig, proxyURL strin
 	if p.cfg.GetAuthConfig() != nil && p.cfg.GetAuthConfig().GetType() == IDPAuthTypeClient {
 		p.authClient, err = NewAuthClient(p.authServerMetadata.TokenEndpoint, apiClient,
 			WithServerName(idp.GetIDPName()),
-			WithClientSecretAuth(p.cfg.GetAuthConfig().GetClientID(), p.cfg.GetAuthConfig().GetClientSecret()))
+			WithClientSecretAuth(p.cfg.GetAuthConfig().GetClientID(), p.cfg.GetAuthConfig().GetClientSecret(), p.cfg.GetAuthConfig().GetClientScope()))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Updated IDP configuration to setup root CA certificate, client certificate and client key to be used for setting up mTLS connection to IdP
- Updated IDP configuration to setup scope for requesting token
- Updated client secret authenticator to include scope while requesting the token from IdP
- Updated provider auth client to use the TLS config from IdP config if provided otherwise use the Central TLS config