### PR TITLE
APIGOV-26694 - shutdown handler registration

### DIFF
--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -52,6 +52,7 @@ type Collector interface {
 	AddMetricDetail(metricDetail Detail)
 	AddAPIMetric(apiMetric *APIMetric)
 	Publish()
+	ShutdownPublish()
 }
 
 // collector - collects the metrics for transactions events
@@ -265,6 +266,11 @@ func (c *collector) AddAPIMetric(metric *APIMetric) {
 
 func (c *collector) Publish() {
 	c.metricBatch.Publish()
+}
+
+func (c *collector) ShutdownPublish() {
+	c.Execute()
+	c.publisher.Execute()
 }
 
 func (c *collector) updateVolume(bytes int64) {


### PR DESCRIPTION
- Allow a shutdown handler to be registered
- Call handler prior to exit of agent
- Add new interface on metric collector to push any cached metrics and usages