### PR TITLE
APIGOV-26157 - Changes to configure the use of cached token for IdP OAuth client

### DIFF
--- a/pkg/authz/oauth/authclient.go
+++ b/pkg/authz/oauth/authclient.go
@@ -17,6 +17,7 @@ import (
 // AuthClient - Interface representing the auth Client
 type AuthClient interface {
 	GetToken() (string, error)
+	FetchToken(useCachedToken bool) (string, error)
 }
 
 // AuthClientOption - configures auth client.
@@ -156,12 +157,18 @@ func (c *authClient) getCachedToken() string {
 
 // GetToken returns a token from cache if not expired or fetches a new token
 func (c *authClient) GetToken() (string, error) {
+	return c.FetchToken(true)
+}
+
+// GetToken returns a token from cache if not expired or fetches a new token
+func (c *authClient) FetchToken(useCachedToken bool) (string, error) {
 	// only one GetToken should execute at a time
 	c.getTokenMutex.Lock()
 	defer c.getTokenMutex.Unlock()
-
-	if token := c.getCachedToken(); token != "" {
-		return token, nil
+	if useCachedToken {
+		if token := c.getCachedToken(); token != "" {
+			return token, nil
+		}
 	}
 
 	// try fetching a new token

--- a/pkg/authz/oauth/provider.go
+++ b/pkg/authz/oauth/provider.go
@@ -297,7 +297,7 @@ func (p *provider) RegisterClient(clientReq ClientMetadata) (ClientMetadata, err
 		return nil, err
 	}
 
-	token, err := p.getClientToken(true)
+	token, err := p.getClientToken()
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (p *provider) hasCodeResponseMethod(clientRequest *clientMetadata) bool {
 // UnregisterClient - removes the OAuth client from IDP
 func (p *provider) UnregisterClient(clientID string) error {
 	authPrefix := p.idpType.getAuthorizationHeaderPrefix()
-	token, err := p.getClientToken(false)
+	token, err := p.getClientToken()
 	if err != nil {
 		return err
 	}
@@ -441,9 +441,10 @@ func (p *provider) UnregisterClient(clientID string) error {
 	return nil
 }
 
-func (p *provider) getClientToken(useCachedToken bool) (string, error) {
+func (p *provider) getClientToken() (string, error) {
 	if p.authClient != nil {
-		return p.authClient.FetchToken(useCachedToken)
+		useTokenCache := p.cfg.GetAuthConfig().UseTokenCache()
+		return p.authClient.FetchToken(useTokenCache)
 	}
 	return p.cfg.GetAuthConfig().GetAccessToken(), nil
 }

--- a/pkg/authz/oauth/provider.go
+++ b/pkg/authz/oauth/provider.go
@@ -297,7 +297,7 @@ func (p *provider) RegisterClient(clientReq ClientMetadata) (ClientMetadata, err
 		return nil, err
 	}
 
-	token, err := p.getClientToken()
+	token, err := p.getClientToken(true)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (p *provider) hasCodeResponseMethod(clientRequest *clientMetadata) bool {
 // UnregisterClient - removes the OAuth client from IDP
 func (p *provider) UnregisterClient(clientID string) error {
 	authPrefix := p.idpType.getAuthorizationHeaderPrefix()
-	token, err := p.getClientToken()
+	token, err := p.getClientToken(false)
 	if err != nil {
 		return err
 	}
@@ -441,9 +441,9 @@ func (p *provider) UnregisterClient(clientID string) error {
 	return nil
 }
 
-func (p *provider) getClientToken() (string, error) {
+func (p *provider) getClientToken(useCachedToken bool) (string, error) {
 	if p.authClient != nil {
-		return p.authClient.GetToken()
+		return p.authClient.FetchToken(useCachedToken)
 	}
 	return p.cfg.GetAuthConfig().GetAccessToken(), nil
 }


### PR DESCRIPTION
- Added config AGENTFEATURES_IDP_AUTH_USECACHEDTOKEN_1 to setup the IdP OAuth client to use cached token
- Config can be set to "false" if cached token is not intended to be used while IdP client calls the DCR endpoints 
