### PR TITLE
APIGOV-29316 - fix connection error over proxy

### DIFF
--- a/pkg/watchmanager/manager.go
+++ b/pkg/watchmanager/manager.go
@@ -91,7 +91,7 @@ func (m *watchManager) createConnection() (*grpc.ClientConn, error) {
 			util.CreateCustomGRPCResolverBuilder(
 				fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.Port),
 				m.cfg.Host,
-				"https")),
+				m.cfg.Host)),
 	}
 
 	m.logger.


### PR DESCRIPTION
- Use host name as scheme for gRPC resolver as library parses the address and uses the host as scheme to lookup the resolver