### PR TITLE
APIGOV-27788 - updated to offline usage rporting

### DIFF
--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -369,8 +369,16 @@ func (client *Client) Publish(ctx context.Context, batch publisher.Batch) error 
 		batch.ACK()
 		return nil // nothing to do
 	}
-
 	_, isMetric := events[0].Content.Meta["metric"]
+
+	if agent.GetCentralConfig().GetUsageReportingConfig().IsOfflineMode() {
+		if outputEventProcessor != nil && !isMetric {
+			outputEventProcessor.Process(events)
+		}
+		batch.ACK()
+		return nil
+	}
+
 	logger := client.logger.WithField(eventTypeStr, "metric")
 
 	if !isMetric {

--- a/pkg/transaction/metric/reportcache.go
+++ b/pkg/transaction/metric/reportcache.go
@@ -170,6 +170,8 @@ func (c *usageReportCache) addReport(event UsageEvent) error {
 
 // saveReport - creates a new file with the latest cached events then clears all reports from the cache, lock outside of this
 func (c *usageReportCache) saveReport() error {
+	c.reportCacheLock.Lock()
+	defer c.reportCacheLock.Unlock()
 	savedEvents := c.getEvents()
 
 	// no reports yet, skip creating the event


### PR DESCRIPTION
- Capture all published events, process them for counting then ack before sending
- Skip logging around metrics and processing of metrics in offline
- Lock the report cache while saving to avoid race where usage being published can my lost