### PR TITLE
APIGOV-27489 - processing runtime compliance

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -25,6 +25,7 @@ const (
 	GET    string = http.MethodGet
 	POST   string = http.MethodPost
 	PUT    string = http.MethodPut
+	PATCH  string = http.MethodPatch
 	DELETE string = http.MethodDelete
 
 	defaultTimeout     = time.Second * 60

--- a/pkg/apic/apiservicerevision.go
+++ b/pkg/apic/apiservicerevision.go
@@ -108,7 +108,7 @@ func (c *ServiceClient) getRevisionCount(queryString string) int {
 		"page":     "1",
 		"pageSize": "1",
 	}
-	res, err := c.executeAPI(coreapi.GET, c.cfg.GetRevisionsURL(), queryParams, nil)
+	res, err := c.executeAPI(coreapi.GET, c.cfg.GetRevisionsURL(), queryParams, nil, nil)
 	if err != nil {
 		return 0
 	}

--- a/pkg/apic/mock/mockclient.go
+++ b/pkg/apic/mock/mockclient.go
@@ -52,6 +52,7 @@ type Client struct {
 	CreateAccessControlListMock                              func(acl *management.AccessControlList) (*management.AccessControlList, error)
 	UpdateResourceInstanceMock                               func(ri v1.Interface) (*v1.ResourceInstance, error)
 	CreateResourceInstanceMock                               func(ri v1.Interface) (*v1.ResourceInstance, error)
+	PatchSubResourceMock                                     func(ri v1.Interface, subResourceName string, patches []map[string]interface{}) (*v1.ResourceInstance, error)
 	DeleteResourceInstanceMock                               func(ri v1.Interface) error
 	CreateSubResourceMock                                    func(rm v1.ResourceMeta, subs map[string]interface{}) error
 	GetResourceMock                                          func(url string) (*v1.ResourceInstance, error)
@@ -335,6 +336,13 @@ func (m *Client) UpdateResourceInstance(ri v1.Interface) (*v1.ResourceInstance, 
 func (m *Client) CreateResourceInstance(ri v1.Interface) (*v1.ResourceInstance, error) {
 	if m.CreateResourceInstanceMock != nil {
 		return m.CreateResourceInstanceMock(ri)
+	}
+	return nil, nil
+}
+
+func (m *Client) PatchSubResource(ri v1.Interface, subResourceName string, patches []map[string]interface{}) (*v1.ResourceInstance, error) {
+	if m.PatchSubResourceMock != nil {
+		return m.PatchSubResourceMock(ri, subResourceName, patches)
 	}
 	return nil, nil
 }

--- a/pkg/compliance/compliance_test.go
+++ b/pkg/compliance/compliance_test.go
@@ -1,0 +1,110 @@
+package compliance
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Axway/agent-sdk/pkg/agent"
+	"github.com/Axway/agent-sdk/pkg/apic"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/apic/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProcessor struct {
+	results       []RuntimeResult
+	collectCalled bool
+}
+
+func (m *mockProcessor) CollectRuntimeResult(results RuntimeResults) error {
+	m.collectCalled = true
+	for _, result := range m.results {
+		results.AddRuntimeResult(result)
+	}
+	return nil
+}
+
+func TestCompliance(t *testing.T) {
+	apicMockCli := &mock.Client{}
+	patchReqCount := 0
+
+	apicMockCli.PatchSubResourceMock = func(ri v1.Interface, subResourceName string, patches []map[string]interface{}) (*v1.ResourceInstance, error) {
+		patchReqCount++
+		resInst, _ := ri.AsInstance()
+		instance := management.NewAPIServiceInstance("", "")
+		instance.FromInstance(resInst)
+		for _, patch := range patches {
+			if patch[apic.PatchOperation] != apic.PatchOpBuildObjectTree {
+				c := patch[apic.PatchValue]
+				buf, _ := json.Marshal(c)
+				compliance := &management.ApiServiceInstanceSourceCompliance{}
+				json.Unmarshal(buf, compliance)
+				instance.Source.Compliance = compliance
+				resInst, _ = instance.AsInstance()
+				agent.GetCacheManager().AddAPIServiceInstance(resInst)
+			}
+		}
+		return instance.AsInstance()
+	}
+
+	tests := []struct {
+		name           string
+		runtimeResults []RuntimeResult
+	}{
+		{
+			name: "no collection",
+		},
+		{
+			name: "collect and publish",
+			runtimeResults: []RuntimeResult{
+				{
+					APIServiceInstance: "test-1",
+					HighCount:          10,
+					MediumCount:        10,
+					LowCount:           0,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patchReqCount = 0
+			agent.InitializeForTest(apicMockCli)
+			processor := &mockProcessor{
+				results: tt.runtimeResults,
+			}
+			for _, result := range tt.runtimeResults {
+				inst := management.NewAPIServiceInstance(result.APIServiceInstance, "test")
+				inst.Source = &management.ApiServiceInstanceSource{
+					DataplaneType: &management.ApiServiceInstanceSourceDataplaneType{
+						Managed: string(apic.Unclassified),
+					},
+				}
+				ri, _ := inst.AsInstance()
+				agent.GetCacheManager().AddAPIServiceInstance(ri)
+			}
+			cm := GetManager()
+			manager, ok := cm.(*complianceManager)
+			assert.True(t, ok)
+			manager.job = &runtimeComplianceJob{
+				logger:    manager.logger,
+				processor: processor,
+			}
+			manager.job.Execute()
+			assert.True(t, processor.collectCalled)
+			for _, result := range tt.runtimeResults {
+				cacheManager := agent.GetCacheManager()
+				ri, _ := cacheManager.GetAPIServiceInstanceByName(result.APIServiceInstance)
+				instance := &management.APIServiceInstance{}
+				instance.FromInstance(ri)
+				assert.NotNil(t, instance.Source)
+				assert.NotNil(t, instance.Source.Compliance)
+				assert.Equal(t, int32(result.HighCount), instance.Source.Compliance.Runtime.Result.HighCount)
+				assert.Equal(t, int32(result.MediumCount), instance.Source.Compliance.Runtime.Result.MediumCount)
+				assert.Equal(t, int32(result.LowCount), instance.Source.Compliance.Runtime.Result.LowCount)
+			}
+			assert.Equal(t, len(tt.runtimeResults), patchReqCount)
+		})
+	}
+}

--- a/pkg/compliance/job.go
+++ b/pkg/compliance/job.go
@@ -1,0 +1,92 @@
+package compliance
+
+import (
+	"time"
+
+	"github.com/Axway/agent-sdk/pkg/agent"
+	"github.com/Axway/agent-sdk/pkg/apic"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+const (
+	SourceCompliancePath = "/source/compliance"
+)
+
+type Processor interface {
+	CollectRuntimeResult(RuntimeResults) error
+}
+
+type runtimeComplianceJob struct {
+	logger    log.FieldLogger
+	id        string
+	processor Processor
+}
+
+func (j *runtimeComplianceJob) Status() error {
+	return nil
+}
+
+func (j *runtimeComplianceJob) Ready() bool {
+	return true
+}
+
+func (j *runtimeComplianceJob) Execute() error {
+	if j.processor != nil {
+		results := &runtimeResults{
+			logger: j.logger,
+		}
+		j.logger.Info("starting runtime compliance processing")
+		j.processor.CollectRuntimeResult(results)
+		j.publishResources(results)
+		j.logger.Info("completed runtime compliance processing")
+	}
+	return nil
+}
+
+func (j *runtimeComplianceJob) publishResources(results *runtimeResults) {
+	cacheManager := agent.GetCacheManager()
+	for instanceName, result := range results.items {
+		ri, err := cacheManager.GetAPIServiceInstanceByName(instanceName)
+		if err != nil {
+			j.logger.WithError(err).WithField("instanceName", instanceName).Warn("skipping instance")
+			continue
+		}
+
+		instance := &management.APIServiceInstance{}
+		instance.FromInstance(ri)
+		if instance.Source != nil {
+			compliance := management.ApiServiceInstanceSourceCompliance{
+				Runtime: management.ApiServiceInstanceSourceRuntimeStatus{
+					Result: management.ApiServiceInstanceSourceRuntimeStatusResult{
+						Timestamp:   v1.Time(time.Now()),
+						HighCount:   int32(result.HighCount),
+						MediumCount: int32(result.MediumCount),
+						LowCount:    int32(result.LowCount),
+					},
+				},
+			}
+
+			patches := make([]map[string]interface{}, 0)
+			patches = append(patches, map[string]interface{}{
+				apic.PatchOperation: apic.PatchOpAdd,
+				apic.PatchPath:      SourceCompliancePath,
+				apic.PatchValue:     compliance,
+			})
+
+			logger := j.logger.
+				WithField("instanceId", ri.Metadata.ID).
+				WithField("instanceName", instanceName).
+				WithField("high", result.HighCount).
+				WithField("medium", result.MediumCount).
+				WithField("high", result.LowCount)
+
+			logger.Debug("updating runtime compliance result")
+			_, err := agent.GetCentralClient().PatchSubResource(instance, management.ApiServiceInstanceSourceSubResourceName, patches)
+			if err != nil {
+				logger.WithError(err).Error("failed to updated runtime compliance result")
+			}
+		}
+	}
+}

--- a/pkg/compliance/manager.go
+++ b/pkg/compliance/manager.go
@@ -1,0 +1,46 @@
+package compliance
+
+import (
+	"time"
+
+	"github.com/Axway/agent-sdk/pkg/jobs"
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+type Manager interface {
+	RegisterRuntimeComplianceJob(interval time.Duration, processor Processor)
+}
+
+type complianceManager struct {
+	logger log.FieldLogger
+	job    *runtimeComplianceJob
+}
+
+var manager Manager
+
+func GetManager() Manager {
+	if manager == nil {
+		cm := &complianceManager{
+			logger: log.NewFieldLogger().WithComponent("compliance"),
+		}
+		manager = cm
+	}
+	return manager
+}
+
+func (m *complianceManager) RegisterRuntimeComplianceJob(interval time.Duration, processor Processor) {
+	if m.job != nil {
+		jobs.UnregisterJob(m.job.id)
+	}
+
+	job := &runtimeComplianceJob{
+		logger:    m.logger,
+		processor: processor,
+	}
+	id, err := jobs.RegisterIntervalJobWithName(job, interval, "Runtime compliance")
+	if err != nil {
+		m.logger.WithError(err).Error("failed to register runtime compliance job")
+	}
+	job.id = id
+	m.job = job
+}

--- a/pkg/compliance/runtimeresults.go
+++ b/pkg/compliance/runtimeresults.go
@@ -1,0 +1,28 @@
+package compliance
+
+import (
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+type RuntimeResult struct {
+	APIServiceInstance string `json:"apiServiceInstance"`
+	HighCount          int64  `json:"highCount"`
+	MediumCount        int64  `json:"mediumCount"`
+	LowCount           int64  `json:"lowCount"`
+}
+
+type RuntimeResults interface {
+	AddRuntimeResult(RuntimeResult)
+}
+
+type runtimeResults struct {
+	logger log.FieldLogger
+	items  map[string]RuntimeResult
+}
+
+func (r *runtimeResults) AddRuntimeResult(result RuntimeResult) {
+	if r.items == nil {
+		r.items = make(map[string]RuntimeResult)
+	}
+	r.items[result.APIServiceInstance] = result
+}


### PR DESCRIPTION
- Added support to execute PATCH request for sub resource updates
- Added compliance manager to register the job with configured processor to collect runtime results
- Compliance job collects the runtime results and execute patch request to update compliance property in source sub-resource on APIServiceInstance