### PR TITLE
APIGOV-29053 - support skipping handling external CRDs

### DIFF
--- a/pkg/agent/handler/credential.go
+++ b/pkg/agent/handler/credential.go
@@ -81,7 +81,7 @@ func (h *credentials) Handle(ctx context.Context, meta *proto.EventMeta, resourc
 	}
 
 	if c, ok := h.prov.(prov.CustomCredential); ok {
-		creds := c.GetIgnoredCredentials()
+		creds := c.GetIgnoredCredentialTypes()
 		for _, cred := range creds {
 			if cred == cr.Spec.CredentialRequestDefinition {
 				logger.WithField("crdName", cred).Debug("skipping handling credential provisioning")

--- a/pkg/agent/handler/credential.go
+++ b/pkg/agent/handler/credential.go
@@ -80,6 +80,16 @@ func (h *credentials) Handle(ctx context.Context, meta *proto.EventMeta, resourc
 		return nil
 	}
 
+	if c, ok := h.prov.(prov.CustomCredential); ok {
+		creds := c.GetIgnoredCredentials()
+		for _, cred := range creds {
+			if cred == cr.Spec.CredentialRequestDefinition {
+				logger.WithField("crdName", cred).Debug("skipping handling credential provisioning")
+				return nil
+			}
+		}
+	}
+
 	var credential *management.Credential
 	if ok := h.shouldProcessPending(cr); ok {
 		log.Trace("processing resource in pending status")

--- a/pkg/apic/provisioning/definitions.go
+++ b/pkg/apic/provisioning/definitions.go
@@ -9,6 +9,7 @@ const (
 	OAuthSecretCRD    = "oauth-secret"
 	OAuthPublicKeyCRD = "oauth-public-key"
 	OAuthIDPCRD       = "oauth-idp"
+	ExternalCRD       = "external-crd"
 
 	OauthClientID            = "clientId"
 	OauthClientSecret        = "clientSecret"
@@ -127,6 +128,10 @@ type Provisioning interface {
 	CredentialDeprovision(CredentialRequest) RequestStatus
 	CredentialProvision(CredentialRequest) (RequestStatus, Credential)
 	CredentialUpdate(CredentialRequest) (RequestStatus, Credential)
+}
+
+type CustomCredential interface {
+	GetIgnoredCredentials() []string
 }
 
 // ExpiredCredentialAction - the action to take on an expired credential

--- a/pkg/apic/provisioning/definitions.go
+++ b/pkg/apic/provisioning/definitions.go
@@ -131,7 +131,7 @@ type Provisioning interface {
 }
 
 type CustomCredential interface {
-	GetIgnoredCredentials() []string
+	GetIgnoredCredentialTypes() []string
 }
 
 // ExpiredCredentialAction - the action to take on an expired credential


### PR DESCRIPTION
- adds an interface with which the agent can send what CRDs to ignore handling