### PR TITLE
APIGOV-24309 - Support for processing access req transfer

### DIFF
--- a/pkg/agent/handler/credential_test.go
+++ b/pkg/agent/handler/credential_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
 	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
 	prov "github.com/Axway/agent-sdk/pkg/apic/provisioning"
@@ -905,6 +906,10 @@ func (m *credClient) UpdateResourceFinalizer(ri *apiv1.ResourceInstance, _, _ st
 
 func (m *credClient) UpdateResourceInstance(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
 	return nil, nil
+}
+
+func (m *credClient) DeleteResourceInstance(ri v1.Interface) error {
+	return nil
 }
 
 const credAppRefName = "managed-app-name"

--- a/pkg/agent/handler/handler.go
+++ b/pkg/agent/handler/handler.go
@@ -45,6 +45,7 @@ type client interface {
 	UpdateResourceFinalizer(ri *v1.ResourceInstance, finalizer, description string, addAction bool) (*v1.ResourceInstance, error)
 	CreateSubResource(rm v1.ResourceMeta, subs map[string]interface{}) error
 	UpdateResourceInstance(ri v1.Interface) (*v1.ResourceInstance, error)
+	DeleteResourceInstance(ri v1.Interface) error
 }
 
 func isStatusFound(rs *v1.ResourceStatus) bool {

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_access_request_spec.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_access_request_spec.go
@@ -4,12 +4,14 @@ package management
 
 // AccessRequestSpec  (management.v1alpha1.AccessRequest)
 type AccessRequestSpec struct {
+	// The name of an AccessRequest resource that specifies migrating access request.
+	AccessRequest string `json:"accessRequest,omitempty"`
 	// The name of an APIServiceInstance resource that specifies where the API is deployed.
 	ApiServiceInstance string `json:"apiServiceInstance"`
 	// The name of an ManagedApplication resource that groups set of credentials.
 	ManagedApplication string `json:"managedApplication"`
 	// The value that matches the AccessRequestDefinition schema linked to the referenced APIServiceInstance. (management.v1alpha1.AccessRequest)
-	Data  map[string]interface{}  `json:"data"`
-	Quota *AccessRequestSpecQuota `json:"quota,omitempty"`
+	Data             map[string]interface{}              `json:"data"`
+	Quota            *AccessRequestSpecQuota             `json:"quota,omitempty"`
 	AdditionalQuotas []AccessRequestSpecAdditionalQuotas `json:"additionalQuotas,omitempty"`
 }

--- a/pkg/apic/provisioning/accessrequest.go
+++ b/pkg/apic/provisioning/accessrequest.go
@@ -8,8 +8,14 @@ type AccessRequest interface {
 	GetApplicationName() string
 	// GetID returns the ID of the resource for the request
 	GetID() string
+	// IsTransferring returns flag indicating the AccessRequest is for migrating referenced AccessRequest
+	IsTransferring() bool
+	// GetReferencedID returns the ID of the referenced AccessRequest resource for the request
+	GetReferencedID() string
 	// GetAccessRequestDetailsValue returns a value found on the 'x-agent-details' sub resource of the AccessRequest.
 	GetAccessRequestDetailsValue(key string) string
+	// GetReferencedAccessRequestDetailsValue returns a value found on the 'x-agent-details' sub resource of the referenced AccessRequest.
+	GetReferencedAccessRequestDetailsValue(key string) string
 	// GetAccessRequestData returns the map[string]interface{} of data from the request
 	GetAccessRequestData() map[string]interface{}
 	// GetAccessRequestProvisioningData returns the interface{} of data from the provisioning response

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder.go
@@ -18,6 +18,7 @@ type accessRequestDef struct {
 	provisionSchema        map[string]interface{}
 	requestSchema          map[string]interface{}
 	provisionEqualsRequest bool
+	transferable           bool
 	registerFunc           RegisterAccessRequestDefinition
 	err                    error
 }
@@ -30,6 +31,7 @@ type AccessRequestBuilder interface {
 	SetProvisionSchema(schema SchemaBuilder) AccessRequestBuilder
 	SetProvisionSchemaToRequestSchema() AccessRequestBuilder
 	SetApplicationProfileDefinition(name string) AccessRequestBuilder
+	IsTransferable() AccessRequestBuilder
 	Register() (*management.AccessRequestDefinition, error)
 }
 
@@ -103,6 +105,12 @@ func (a *accessRequestDef) SetProvisionSchema(schema SchemaBuilder) AccessReques
 	return a
 }
 
+// IsTransferable - marks the access request transferable for plan migration
+func (a *accessRequestDef) IsTransferable() AccessRequestBuilder {
+	a.transferable = true
+	return a
+}
+
 // Register - create the access request defintion and send it to Central
 func (a *accessRequestDef) Register() (*management.AccessRequestDefinition, error) {
 	if a.err != nil {
@@ -130,6 +138,12 @@ func (a *accessRequestDef) Register() (*management.AccessRequestDefinition, erro
 		Provision: &management.AccessRequestDefinitionSpecProvision{
 			Schema: a.provisionSchema,
 		},
+	}
+
+	if a.transferable {
+		spec.Provision.Policies = management.AccessRequestDefinitionSpecProvisionPolicies{
+			Transferable: true,
+		}
 	}
 
 	hashInt, _ := util.ComputeHash(spec)

--- a/pkg/apic/provisioning/accessrequestdefinitionbuilder_test.go
+++ b/pkg/apic/provisioning/accessrequestdefinitionbuilder_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestNewAccessRequestBuilder(t *testing.T) {
 	tests := []struct {
-		name       string
-		noSchema   bool
-		copySchema bool
-		wantErr    bool
+		name         string
+		noSchema     bool
+		copySchema   bool
+		transferable bool
+		wantErr      bool
 	}{
 		{
 			name: "Success",
@@ -28,6 +29,10 @@ func TestNewAccessRequestBuilder(t *testing.T) {
 		{
 			name:       "Copied",
 			copySchema: true,
+		},
+		{
+			name:         "Transferable",
+			transferable: true,
 		},
 	}
 	for _, tt := range tests {
@@ -51,6 +56,10 @@ func TestNewAccessRequestBuilder(t *testing.T) {
 			if tt.wantErr {
 				builder = builder.SetRequestSchema(nil)
 				builder = builder.SetProvisionSchema(nil)
+			}
+
+			if tt.transferable {
+				builder = builder.IsTransferable()
 			}
 
 			if !tt.noSchema {
@@ -84,6 +93,7 @@ func TestNewAccessRequestBuilder(t *testing.T) {
 				assert.Equal(t, tt.name, ard.Name)
 				assert.Equal(t, "apd", ard.Applicationprofile.Name)
 				assert.True(t, registerFuncCalled)
+				assert.Equal(t, tt.transferable, ard.Spec.Provision.Policies.Transferable)
 			}
 		})
 	}

--- a/scripts/apiserver/model_access_request_spec.tmpl
+++ b/scripts/apiserver/model_access_request_spec.tmpl
@@ -4,6 +4,8 @@ package management
 
 // AccessRequestSpec  (management.v1alpha1.AccessRequest)
 type AccessRequestSpec struct {
+	// The name of an AccessRequest resource that specifies migrating access request.
+	AccessRequest string `json:"accessRequest,omitempty"`
 	// The name of an APIServiceInstance resource that specifies where the API is deployed.
 	ApiServiceInstance string `json:"apiServiceInstance"`
 	// The name of an ManagedApplication resource that groups set of credentials.


### PR DESCRIPTION
- Updated AccessRequestDefinitionBuilder to build ARD with transferable policy
- Updated AccessRequest handler to not cache created/updated access request until processed for pending state
- Updated access data to be passed to agent handler to hold referenced access request and its agent details
- On successful processing of migrated access request, referenced access request finalizer are removed and resource is deleted.