### PR TITLE
APIGOV-28400 - add mode to azure dataplane

### DIFF
--- a/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_azure.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_azure.go
@@ -26,4 +26,6 @@ type DataplaneSpecAzure struct {
 	EventHubNamespace string `json:"eventHubNamespace,omitempty"`
 	// Consumer groups enable consuming applications to each have a separate view of the event stream. They read the stream independently at their own pace and with their own offsets.
 	EventHubConsumerGroup string `json:"eventHubConsumerGroup,omitempty"`
+	// Dictates the operation mode for the discovery agent
+	Mode string `json:"mode,omitempty"`
 }


### PR DESCRIPTION
add mode to the azure dataplane.
Mode is either APIM or EventHub.  APIM is the default