### PR TITLE
APIGOV-29690 - write initial watch request

### DIFF
--- a/pkg/agent/stream/client.go
+++ b/pkg/agent/stream/client.go
@@ -241,6 +241,7 @@ func (s *StreamerClient) UpdateAgentStatus(state, prevState, message string) err
 func (s *StreamerClient) writeStatusRequest(state, message string) error {
 	if s.canUpdateStatus() {
 		req := &proto.Request{
+			SelfLink:    s.topicSelfLink,
 			RequestType: proto.RequestType_AGENT_STATUS.Enum(),
 			AgentStatus: &proto.AgentStatus{
 				State:   state,


### PR DESCRIPTION
- update to write initial request without relying on the initial timer
- include watchTopicSelf link in status update request to watch service