### PR TITLE
APIGOV-DG000 - fix ARD creation

### DIFF
--- a/pkg/apic/definitions.go
+++ b/pkg/apic/definitions.go
@@ -55,6 +55,7 @@ const (
 	GitHub       DataplaneType = "GitHub"
 	GitLab       DataplaneType = "GitLab"
 	SwaggerHub   DataplaneType = "SwaggerHub"
+	WebMethods   DataplaneType = "WebMethods"
 	Unidentified DataplaneType = "Unidentified"
 	Unclassified DataplaneType = "Unclassified"
 )

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -96,7 +96,7 @@ func (s *ServiceBody) GetScopes() map[string]string {
 
 // GetCredentialRequestDefinitions - returns the array of all credential request policies
 func (s *ServiceBody) GetCredentialRequestDefinitions() []string {
-	if len(s.credentialRequestPolicies) > 0 {
+	if len(s.credentialRequestPolicies) > 0 || s.ignoreSpecBasesCreds {
 		return s.credentialRequestPolicies
 	}
 	for _, policy := range s.authPolicies {

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -3,6 +3,7 @@ package apic
 import (
 	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
+	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
 // APIKeyInfo -
@@ -64,6 +65,7 @@ type ServiceBody struct {
 	isDesignDataplane         bool
 	referencedServiceName     string
 	referencedInstanceName    string
+	logger                    log.FieldLogger
 }
 
 // SetAccessRequestDefinitionName - set the name of the access request definition for this service body
@@ -118,6 +120,7 @@ func (s *ServiceBody) GetAccessRequestDefinition() *management.AccessRequestDefi
 
 func (s *ServiceBody) createAccessRequestDefinition() error {
 	if !s.uniqueARD {
+		s.logger.WithField("ardName", s.ardName).Debug("skipping registering new ARD")
 		return nil
 	}
 	oauthScopes := make([]string, 0)

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -56,6 +56,7 @@ type ServiceBody struct {
 	credentialRequestPolicies []string
 	ardName                   string
 	uniqueARD                 bool
+	ignoreSpecBasesCreds      bool
 	specHash                  string
 	specVersion               string
 	accessRequestDefinition   *management.AccessRequestDefinition
@@ -72,6 +73,10 @@ type ServiceBody struct {
 func (s *ServiceBody) SetAccessRequestDefinitionName(ardName string, isUnique bool) {
 	s.ardName = ardName
 	s.uniqueARD = isUnique
+}
+
+func (s *ServiceBody) SetIgnoreSpecBasedCreds(ignore bool) {
+	s.ignoreSpecBasesCreds = ignore
 }
 
 // GetAuthPolicies - returns the array of all auth policies in the ServiceBody
@@ -119,7 +124,7 @@ func (s *ServiceBody) GetAccessRequestDefinition() *management.AccessRequestDefi
 }
 
 func (s *ServiceBody) createAccessRequestDefinition() error {
-	if !s.uniqueARD {
+	if s.ignoreSpecBasesCreds {
 		s.logger.WithField("ardName", s.ardName).Debug("skipping registering new ARD")
 		return nil
 	}

--- a/pkg/apic/servicebody.go
+++ b/pkg/apic/servicebody.go
@@ -117,6 +117,9 @@ func (s *ServiceBody) GetAccessRequestDefinition() *management.AccessRequestDefi
 }
 
 func (s *ServiceBody) createAccessRequestDefinition() error {
+	if !s.uniqueARD {
+		return nil
+	}
 	oauthScopes := make([]string, 0)
 	for scope := range s.GetScopes() {
 		oauthScopes = append(oauthScopes, scope)

--- a/pkg/apic/servicebuilder.go
+++ b/pkg/apic/servicebuilder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Axway/agent-sdk/pkg/apic/provisioning"
 	"github.com/Axway/agent-sdk/pkg/config"
+	"github.com/Axway/agent-sdk/pkg/util/log"
 )
 
 const (
@@ -97,6 +98,7 @@ func NewServiceBodyBuilder() ServiceBuilder {
 			InstanceAgentDetails:      make(map[string]interface{}),
 			RevisionAgentDetails:      make(map[string]interface{}),
 			requestDefinitionsAllowed: true,
+			logger:                    log.NewFieldLogger().WithPackage("sdk.apic").WithComponent("serviceBuilder"),
 		},
 	}
 }

--- a/pkg/apic/servicebuilder_test.go
+++ b/pkg/apic/servicebuilder_test.go
@@ -63,7 +63,6 @@ func TestServiceBodySetters(t *testing.T) {
 		SetStatus(UnpublishedStatus).
 		SetState(PublishedStatus).
 		SetSubscriptionName("testsubscription").
-		SetAPISpec([]byte{}).
 		AddServiceEndpoint("https", "test.com", 443, "/test").
 		SetImage("image").
 		SetImageContentType("image/jpeg").
@@ -82,7 +81,8 @@ func TestServiceBodySetters(t *testing.T) {
 		SetInstanceAgentDetails(instDetails).
 		SetRevisionAgentDetails(revDetails).
 		SetReferenceServiceName("refSvc", "refEnv").
-		SetReferenceInstanceName("refInstance", "refEnv")
+		SetReferenceInstanceName("refInstance", "refEnv").
+		SetIgnoreSpecBasedCreds(true)
 
 	sb, err := serviceBuilder.
 		SetServiceEndpoints(ep).
@@ -134,6 +134,7 @@ func TestServiceBodySetters(t *testing.T) {
 	assert.Equal(t, false, sb.isDesignDataplane)
 	assert.Equal(t, "refEnv/refSvc", sb.GetReferencedServiceName())
 	assert.Equal(t, "refEnv/refInstance", sb.GetReferenceInstanceName())
+	assert.Equal(t, true, sb.ignoreSpecBasesCreds)
 
 	sb, err = serviceBuilder.
 		SetSourceDataplaneType(GitHub, true).


### PR DESCRIPTION
Adds a flag that ignores creating ARD and CRDs based on the spec provided in the serviceBody