### PR TITLE
APIGOV-26670 - add flag for installDir to be part of the install 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Order is important; the last matching pattern takes the most precedence.
 
-* @jcollins-axway @dfeldick @sbolosan @vivekschauhan @neha-viswanathan
+* @jcollins-axway @dfeldick @sbolosan @vivekschauhan @alrosca @dgghinea
 
 #[CSR]
  # .csr-profile.json requires SPOC approval for any modifications

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -27,13 +27,15 @@ import (
 
 // Constants for cmd flags
 const (
-	pathConfigFlag        = "pathConfig"
-	beatsPathConfigFlag   = "path.config"
-	EnvFileFlag           = "envFile"
-	EnvFileFlagDesciption = "Path of the file with environment variables to override configuration"
-	cpuprofile            = "cpuprofile"
-	memprofile            = "memprofile"
-	httpprofile           = "httpprofile"
+	pathConfigFlag            = "pathConfig"
+	beatsPathConfigFlag       = "path.config"
+	EnvFileFlag               = "envFile"
+	EnvFileFlagDescription    = "Path of the file with environment variables to override configuration"
+	InstallDirFlag            = "installDir"
+	InstallDirFlagDescription = "The working directory"
+	cpuprofile                = "cpuprofile"
+	memprofile                = "memprofile"
+	httpprofile               = "httpprofile"
 )
 
 // CommandHandler - Root command execution handler
@@ -172,7 +174,8 @@ func NewCmd(rootCmd *cobra.Command, exeName, desc string, initConfigHandler Init
 // Add the command line properties for the logger and path config
 func (c *agentRootCommand) addBaseProps(agentType config.AgentType) {
 	c.props.AddStringPersistentFlag(pathConfigFlag, ".", "Path to the directory containing the YAML configuration file for the agent")
-	c.props.AddStringPersistentFlag(EnvFileFlag, "", EnvFileFlagDesciption)
+	c.props.AddStringPersistentFlag(EnvFileFlag, "", EnvFileFlagDescription)
+	c.props.AddStringPersistentFlag(InstallDirFlag, "", InstallDirFlagDescription)
 	if agentType == config.DiscoveryAgent {
 		c.props.AddStringProperty(cpuprofile, "", "write cpu profile to `file`")
 		c.props.AddStringProperty(memprofile, "", "write memory profile to `file`")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ const (
 	EnvFileFlag               = "envFile"
 	EnvFileFlagDescription    = "Path of the file with environment variables to override configuration"
 	InstallDirFlag            = "installDir"
-	InstallDirFlagDescription = "The working directory"
+	InstallDirFlagDescription = "The path to the working directory. If not set, will default the working directory to the execution path"
 	cpuprofile                = "cpuprofile"
 	memprofile                = "memprofile"
 	httpprofile               = "httpprofile"

--- a/pkg/cmd/service/cmd.go
+++ b/pkg/cmd/service/cmd.go
@@ -61,6 +61,9 @@ func GenServiceCmd(pathArg string) *cobra.Command {
 			if pflag := cmd.Flag(corecmd.EnvFileFlag); pflag != nil {
 				globalAgentService.EnvFile = pflag.Value.String()
 			}
+			if pflag := cmd.Flag(corecmd.InstallDirFlag); pflag != nil {
+				globalAgentService.InstallDir = pflag.Value.String()
+			}
 			if globalAgentService.Path == "." || globalAgentService.Path == "" {
 				var err error
 				globalAgentService.Path, err = os.Getwd()

--- a/pkg/cmd/service/daemon/daemon.go
+++ b/pkg/cmd/service/daemon/daemon.go
@@ -53,6 +53,9 @@ type Daemon interface {
 
 	// GetServiceName - gets the name of the service
 	GetServiceName() string
+
+	// SetInstallDir - sets the installation directory
+	SetInstallDir(string) error
 }
 
 // Executable interface defines controlling methods of executable service

--- a/pkg/cmd/service/daemon/daemonlinux.go
+++ b/pkg/cmd/service/daemon/daemonlinux.go
@@ -4,7 +4,7 @@ package daemon
 func newDaemon(name, description string, dependencies []string) (Daemon, error) {
 	// newer subsystem must be checked first
 	if _, err := fs.Stat("/run/systemd/system"); err == nil {
-		return &systemDRecord{name, description, dependencies, "", "", ""}, nil
+		return &systemDRecord{name, description, dependencies, "", "", "", ""}, nil
 	}
 	return nil, ErrUnsupportedSystem
 }

--- a/pkg/cmd/service/daemon/daemonlinuxsystemd.go
+++ b/pkg/cmd/service/daemon/daemonlinuxsystemd.go
@@ -340,7 +340,7 @@ After={{.Dependencies}}
 ExecStart={{.Path}} {{.Args}}
 User={{.User}}
 Group={{.Group}}
-WorkingDirectory{{.InstallDir}}
+WorkingDirectory={{.InstallDir}}
 Restart=on-failure
 RestartSec=60s
 

--- a/pkg/cmd/service/daemon/daemonlinuxsystemd.go
+++ b/pkg/cmd/service/daemon/daemonlinuxsystemd.go
@@ -24,6 +24,7 @@ type systemDRecord struct {
 	user         string
 	group        string
 	envFile      string
+	installDir   string
 }
 
 // Standard service path for systemD daemons
@@ -98,13 +99,14 @@ func (s *systemDRecord) install(args ...string) (string, error) {
 	if err := templ.Execute(
 		file,
 		&struct {
-			Name, Description, Dependencies, User, Group, Path, Args string
+			Name, Description, Dependencies, User, Group, Path, InstallDir, Args string
 		}{
 			s.name,
 			s.description,
 			strings.Join(s.dependencies, " "),
 			s.user,
 			s.group,
+			s.installDir,
 			execPatch,
 			strings.Join(args, " "),
 		},
@@ -309,6 +311,14 @@ func (s *systemDRecord) SetEnvFile(envFile string) error {
 	return nil
 }
 
+// SetInstallDir - sets the installDir that will be used by the service
+func (s *systemDRecord) SetInstallDir(installDir string) error {
+	// set the absolute path, incase it is relative
+	envFileAbsolute, _ := filepath.Abs(installDir)
+	s.installDir = envFileAbsolute
+	return nil
+}
+
 // SetUser - sets the user that will execute the service
 func (s *systemDRecord) SetUser(user string) error {
 	s.user = user
@@ -330,6 +340,7 @@ After={{.Dependencies}}
 ExecStart={{.Path}} {{.Args}}
 User={{.User}}
 Group={{.Group}}
+WorkingDirectory{{.InstallDir}}
 Restart=on-failure
 RestartSec=60s
 

--- a/pkg/cmd/service/daemon/daemonlinuxsystemd.go
+++ b/pkg/cmd/service/daemon/daemonlinuxsystemd.go
@@ -80,10 +80,14 @@ func (s *systemDRecord) install(args ...string) (string, error) {
 		return failed, err
 	}
 
-	execPatch, err := executablePath(s.name)
+	execPath, err := executablePath(s.name)
 	if err != nil {
 		file.Close()
 		return failed, err
+	}
+
+	if s.installDir == "" {
+		s.installDir = filepath.Dir(execPath)
 	}
 
 	templ, err := template.New("systemDConfig").Parse(systemDConfig)
@@ -106,8 +110,8 @@ func (s *systemDRecord) install(args ...string) (string, error) {
 			strings.Join(s.dependencies, " "),
 			s.user,
 			s.group,
+			execPath,
 			s.installDir,
-			execPatch,
 			strings.Join(args, " "),
 		},
 	); err != nil {

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -20,7 +20,7 @@ var (
 	execCommand = exec.Command
 )
 
-//AgentService -
+// AgentService -
 type AgentService struct {
 	service     daemon.Daemon
 	Name        string
@@ -30,6 +30,7 @@ type AgentService struct {
 	EnvFile     string
 	User        string
 	Group       string
+	InstallDir  string
 }
 
 func newAgentService() (*AgentService, error) {
@@ -60,6 +61,7 @@ func (a *AgentService) HandleServiceFlag(command string) error {
 		a.service.SetEnvFile(a.EnvFile)
 		a.service.SetUser(a.User)
 		a.service.SetGroup(a.Group)
+		a.service.SetInstallDir(a.InstallDir)
 		_, err = a.service.Install(a.PathArg, a.Path)
 	case "update":
 		fmt.Println("updating the agent service")
@@ -67,6 +69,7 @@ func (a *AgentService) HandleServiceFlag(command string) error {
 		a.service.SetEnvFile(a.EnvFile)
 		a.service.SetUser(a.User)
 		a.service.SetGroup(a.Group)
+		a.service.SetInstallDir(a.InstallDir)
 		_, err = a.service.Update(a.PathArg, a.Path)
 	case "remove":
 		fmt.Println("removing the agent service")

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	UNEXPECTED_ERR = "Unexpected error returned"
+)
+
 type mockDaemon struct {
 	installCalled     bool
 	updateCalled      bool
@@ -21,11 +25,12 @@ type mockDaemon struct {
 	serviceNameCalled bool
 }
 
-func (m *mockDaemon) GetTemplate() string      { return "" }
-func (m *mockDaemon) SetTemplate(string) error { return nil }
-func (m *mockDaemon) SetEnvFile(string) error  { return nil }
-func (m *mockDaemon) SetUser(string) error     { return nil }
-func (m *mockDaemon) SetGroup(string) error    { return nil }
+func (m *mockDaemon) GetTemplate() string        { return "" }
+func (m *mockDaemon) SetTemplate(string) error   { return nil }
+func (m *mockDaemon) SetEnvFile(string) error    { return nil }
+func (m *mockDaemon) SetUser(string) error       { return nil }
+func (m *mockDaemon) SetGroup(string) error      { return nil }
+func (m *mockDaemon) SetInstallDir(string) error { return nil }
 
 func (m *mockDaemon) Install(args ...string) (string, error) {
 	m.installCalled = true
@@ -87,6 +92,7 @@ func newMockAgentService() *AgentService {
 		User:        "user",
 		Group:       "group",
 		EnvFile:     "./filename",
+		InstallDir:  "/this/install/dir",
 	}
 }
 
@@ -130,54 +136,54 @@ func TestHandleService(t *testing.T) {
 	// Install
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("install")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).installCalled)
 
 	// Update
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("update")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).updateCalled)
 
 	// Remove
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("remove")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).removeCalled)
 
 	// Start
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("start")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).startCalled)
 
 	// Stop
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("stop")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).stopCalled)
 
 	// Logs
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("logs")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).logsCalled)
 
 	// Status
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("status")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).statusCalled)
 
 	// Enable
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("enable")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).enableCalled)
 
 	// Service Name
 	a = newMockAgentService()
 	err = a.HandleServiceFlag("name")
-	assert.Nil(t, err, "Unexpected error returned")
+	assert.Nil(t, err, UNEXPECTED_ERR)
 	assert.True(t, a.service.(*mockDaemon).serviceNameCalled)
 }


### PR DESCRIPTION
1. add installDir parameter on command
2. when installDir added, set to WorkingDirectory in service definition
3. when installDir is not added, set to default execution path
