### PR TITLE
APIGOV-27487 - Updates to setup source dataplane type and references

### DIFF
--- a/pkg/apic/apiservice.go
+++ b/pkg/apic/apiservice.go
@@ -52,6 +52,7 @@ func (c *ServiceClient) buildAPIService(serviceBody *ServiceBody) *management.AP
 		Status: buildAPIServiceStatusSubResource(ownerErr),
 	}
 
+	buildAPIServiceSourceSubResource(svc, serviceBody)
 	svcDetails := buildAgentDetailsSubResource(serviceBody, true, serviceBody.ServiceAgentDetails)
 	c.setMigrationFlags(svcDetails)
 
@@ -94,6 +95,7 @@ func (c *ServiceClient) updateAPIService(serviceBody *ServiceBody, svc *manageme
 	svc.Owner = owner
 	svc.Attributes = util.CheckEmptyMapStringString(serviceBody.ServiceAttributes)
 	svc.Status = buildAPIServiceStatusSubResource(ownerErr)
+	buildAPIServiceSourceSubResource(svc, serviceBody)
 
 	svcDetails := buildAgentDetailsSubResource(serviceBody, true, serviceBody.ServiceAgentDetails)
 	newSVCDetails := util.MergeMapStringInterface(util.GetAgentDetails(svc), svcDetails)
@@ -111,6 +113,35 @@ func (c *ServiceClient) updateAPIService(serviceBody *ServiceBody, svc *manageme
 			ContentType: serviceBody.ImageContentType,
 			Data:        serviceBody.Image,
 		}
+	}
+}
+
+func buildAPIServiceSourceSubResource(svc *management.APIService, serviceBody *ServiceBody) {
+	serviceBody.serviceContext.updateServiceSource = false
+
+	source := svc.Source
+	if source == nil {
+		svc.Source = &management.ApiServiceSource{}
+		source = svc.Source
+	}
+
+	dataplaneType := serviceBody.GetDataplaneType()
+	if dataplaneType != "" {
+		if serviceBody.IsDesignDataplane() {
+			if source.DataplaneType.Design != dataplaneType.String() {
+				source.DataplaneType.Design = dataplaneType.String()
+				serviceBody.serviceContext.updateServiceSource = true
+			}
+		} else if source.DataplaneType.Managed != dataplaneType.String() {
+			source.DataplaneType.Managed = dataplaneType.String()
+			serviceBody.serviceContext.updateServiceSource = true
+		}
+	}
+
+	referencedSvc := serviceBody.GetReferencedServiceName()
+	if referencedSvc != "" && source.References.ApiService != referencedSvc {
+		source.References.ApiService = serviceBody.GetReferencedServiceName()
+		serviceBody.serviceContext.updateServiceSource = true
 	}
 }
 
@@ -175,7 +206,7 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*management.AP
 	}
 
 	svc.Name = serviceBody.serviceContext.serviceName
-	err = c.updateAPIServiceSubresources(svc)
+	err = c.updateAPIServiceSubresources(svc, serviceBody.serviceContext.updateServiceSource)
 	if err != nil && serviceBody.serviceContext.serviceAction == addAPI {
 		_, e := c.rollbackAPIService(serviceBody.serviceContext.serviceName)
 		if e != nil {
@@ -188,10 +219,10 @@ func (c *ServiceClient) processService(serviceBody *ServiceBody) (*management.AP
 	return svc, err
 }
 
-func (c *ServiceClient) updateAPIServiceSubresources(svc *management.APIService) error {
+func (c *ServiceClient) updateAPIServiceSubresources(svc *management.APIService, updateSource bool) error {
 	subResources := make(map[string]interface{})
 	if svc.Status != nil {
-		subResources["status"] = svc.Status
+		subResources[management.ApiServiceStatusSubResourceName] = svc.Status
 	}
 
 	if len(svc.SubResources) > 0 {
@@ -200,11 +231,16 @@ func (c *ServiceClient) updateAPIServiceSubresources(svc *management.APIService)
 		}
 	}
 
+	if updateSource && svc.Source != nil {
+		subResources[management.ApiServiceSourceSubResourceName] = svc.Source
+	}
+
 	if len(subResources) > 0 {
 		return c.CreateSubResource(svc.ResourceMeta, subResources)
 	}
 	return nil
 }
+
 func (c *ServiceClient) getAPIServiceByExternalAPIID(apiID string) (*management.APIService, error) {
 	ri := c.caches.GetAPIServiceWithAPIID(apiID)
 	if ri == nil {

--- a/pkg/apic/apiservice_test.go
+++ b/pkg/apic/apiservice_test.go
@@ -898,3 +898,217 @@ func Test_buildAPIServiceNilAttributes(t *testing.T) {
 	client.updateAPIService(body, svc)
 	assert.NotNil(t, svc.Attributes)
 }
+
+func createAPIService(name, id string, refSvc string, dpType string, isDesign bool) *management.APIService {
+	apiSvc := &management.APIService{
+		ResourceMeta: apiv1.ResourceMeta{
+			Name:  name,
+			Title: name,
+			SubResources: map[string]interface{}{
+				defs.XAgentDetails: map[string]interface{}{
+					defs.AttrExternalAPIID:   id,
+					defs.AttrExternalAPIName: name,
+				},
+			},
+		},
+		Spec: management.ApiServiceSpec{},
+	}
+	if refSvc != "" || dpType != "" {
+		apiSvc.Source = &management.ApiServiceSource{
+			References: management.ApiServiceSourceReferences{
+				ApiService: refSvc,
+			},
+		}
+		apiSvc.Source.DataplaneType = management.ApiServiceSourceDataplaneType{}
+		if isDesign {
+			apiSvc.Source.DataplaneType.Design = dpType
+		} else {
+			apiSvc.Source.DataplaneType.Managed = dpType
+		}
+	}
+	return apiSvc
+}
+
+func TestServiceSourceUpdates(t *testing.T) {
+	// case 1 - new service, source managed dataplane, sub resource updated
+	// case 2 - new service, source design dataplane, sub resource updated
+	// case 3 - new service, source unmanaged dataplane with reference, sub resource updated
+	// case 4 - existing service, no source, source updated
+	// case 5 - existing service, existing source, different dataplane type, source updated
+	// case 6 - existing service, existing source, different reference, source updated
+	// case 7 - existing service, existing source, same dataplane type and same reference, no source updated
+	testCases := []struct {
+		name               string
+		svcName            string
+		managedDataplane   DataplaneType
+		designDataplane    DataplaneType
+		existingSvc        *management.APIService
+		referenceService   string
+		apiserverResponses []api.MockResponse
+	}{
+		{
+			name:             "new service for managed dataplane",
+			svcName:          "newSvcManaged",
+			managedDataplane: AWS,
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to create the service
+					RespCode: http.StatusCreated,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:            "new service for design dataplane",
+			svcName:         "newSvcDesign",
+			designDataplane: GitLab,
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to create the service
+					RespCode: http.StatusCreated,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:             "new service for unmanaged dataplane with referenced service",
+			svcName:          "newSvcUnmanaged",
+			managedDataplane: Unclassified,
+			referenceService: "refSvc",
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to create the service
+					RespCode: http.StatusCreated,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:             "existing service with no source",
+			svcName:          "existingSvcNoSource",
+			managedDataplane: AWS,
+			existingSvc:      createAPIService("existingSvcNoSource", "existingSvcNoSource", "", "", false),
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to update the service
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:             "existing service with different dataplane type",
+			svcName:          "existingSvcDiffDpType",
+			managedDataplane: AWS,
+			existingSvc:      createAPIService("existingSvcDiffDpType", "existingSvcDiffDpType", "", Unidentified.String(), false),
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to update the service
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:             "existing service with different referenced service",
+			svcName:          "existingSvcDiffRefSvc",
+			managedDataplane: AWS,
+			existingSvc:      createAPIService("existingSvcDiffRefSvc", "existingSvcDiffRefSvc", "existingRefSvc", AWS.String(), false),
+			referenceService: "newRefSvc",
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to update the service
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update source subresource
+					RespCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			name:             "existing service with same source",
+			svcName:          "existingSvcSameSource",
+			managedDataplane: AWS,
+			existingSvc:      createAPIService("existingSvcSameSource", "existingSvcSameSource", "refSvc", AWS.String(), false),
+			referenceService: "refSvc",
+			apiserverResponses: []api.MockResponse{
+				{
+					FileName: "./testdata/apiservice.json", // call to update the service
+					RespCode: http.StatusOK,
+				},
+				{
+					FileName: "./testdata/apiservice.json", // call to update x-agent-details subresource
+					RespCode: http.StatusOK,
+				},
+				// no source subresource update
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			client, httpClient := GetTestServiceClient()
+			if test.existingSvc != nil {
+				ri, _ := test.existingSvc.AsInstance()
+				client.caches.AddAPIService(ri)
+			}
+
+			body := &ServiceBody{
+				RestAPIID: test.svcName,
+			}
+			if test.managedDataplane != "" {
+				body.dataplaneType = test.managedDataplane
+			}
+			if test.designDataplane != "" {
+				body.dataplaneType = test.designDataplane
+				body.isDesignDataplane = true
+			}
+			body.referencedServiceName = test.referenceService
+			httpClient.SetResponses(test.apiserverResponses)
+
+			svc, err := client.processService(body)
+			assert.Nil(t, err)
+			assert.NotNil(t, svc)
+			assert.Equal(t, len(test.apiserverResponses), httpClient.RespCount)
+		})
+	}
+}

--- a/pkg/apic/apiserviceinstance.go
+++ b/pkg/apic/apiserviceinstance.go
@@ -102,6 +102,7 @@ func (c *ServiceClient) buildAPIServiceInstance(
 		Spec:  spec,
 		Owner: owner,
 	}
+	buildAPIServiceInstanceSourceSubResource(instance, serviceBody)
 
 	instDetails := util.MergeMapStringInterface(serviceBody.ServiceAgentDetails, serviceBody.InstanceAgentDetails)
 	details := buildAgentDetailsSubResource(serviceBody, false, instDetails)
@@ -127,11 +128,42 @@ func (c *ServiceClient) updateAPIServiceInstance(
 		instance.Spec = buildAPIServiceInstanceMarketplaceSpec(serviceBody, endpoints, c.checkCredentialRequestDefinitions(serviceBody))
 	}
 	instance.Owner = owner
+	buildAPIServiceInstanceSourceSubResource(instance, serviceBody)
 
 	details := util.MergeMapStringInterface(serviceBody.ServiceAgentDetails, serviceBody.InstanceAgentDetails)
 	util.SetAgentDetails(instance, buildAgentDetailsSubResource(serviceBody, false, details))
 
 	return instance
+}
+
+func buildAPIServiceInstanceSourceSubResource(instance *management.APIServiceInstance, serviceBody *ServiceBody) *management.ApiServiceInstanceSource {
+	serviceBody.serviceContext.updateInstanceSource = false
+
+	source := instance.Source
+	if source == nil {
+		instance.Source = &management.ApiServiceInstanceSource{}
+		source = instance.Source
+	}
+
+	dataplaneType := serviceBody.GetDataplaneType()
+	if dataplaneType != "" {
+		if serviceBody.IsDesignDataplane() {
+			if source.DataplaneType.Design != dataplaneType.String() {
+				source.DataplaneType.Design = dataplaneType.String()
+				serviceBody.serviceContext.updateInstanceSource = true
+			}
+		} else if source.DataplaneType.Managed != dataplaneType.String() {
+			source.DataplaneType.Managed = dataplaneType.String()
+			serviceBody.serviceContext.updateInstanceSource = true
+		}
+	}
+
+	referencedInstance := serviceBody.GetReferenceInstanceName()
+	if referencedInstance != "" && source.References.ApiServiceInstance != referencedInstance {
+		source.References.ApiServiceInstance = serviceBody.GetReferenceInstanceName()
+		serviceBody.serviceContext.updateInstanceSource = true
+	}
+	return nil
 }
 
 // processInstance - Creates or updates an API Service Instance based on the current API Service Revision.
@@ -159,6 +191,10 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 	addSpecHashToResource(instance)
 
 	ri, err := c.CreateOrUpdateResource(instance)
+	if err == nil {
+		err = c.updateAPIServiceInstanceSubresources(ri, instance, serviceBody)
+	}
+
 	if err != nil {
 		if serviceBody.serviceContext.serviceAction == addAPI {
 			_, rollbackErr := c.rollbackAPIService(serviceBody.serviceContext.serviceName)
@@ -173,6 +209,19 @@ func (c *ServiceClient) processInstance(serviceBody *ServiceBody) error {
 	serviceBody.serviceContext.instanceName = instance.Name
 
 	return err
+}
+
+func (c *ServiceClient) updateAPIServiceInstanceSubresources(ri apiv1.Interface, instance *management.APIServiceInstance, serviceBody *ServiceBody) error {
+	subResources := make(map[string]interface{})
+	if serviceBody.serviceContext.updateInstanceSource && instance.Source != nil {
+		subResources[management.ApiServiceInstanceSourceSubResourceName] = instance.Source
+	}
+
+	if len(subResources) > 0 {
+		inst, _ := ri.AsInstance()
+		return c.CreateSubResource(inst.ResourceMeta, subResources)
+	}
+	return nil
 }
 
 func createInstanceEndpoint(endpoints []EndpointDefinition) ([]management.ApiServiceInstanceSpecEndpoint, error) {

--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -39,6 +39,29 @@ const (
 	DefaultTeamKey = "DefaultTeam"
 )
 
+// consts for dataplane type
+type DataplaneType string
+
+const (
+	APIM         DataplaneType = "APIM"
+	AWS          DataplaneType = "AWS"
+	Azure        DataplaneType = "Azure"
+	Apigee       DataplaneType = "Apigee"
+	Istio        DataplaneType = "Istio"
+	Mulesoft     DataplaneType = "Mulesoft"
+	Kong         DataplaneType = "Kong"
+	Kafka        DataplaneType = "Kafka"
+	GitHub       DataplaneType = "GitHub"
+	GitLab       DataplaneType = "GitLab"
+	SwaggerHub   DataplaneType = "SwaggerHub"
+	Unidentified DataplaneType = "Unidentified"
+	Unclassified DataplaneType = "Unclassified"
+)
+
+func (t DataplaneType) String() string {
+	return string(t)
+}
+
 // consts for state
 const (
 	UnpublishedState     = "UNPUBLISHED"
@@ -74,6 +97,8 @@ type serviceContext struct {
 	revisionCount        int
 	instanceName         string
 	consumerInstanceName string
+	updateServiceSource  bool
+	updateInstanceSource bool
 }
 
 // EndpointDefinition - holds the service endpoint definition

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -49,7 +49,7 @@ func (c *ServiceClient) PublishService(serviceBody *ServiceBody) (*management.AP
 	// there is a current envoy restriction with the payload size (10mb). Quick check on the size
 	if binary.Size(serviceBody.SpecDefinition) >= tenMB {
 		// if greater than 10mb, return
-		err := fmt.Errorf("service %s carries a payload greater than 10mb. Service not created.", serviceBody.APIName)
+		err := fmt.Errorf("service %s carries a payload greater than 10mb. Service not created", serviceBody.APIName)
 		logger.WithError(err).Error("error processing service")
 		return nil, err
 	}

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -60,6 +60,10 @@ type ServiceBody struct {
 	accessRequestDefinition   *management.AccessRequestDefinition
 	specHashes                map[string]interface{} // map of hash values to revision names
 	requestDefinitionsAllowed bool                   // used to validate if the instance can have request definitions or not. Use case example - v7 unpublished, remove request definitions
+	dataplaneType             DataplaneType
+	isDesignDataplane         bool
+	referencedServiceName     string
+	referencedInstanceName    string
 }
 
 // SetAccessRequestDefinitionName - set the name of the access request definition for this service body
@@ -130,4 +134,22 @@ func (s *ServiceBody) createAccessRequestDefinition() error {
 // GetSpecVersion - returns version parsed from the spec
 func (s *ServiceBody) GetSpecVersion() string {
 	return s.specVersion
+}
+
+// GetDataplaneType - returns dataplane type
+func (s *ServiceBody) GetDataplaneType() DataplaneType {
+	return s.dataplaneType
+}
+
+// IsDesignDataplane - returns true for design dataplane
+func (s *ServiceBody) IsDesignDataplane() bool {
+	return s.isDesignDataplane
+}
+
+func (s *ServiceBody) GetReferencedServiceName() string {
+	return s.referencedServiceName
+}
+
+func (s *ServiceBody) GetReferenceInstanceName() string {
+	return s.referencedInstanceName
 }

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -54,6 +54,11 @@ type ServiceBuilder interface {
 	SetServiceAgentDetails(attr map[string]interface{}) ServiceBuilder
 	SetInstanceAgentDetails(attr map[string]interface{}) ServiceBuilder
 	SetRevisionAgentDetails(attr map[string]interface{}) ServiceBuilder
+
+	SetSourceDataplaneType(dataplaneType DataplaneType, isDesign bool) ServiceBuilder
+	SetReferenceServiceName(serviceName, envName string) ServiceBuilder
+	SetReferenceInstanceName(instanceName, envName string) ServiceBuilder
+
 	Build() (ServiceBody, error)
 }
 
@@ -350,6 +355,9 @@ func (b *serviceBodyBuilder) Build() (ServiceBody, error) {
 		}
 	}
 
+	if b.serviceBody.dataplaneType == "" {
+		b.serviceBody.dataplaneType = "Unidentified"
+	}
 	return b.serviceBody, nil
 }
 
@@ -369,5 +377,30 @@ func (b *serviceBodyBuilder) AddCredentialRequestDefinition(credentialRequestDef
 func (b *serviceBodyBuilder) SetAccessRequestDefinitionName(accessRequestDefName string, isUnique bool) ServiceBuilder {
 	b.serviceBody.ardName = accessRequestDefName
 	b.serviceBody.uniqueARD = isUnique
+	return b
+}
+
+func (b *serviceBodyBuilder) SetSourceDataplaneType(dataplaneType DataplaneType, isDesign bool) ServiceBuilder {
+	b.serviceBody.dataplaneType = dataplaneType
+	b.serviceBody.isDesignDataplane = isDesign
+	return b
+}
+
+func (b *serviceBodyBuilder) SetReferenceServiceName(serviceName, envName string) ServiceBuilder {
+	if envName != "" {
+		b.serviceBody.referencedServiceName = fmt.Sprintf("%s/%s", envName, serviceName)
+	} else {
+		b.serviceBody.referencedServiceName = serviceName
+	}
+
+	return b
+}
+
+func (b *serviceBodyBuilder) SetReferenceInstanceName(instanceName, envName string) ServiceBuilder {
+	if envName != "" {
+		b.serviceBody.referencedInstanceName = fmt.Sprintf("%s/%s", envName, instanceName)
+	} else {
+		b.serviceBody.referencedInstanceName = instanceName
+	}
 	return b
 }

--- a/pkg/apic/servicebuilder_test.go
+++ b/pkg/apic/servicebuilder_test.go
@@ -82,6 +82,8 @@ func TestServiceBodySetters(t *testing.T) {
 		SetInstanceAgentDetails(instDetails).
 		SetRevisionAgentDetails(revDetails).
 		SetServiceEndpoints(ep).
+		SetReferenceServiceName("refSvc", "refEnv").
+		SetReferenceInstanceName("refInstance", "refEnv").
 		Build()
 
 	assert.Nil(t, err)
@@ -126,6 +128,19 @@ func TestServiceBodySetters(t *testing.T) {
 	assert.Equal(t, svcDetails, sb.ServiceAgentDetails)
 	assert.Equal(t, instDetails, sb.InstanceAgentDetails)
 	assert.Equal(t, revDetails, sb.RevisionAgentDetails)
+	assert.Equal(t, Unidentified, sb.dataplaneType)
+	assert.Equal(t, false, sb.isDesignDataplane)
+	assert.Equal(t, "refEnv/refSvc", sb.GetReferencedServiceName())
+	assert.Equal(t, "refEnv/refInstance", sb.GetReferenceInstanceName())
+
+	sb, err = serviceBuilder.
+		SetSourceDataplaneType(GitHub, true).
+		Build()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, sb)
+	assert.Equal(t, GitHub, sb.dataplaneType)
+	assert.Equal(t, true, sb.isDesignDataplane)
 }
 
 func TestServiceBodyWithParseError(t *testing.T) {

--- a/pkg/apic/testdata/existingserviceinstances.json
+++ b/pkg/apic/testdata/existingserviceinstances.json
@@ -3,7 +3,7 @@
         "group": "management",
         "apiVersion": "v1alpha1",
         "kind": "APIServiceInstance",
-        "name": "daleapi.1",
+        "name": "existingInstance",
         "title": "DaleAPI (V7)",
         "metadata": {
             "id": "e4ecaab773cb08300173dab5a4220273",
@@ -47,7 +47,15 @@
         },
         "x-agent-details": {
             "createdBy": "",
-            "externalAPIID": "2f5f92f0-f5e4-44fb-bc84-599c27b3497a"
+            "externalAPIID": "existingInstance"
+        },
+        "source" : {
+            "dataplaneType": {
+                "managed": "Unclassified"
+            },
+            "references" : {
+                "apiServiceInstance": "refInstance"
+            }
         }
     }
 ]


### PR DESCRIPTION
- Added interface to be used by agents for setting source dataplane type, if not set defaults to Unidentified
- Added interface to be used by graylog agent for setting referenced service and instance
- Updated APIService and APIServiceInstance processing to setup source subresource if not already set
- Source subresource is updated only when dataplane type or references require update.