### PR TITLE
APIGOV-27057 - update sampling percentage with new default and max

### DIFF
--- a/pkg/traceability/config.go
+++ b/pkg/traceability/config.go
@@ -99,9 +99,13 @@ func readConfig(cfg *common.Config, info beat.Info) (*Config, error) {
 
 	// Setup the sampling config, if central config can not be found assume online mode
 	if agent.GetCentralConfig() != nil && agent.GetCentralConfig().GetUsageReportingConfig() != nil {
-		sampling.SetupSampling(outputConfig.Sampling, agent.GetCentralConfig().GetUsageReportingConfig().IsOfflineMode())
+		err = sampling.SetupSampling(outputConfig.Sampling, agent.GetCentralConfig().GetUsageReportingConfig().IsOfflineMode())
 	} else {
-		sampling.SetupSampling(outputConfig.Sampling, false)
+		err = sampling.SetupSampling(outputConfig.Sampling, false)
+	}
+
+	if err != nil {
+		log.Warn(err.Error())
 	}
 
 	// Force piplining to 0

--- a/pkg/traceability/sampling/definitions.go
+++ b/pkg/traceability/sampling/definitions.go
@@ -1,14 +1,15 @@
 package sampling
 
-//SampleKey - the key used in the metadata when a transaction qualifies for sampling and should be sent to Observer
+// SampleKey - the key used in the metadata when a transaction qualifies for sampling and should be sent to Observer
+// defaultSamplingRate - the default sampling rate in percentage
 const (
 	SampleKey           = "sample"
 	countMax            = 100
-	defaultSamplingRate = 10
+	defaultSamplingRate = 1
 	globalCounter       = "global"
 )
 
-//TransactionDetails - details about the transaction that are used for sampling
+// TransactionDetails - details about the transaction that are used for sampling
 type TransactionDetails struct {
 	Status string
 	APIID  string

--- a/pkg/traceability/sampling/definitions.go
+++ b/pkg/traceability/sampling/definitions.go
@@ -4,7 +4,7 @@ package sampling
 // defaultSamplingRate - the default sampling rate in percentage
 const (
 	SampleKey           = "sample"
-	countMax            = 10
+	countMax            = 100
 	defaultSamplingRate = 1
 	globalCounter       = "global"
 )

--- a/pkg/traceability/sampling/definitions.go
+++ b/pkg/traceability/sampling/definitions.go
@@ -6,6 +6,7 @@ const (
 	SampleKey           = "sample"
 	countMax            = 100
 	defaultSamplingRate = 1
+	maximumSamplingRate = 10
 	globalCounter       = "global"
 )
 

--- a/pkg/traceability/sampling/definitions.go
+++ b/pkg/traceability/sampling/definitions.go
@@ -4,7 +4,7 @@ package sampling
 // defaultSamplingRate - the default sampling rate in percentage
 const (
 	SampleKey           = "sample"
-	countMax            = 100
+	countMax            = 10
 	defaultSamplingRate = 1
 	globalCounter       = "global"
 )

--- a/pkg/traceability/sampling/errors.go
+++ b/pkg/traceability/sampling/errors.go
@@ -5,5 +5,5 @@ import "github.com/Axway/agent-sdk/pkg/util/errors"
 // Config errors
 var (
 	ErrGlobalSamplingCfg = errors.New(1520, "the global sampling config has not been initialized")
-	ErrSamplingCfg       = errors.New(1521, "sampling percentage must be between 0 and 10.  Setting sampling percentage to default value of 1 percent")
+	ErrSamplingCfg       = errors.Newf(1521, "sampling percentage must be between 0 and %v.  Setting sampling percentage to default value of %v percent")
 )

--- a/pkg/traceability/sampling/errors.go
+++ b/pkg/traceability/sampling/errors.go
@@ -5,5 +5,5 @@ import "github.com/Axway/agent-sdk/pkg/util/errors"
 // Config errors
 var (
 	ErrGlobalSamplingCfg = errors.New(1520, "the global sampling config has not been initialized")
-	ErrSamplingCfg       = errors.New(1521, "sampling percentage must be between 0 and 10")
+	ErrSamplingCfg       = errors.New(1521, "sampling percentage must be between 0 and 10.  Setting sampling percentage to default value of 1 percent")
 )

--- a/pkg/traceability/sampling/errors.go
+++ b/pkg/traceability/sampling/errors.go
@@ -5,5 +5,5 @@ import "github.com/Axway/agent-sdk/pkg/util/errors"
 // Config errors
 var (
 	ErrGlobalSamplingCfg = errors.New(1520, "the global sampling config has not been initialized")
-	ErrSamplingCfg       = errors.New(1521, "sampling percentage must be between 0 and 100")
+	ErrSamplingCfg       = errors.New(1521, "sampling percentage must be between 0 and 10")
 )

--- a/pkg/traceability/sampling/globalsampling.go
+++ b/pkg/traceability/sampling/globalsampling.go
@@ -11,13 +11,13 @@ var agentSamples *sample
 
 // Sampling - configures the sampling of events the agent sends to Amplify
 type Sampling struct {
-	Percentage      int  `config:"percentage"    validate:"min=0, max=100"`
+	Percentage      int  `config:"percentage"    validate:"min=0, max=10"`
 	PerAPI          bool `config:"per_api"`
 	PerSub          bool `config:"per_subscription"`
 	ReportAllErrors bool `config:"reportAllErrors" yaml:"reportAllErrors"`
 }
 
-//DefaultConfig - returns a default sampling config where all transactions are sent
+// DefaultConfig - returns a default sampling config where all transactions are sent
 func DefaultConfig() Sampling {
 	return Sampling{
 		Percentage:      defaultSamplingRate,

--- a/pkg/traceability/sampling/globalsampling.go
+++ b/pkg/traceability/sampling/globalsampling.go
@@ -52,7 +52,7 @@ func SetupSampling(cfg Sampling, offlineMode bool) error {
 		counterLock:   sync.Mutex{},
 	}
 	if invalidSampling {
-		return ErrSamplingCfg
+		return ErrSamplingCfg.FormatError(maximumSamplingRate, defaultSamplingRate)
 	}
 	return nil
 }

--- a/pkg/traceability/sampling/globalsampling.go
+++ b/pkg/traceability/sampling/globalsampling.go
@@ -11,7 +11,7 @@ var agentSamples *sample
 
 // Sampling - configures the sampling of events the agent sends to Amplify
 type Sampling struct {
-	Percentage      int  `config:"percentage"    validate:"min=0, max=10"`
+	Percentage      int  `config:"percentage"`
 	PerAPI          bool `config:"per_api"`
 	PerSub          bool `config:"per_subscription"`
 	ReportAllErrors bool `config:"reportAllErrors" yaml:"reportAllErrors"`
@@ -34,19 +34,25 @@ func GetGlobalSamplingPercentage() (int, error) {
 
 // SetupSampling - set up the global sampling for use by traceability
 func SetupSampling(cfg Sampling, offlineMode bool) error {
+	invalidSampling := false
 	if offlineMode {
 		// In offline mode sampling is always 0
 		cfg.Percentage = 0
 	}
 
 	// Validate the config to make sure it is not out of bounds
-	if cfg.Percentage < 0 || cfg.Percentage > countMax {
-		return ErrSamplingCfg
+	if cfg.Percentage < 0 || cfg.Percentage > maximumSamplingRate {
+		invalidSampling = true
+		cfg.Percentage = defaultSamplingRate
 	}
+
 	agentSamples = &sample{
 		config:        cfg,
 		currentCounts: make(map[string]int),
 		counterLock:   sync.Mutex{},
+	}
+	if invalidSampling {
+		return ErrSamplingCfg
 	}
 	return nil
 }

--- a/pkg/traceability/sampling/sampling_test.go
+++ b/pkg/traceability/sampling/sampling_test.go
@@ -23,7 +23,7 @@ func TestSamplingConfig(t *testing.T) {
 			errExpected: false,
 			config:      DefaultConfig(),
 			expectedConfig: Sampling{
-				Percentage: 10,
+				Percentage: 1,
 			},
 		},
 		{

--- a/pkg/traceability/sampling/sampling_test.go
+++ b/pkg/traceability/sampling/sampling_test.go
@@ -345,30 +345,6 @@ func TestFilterEvents(t *testing.T) {
 		config         Sampling
 	}{
 		{
-			name:           "All Events",
-			testEvents:     2000,
-			eventsExpected: 2000,
-			config: Sampling{
-				Percentage: 100,
-			},
-		},
-		{
-			name:           "50% of Events",
-			testEvents:     2000,
-			eventsExpected: 1000,
-			config: Sampling{
-				Percentage: 50,
-			},
-		},
-		{
-			name:           "25% of Events",
-			testEvents:     2000,
-			eventsExpected: 500,
-			config: Sampling{
-				Percentage: 25,
-			},
-		},
-		{
 			name:           "10% of Events",
 			testEvents:     2000,
 			eventsExpected: 200,

--- a/pkg/traceability/sampling/sampling_test.go
+++ b/pkg/traceability/sampling/sampling_test.go
@@ -30,10 +30,10 @@ func TestSamplingConfig(t *testing.T) {
 			name:        "Good Custom Config",
 			errExpected: false,
 			config: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 			},
 			expectedConfig: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 			},
 		},
 		{
@@ -54,11 +54,11 @@ func TestSamplingConfig(t *testing.T) {
 			name:        "Good Config, Report All Errors",
 			errExpected: false,
 			config: Sampling{
-				Percentage:      50,
+				Percentage:      10,
 				ReportAllErrors: true,
 			},
 			expectedConfig: Sampling{
-				Percentage: 50,
+				Percentage: 10,
 			},
 		},
 	}
@@ -88,43 +88,28 @@ func TestShouldSample(t *testing.T) {
 		subIDs           map[string]string
 	}{
 		{
-			name: "All Transactions",
+			name: "Maximum Transactions",
 			apiTransactions: map[string]int{
 				"id1": 1000,
 				"id2": 1000,
 			},
-			expectedSampled: 2000,
+			expectedSampled: 200,
 			config: Sampling{
-				Percentage: 100,
+				Percentage: 10,
 				PerAPI:     false,
 			},
 		},
 		{
-			name: "50% of Transactions when per api is disabled",
+			name: "5% of Transactions when per api is disabled",
 			apiTransactions: map[string]int{
 				"id1": 50,
 				"id2": 50,
 				"id3": 50,
 				"id4": 50,
 			}, // Total = 200
-			expectedSampled: 100,
+			expectedSampled: 10,
 			config: Sampling{
-				Percentage: 50,
-				PerAPI:     false,
-			},
-		},
-		{
-			name: "25% of Transactions when per api is disabled",
-			apiTransactions: map[string]int{
-				"id1": 105,
-				"id2": 100,
-				"id3": 50,
-				"id4": 15,
-				"id5": 5,
-			}, // Total = 275
-			expectedSampled: 75,
-			config: Sampling{
-				Percentage: 25,
+				Percentage: 5,
 				PerAPI:     false,
 			},
 		},
@@ -165,36 +150,21 @@ func TestShouldSample(t *testing.T) {
 			},
 		},
 		{
-			name: "50% per API of Transactions when per api is enabled",
+			name: "5% per API of Transactions when per api is enabled",
 			apiTransactions: map[string]int{
 				"id1": 50, // expect 50
 				"id2": 50, // expect 50
 				"id3": 50, // expect 50
 				"id4": 50, // expect 50
 			},
-			expectedSampled: 200,
+			expectedSampled: 20,
 			config: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 				PerAPI:     true,
 			},
 		},
 		{
-			name: "25% per API of Transactions when per api is enabled",
-			apiTransactions: map[string]int{
-				"id1": 105, // expect 30
-				"id2": 100, // expect 25
-				"id3": 50,  // expect 25
-				"id4": 15,  // expect 15
-				"id5": 5,   // expect 5
-			},
-			expectedSampled: 100,
-			config: Sampling{
-				Percentage: 25,
-				PerAPI:     true,
-			},
-		},
-		{
-			name: "50% of subscription transactions when per api and per sub are enabled",
+			name: "5% of subscription transactions when per api and per sub are enabled",
 			apiTransactions: map[string]int{
 				"id1": 50, // expect 50
 				"id2": 50, // expect 50
@@ -207,15 +177,15 @@ func TestShouldSample(t *testing.T) {
 				"id3": "sub3",
 				"id4": "sub4",
 			},
-			expectedSampled: 200,
+			expectedSampled: 20,
 			config: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 				PerAPI:     true,
 				PerSub:     true,
 			},
 		},
 		{
-			name: "50% of subscription transactions when per api is disabled and per sub is enabled",
+			name: "5% of subscription transactions when per api is disabled and per sub is enabled",
 			apiTransactions: map[string]int{
 				"id1": 50, // expect 50
 				"id2": 50, // expect 50
@@ -228,15 +198,15 @@ func TestShouldSample(t *testing.T) {
 				"id3": "sub3",
 				"id4": "sub4",
 			},
-			expectedSampled: 200,
+			expectedSampled: 20,
 			config: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 				PerAPI:     false,
 				PerSub:     true,
 			},
 		},
 		{
-			name: "50% of per API transactions when per api and per sub are enabled, but no subID is found",
+			name: "5% of per API transactions when per api and per sub are enabled, but no subID is found",
 			apiTransactions: map[string]int{
 				"id1": 50, // expect 50
 				"id2": 50, // expect 50
@@ -244,9 +214,9 @@ func TestShouldSample(t *testing.T) {
 				"id4": 50, // expect 50
 			},
 			subIDs:          map[string]string{},
-			expectedSampled: 200,
+			expectedSampled: 20,
 			config: Sampling{
-				Percentage: 50,
+				Percentage: 5,
 				PerAPI:     true,
 				PerSub:     true,
 			},


### PR DESCRIPTION
New updates for SDK
1. with no value to config, sampling percentage should default to 1
2. with value greater than 10, it should warn you that the agent will default to 1% and continue
3. removed json validation out of beats and manually validating sampling percentage