### PR TITLE
APIGOV-26088 - Fix to use the masking character from config

### DIFF
--- a/pkg/transaction/httpprotocolbuilder.go
+++ b/pkg/transaction/httpprotocolbuilder.go
@@ -451,7 +451,7 @@ func headersRedaction(requestHeaders, responseHeaders map[string]string, redacti
 		if redactionConfig == nil {
 			redactedHeaders, err = redaction.RequestHeadersRedaction(requestHeaders)
 		} else {
-			redactedHeaders, err = redactionConfig.RequestHeadersRedaction(redactedHeaders)
+			redactedHeaders, err = redactionConfig.RequestHeadersRedaction(requestHeaders)
 		}
 		if err != nil {
 			return emptyHeaders, emptyHeaders, ErrInRedactions.FormatError("RequestHeaders", err)


### PR DESCRIPTION
- Removed global variable to allow using the configured masking character
- Included fix for redacting request headers