### PR TITLE
APIGOV-30109 - Compliance agent handling in SDK

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -44,9 +44,6 @@ const (
 	RedirectURLsField = "redirectURLs"
 )
 
-// AgentResourceType - Holds the type for agent resource in Central
-var AgentResourceType string
-
 // APIValidator - Callback for validating the API
 type APIValidator func(apiID, stageName string) bool
 
@@ -180,7 +177,9 @@ func InitializeWithAgentFeatures(centralCfg config.CentralConfig, agentFeaturesC
 
 	// call the metric services.
 	metricServicesConfigs := agentFeaturesCfg.GetMetricServicesConfigs()
-	agent.customUnitHandler = customunit.NewCustomUnitHandler(metricServicesConfigs, agent.cacheManager, centralCfg.GetAgentType())
+	if agent.cfg.GetAgentType() != config.ComplianceAgent {
+		agent.customUnitHandler = customunit.NewCustomUnitHandler(metricServicesConfigs, agent.cacheManager, centralCfg.GetAgentType())
+	}
 
 	if !agent.isInitialized {
 		err = handleInitialization()
@@ -281,7 +280,7 @@ func registerExternalIDPs() error {
 		return nil
 	}
 
-	if agent.cfg.GetAgentType() != config.TraceabilityAgent {
+	if agent.cfg.GetAgentType() == config.DiscoveryAgent {
 		idPCfg := agent.agentFeaturesCfg.GetExternalIDPConfig()
 		if idPCfg == nil {
 			return nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -802,7 +802,6 @@ func newHandlers() []handler.Handler {
 					[]apiV1.GroupKind{
 						management.EnvironmentGVK().GroupKind,
 						management.APIServiceInstanceGVK().GroupKind,
-						management.DiscoveryAgentGVK().GroupKind,
 					},
 				),
 			),

--- a/pkg/agent/credendtialvalidator.go
+++ b/pkg/agent/credendtialvalidator.go
@@ -135,6 +135,10 @@ func (j *credentialValidator) validateCredential(credKey string, now time.Time) 
 }
 
 func registerCredentialChecker() *credentialValidator {
+	if agent.cfg.GetAgentType() != config.DiscoveryAgent {
+		return nil
+	}
+
 	c := newCredentialChecker(agent.cacheManager, agent.apicClient)
 
 	err := agent.cfg.SetWatchResourceFilters([]config.ResourceFilter{

--- a/pkg/agent/events/requestqueue_test.go
+++ b/pkg/agent/events/requestqueue_test.go
@@ -36,9 +36,9 @@ func TestRequestQueue(t *testing.T) {
 				q.Start()
 				time.Sleep(1 * time.Second)
 				go func() {
+					defer wg.Done()
 					receivedReq = <-requestCh
 					q.Stop()
-					wg.Done()
 				}()
 			}
 

--- a/pkg/agent/events/requestqueue_test.go
+++ b/pkg/agent/events/requestqueue_test.go
@@ -34,12 +34,12 @@ func TestRequestQueue(t *testing.T) {
 			if tc.queueActivated {
 				wg.Add(1)
 				q.Start()
-				time.Sleep(1 * time.Second)
+				time.Sleep(time.Second)
 				go func() {
-					defer wg.Done()
 					receivedReq = <-requestCh
-					time.Sleep(time.Second / 2)
 					q.Stop()
+					time.Sleep(time.Second)
+					wg.Done()
 				}()
 			}
 

--- a/pkg/agent/events/requestqueue_test.go
+++ b/pkg/agent/events/requestqueue_test.go
@@ -38,6 +38,7 @@ func TestRequestQueue(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					receivedReq = <-requestCh
+					time.Sleep(time.Second / 2)
 					q.Stop()
 				}()
 			}

--- a/pkg/agent/events/requestqueue_test.go
+++ b/pkg/agent/events/requestqueue_test.go
@@ -38,7 +38,6 @@ func TestRequestQueue(t *testing.T) {
 				go func() {
 					receivedReq = <-requestCh
 					q.Stop()
-					time.Sleep(time.Second)
 					wg.Done()
 				}()
 			}
@@ -58,6 +57,7 @@ func TestRequestQueue(t *testing.T) {
 
 			wg.Wait()
 			assert.Equal(t, req, receivedReq)
+			time.Sleep(time.Millisecond * 500)
 			assert.False(t, q.IsActive())
 		})
 	}

--- a/pkg/agent/events/watchtopic.go
+++ b/pkg/agent/events/watchtopic.go
@@ -26,6 +26,7 @@ var agentTypesMap = map[config.AgentType]string{
 
 type watchTopicFeatures interface {
 	GetAgentType() config.AgentType
+	GetManagedEnvironments() []string
 	GetWatchResourceFilters() []config.ResourceFilter
 }
 
@@ -285,6 +286,15 @@ func NewComplianceWatchTopic(name, scope string, agentResourceGroupKind v1.Group
 		{GroupKind: agentResourceGroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: updated},
 		{GroupKind: management.APIServiceGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
 		{GroupKind: management.APIServiceInstanceGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
+		{GroupKind: management.ComplianceAgentGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
+	}
+
+	for _, env := range features.GetManagedEnvironments() {
+		kinds = append(kinds, []kindValues{
+			{GroupKind: management.EnvironmentGVK().GroupKind, Name: env, EventTypes: all},                                                          // watch environments
+			{GroupKind: management.DiscoveryAgentGVK().GroupKind, ScopeKind: management.EnvironmentGVK().Kind, ScopeName: env, EventTypes: all},     // watch discovery agents
+			{GroupKind: management.APIServiceInstanceGVK().GroupKind, ScopeKind: management.EnvironmentGVK().Kind, ScopeName: env, EventTypes: all}, // watch api service instances
+		}...)
 	}
 
 	return WatchTopicValues{

--- a/pkg/agent/events/watchtopic.go
+++ b/pkg/agent/events/watchtopic.go
@@ -292,7 +292,6 @@ func NewComplianceWatchTopic(name, scope string, agentResourceGroupKind v1.Group
 	for _, env := range features.GetManagedEnvironments() {
 		kinds = append(kinds, []kindValues{
 			{GroupKind: management.EnvironmentGVK().GroupKind, Name: env, EventTypes: all},                                                          // watch environments
-			{GroupKind: management.DiscoveryAgentGVK().GroupKind, ScopeKind: management.EnvironmentGVK().Kind, ScopeName: env, EventTypes: all},     // watch discovery agents
 			{GroupKind: management.APIServiceInstanceGVK().GroupKind, ScopeKind: management.EnvironmentGVK().Kind, ScopeName: env, EventTypes: all}, // watch api service instances
 		}...)
 	}

--- a/pkg/agent/events/watchtopic.go
+++ b/pkg/agent/events/watchtopic.go
@@ -283,10 +283,9 @@ func NewTraceWatchTopic(name, scope string, agentResourceGroupKind v1.GroupKind,
 // NewComplianceWatchTopic creates a WatchTopic template string
 func NewComplianceWatchTopic(name, scope string, agentResourceGroupKind v1.GroupKind, features watchTopicFeatures) WatchTopicValues {
 	kinds := []kindValues{
-		{GroupKind: agentResourceGroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: updated},
+		{GroupKind: agentResourceGroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
 		{GroupKind: management.APIServiceGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
 		{GroupKind: management.APIServiceInstanceGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
-		{GroupKind: management.ComplianceAgentGVK().GroupKind, ScopeName: scope, ScopeKind: management.EnvironmentGVK().Kind, EventTypes: all},
 	}
 
 	for _, env := range features.GetManagedEnvironments() {

--- a/pkg/agent/events/watchtopic_test.go
+++ b/pkg/agent/events/watchtopic_test.go
@@ -230,21 +230,16 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 			if len(tc.managedEnvs) > 0 && tc.agentType == config.ComplianceAgent {
 				for _, env := range tc.managedEnvs {
 					foundEnv := false
-					foundDA := false
 					foundAPIS := false
 					for _, wtFilter := range wt.Spec.Filters {
 						if wtFilter.Group == management.EnvironmentGVK().Group && wtFilter.Kind == management.EnvironmentGVK().Kind && wtFilter.Name == env {
 							foundEnv = true
-						}
-						if wtFilter.Group == management.DiscoveryAgentGVK().Group && wtFilter.Kind == management.DiscoveryAgentGVK().Kind && wtFilter.Scope.Name == env {
-							foundDA = true
 						}
 						if wtFilter.Group == management.APIServiceInstanceGVK().Group && wtFilter.Kind == management.APIServiceInstanceGVK().Kind && wtFilter.Scope.Name == env {
 							foundAPIS = true
 						}
 					}
 					assert.Truef(t, foundEnv, "managed env, %s, environment filter not found", env)
-					assert.Truef(t, foundDA, "managed env, %s, discovery agent filter not found", env)
 					assert.Truef(t, foundAPIS, "managed env, %s, api service instance filter not found", env)
 				}
 			}

--- a/pkg/agent/events/watchtopic_test.go
+++ b/pkg/agent/events/watchtopic_test.go
@@ -138,6 +138,20 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 			filterList: []config.ResourceFilter{},
 		},
 		{
+			name:      "should create a watch topic for a compliance agent if it does not exist",
+			agentType: config.ComplianceAgent,
+			hasErr:    false,
+			client: &mockAPIClient{
+				getErr: fmt.Errorf("not found"),
+				ri: &apiv1.ResourceInstance{
+					ResourceMeta: apiv1.ResourceMeta{
+						Name: "wt-name",
+					},
+				},
+			},
+			filterList: []config.ResourceFilter{},
+		},
+		{
 			name:      "should create a watch topic for a discovery agent if it does not exist",
 			agentType: config.DiscoveryAgent,
 			hasErr:    false,

--- a/pkg/agent/events/watchtopic_test.go
+++ b/pkg/agent/events/watchtopic_test.go
@@ -61,12 +61,17 @@ func TestCreateWatchTopic(t *testing.T) {
 }
 
 type mockWatchTopicFeatures struct {
-	agentType  config.AgentType
-	filterList []config.ResourceFilter
+	agentType   config.AgentType
+	managedEnvs []string
+	filterList  []config.ResourceFilter
 }
 
 func (m *mockWatchTopicFeatures) GetAgentType() config.AgentType {
 	return m.agentType
+}
+
+func (m *mockWatchTopicFeatures) GetManagedEnvironments() []string {
+	return m.managedEnvs
 }
 
 func (m *mockWatchTopicFeatures) GetWatchResourceFilters() []config.ResourceFilter {
@@ -104,11 +109,12 @@ func Test_parseWatchTopic(t *testing.T) {
 
 func TestGetOrCreateWatchTopic(t *testing.T) {
 	tests := []struct {
-		name       string
-		client     *mockAPIClient
-		hasErr     bool
-		agentType  config.AgentType
-		filterList []config.ResourceFilter
+		name        string
+		client      *mockAPIClient
+		hasErr      bool
+		agentType   config.AgentType
+		filterList  []config.ResourceFilter
+		managedEnvs []string
 	}{
 		{
 			name:      "should retrieve a watch topic if it exists",
@@ -149,7 +155,8 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 					},
 				},
 			},
-			filterList: []config.ResourceFilter{},
+			filterList:  []config.ResourceFilter{},
+			managedEnvs: []string{"managedEnv1", "managedEnv2"},
 		},
 		{
 			name:      "should create a watch topic for a discovery agent if it does not exist",
@@ -195,7 +202,7 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			name := "agent-name"
-			features := &mockWatchTopicFeatures{agentType: tc.agentType, filterList: tc.filterList}
+			features := &mockWatchTopicFeatures{agentType: tc.agentType, filterList: tc.filterList, managedEnvs: tc.managedEnvs}
 
 			wt, err := getOrCreateWatchTopic(name, "scope", tc.client, features)
 			if tc.hasErr == true {
@@ -218,6 +225,28 @@ func TestGetOrCreateWatchTopic(t *testing.T) {
 					}
 				}
 				assert.True(t, found)
+			}
+			// validate watch topic filter for compliance agent managed env filters
+			if len(tc.managedEnvs) > 0 && tc.agentType == config.ComplianceAgent {
+				for _, env := range tc.managedEnvs {
+					foundEnv := false
+					foundDA := false
+					foundAPIS := false
+					for _, wtFilter := range wt.Spec.Filters {
+						if wtFilter.Group == management.EnvironmentGVK().Group && wtFilter.Kind == management.EnvironmentGVK().Kind && wtFilter.Name == env {
+							foundEnv = true
+						}
+						if wtFilter.Group == management.DiscoveryAgentGVK().Group && wtFilter.Kind == management.DiscoveryAgentGVK().Kind && wtFilter.Scope.Name == env {
+							foundDA = true
+						}
+						if wtFilter.Group == management.APIServiceInstanceGVK().Group && wtFilter.Kind == management.APIServiceInstanceGVK().Kind && wtFilter.Scope.Name == env {
+							foundAPIS = true
+						}
+					}
+					assert.Truef(t, foundEnv, "managed env, %s, environment filter not found", env)
+					assert.Truef(t, foundDA, "managed env, %s, discovery agent filter not found", env)
+					assert.Truef(t, foundAPIS, "managed env, %s, api service instance filter not found", env)
+				}
 			}
 		})
 	}

--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -29,7 +29,7 @@ func newEventSync() (*EventSync, error) {
 	migrations := []migrate.Migrator{}
 
 	// Make sure only DA agents run migration processes
-	runMigrations := agent.cfg.GetAgentType() != config.TraceabilityAgent
+	runMigrations := agent.cfg.GetAgentType() == config.DiscoveryAgent
 
 	if runMigrations {
 		// add attribute migration to migrations

--- a/pkg/agent/handler/agentresource.go
+++ b/pkg/agent/handler/agentresource.go
@@ -24,48 +24,87 @@ type TraceabilityTriggerHandler interface {
 	TriggerTraceability()
 }
 
+// Register an AgentResourceUpdateHandler in an agent to trigger events when changes to the resource is made
+type AgentResourceUpdateHandler interface {
+	AgentResourceUpdate(ctx context.Context, resource *v1.ResourceInstance)
+}
+
+type agentTypeHandler func(action proto.Event_Type, subres string, resource *v1.ResourceInstance) error
+
 type agentResourceHandler struct {
 	agentResourceManager resource.Manager
 	sampler              sampling
+	agentTypeHandler     map[string]agentTypeHandler
 }
 
 // NewAgentResourceHandler - creates a Handler for Agent resources
 func NewAgentResourceHandler(agentResourceManager resource.Manager, sampler sampling) Handler {
-	return &agentResourceHandler{
+	h := &agentResourceHandler{
 		agentResourceManager: agentResourceManager,
 		sampler:              sampler,
 	}
+	h.agentTypeHandler = map[string]agentTypeHandler{
+		management.DiscoveryAgentGVK().Kind:    h.handleDiscovery,
+		management.TraceabilityAgentGVK().Kind: h.handleTraceability,
+		management.ComplianceAgentGVK().Kind:   h.handleCompliance,
+	}
+	return h
 }
 
 func (h *agentResourceHandler) Handle(ctx context.Context, meta *proto.EventMeta, resource *v1.ResourceInstance) error {
-	action := GetActionFromContext(ctx)
-
-	if h.agentResourceManager != nil && action == proto.Event_UPDATED {
-		kind := resource.Kind
-		switch kind {
-		case discoveryAgent:
-			fallthrough
-		case traceabilityAgent:
-			h.agentResourceManager.SetAgentResource(resource)
-		}
-	}
-
-	if !(action == proto.Event_SUBRESOURCEUPDATED && resource.Kind == traceabilityAgent && meta.Subresource == agentStateSubresource) {
+	// skip any processing if the agent resource manager is not set
+	if h.agentResourceManager == nil {
 		return nil
 	}
 
+	action := GetActionFromContext(ctx)
+	if f, ok := h.agentTypeHandler[resource.Kind]; ok {
+		return f(action, meta.Subresource, resource)
+	}
+
+	return nil
+}
+
+func (h *agentResourceHandler) handleDiscovery(action proto.Event_Type, subres string, resource *v1.ResourceInstance) error {
+	if action == proto.Event_UPDATED {
+		h.agentResourceManager.SetAgentResource(resource)
+	}
+	return nil
+}
+
+func (h *agentResourceHandler) handleTraceability(action proto.Event_Type, subres string, resource *v1.ResourceInstance) error {
+
+	switch {
+	case action == proto.Event_UPDATED:
+		h.agentResourceManager.SetAgentResource(resource)
+	case action == proto.Event_SUBRESOURCEUPDATED && subres == management.TraceabilityAgentAgentstateSubResourceName:
+		return h.handleTraceabilitySampling(resource)
+	}
+
+	return nil
+}
+
+func (h *agentResourceHandler) handleTraceabilitySampling(resource *v1.ResourceInstance) error {
 	ta := &management.TraceabilityAgent{}
 	err := ta.FromInstance(resource)
 	if err != nil {
 		return err
 	}
-	if ta.Agentstate.Sampling.Enabled {
-		h.sampler.EnableSampling(ta.Agentstate.Sampling.Limit, time.Time(ta.Agentstate.Sampling.EndTime))
 
-		if traceabilityTriggerHandler, ok := h.agentResourceManager.GetHandler().(TraceabilityTriggerHandler); ok {
-			traceabilityTriggerHandler.TriggerTraceability()
-		}
+	if !ta.Agentstate.Sampling.Enabled {
+		return nil
 	}
 
+	h.sampler.EnableSampling(ta.Agentstate.Sampling.Limit, time.Time(ta.Agentstate.Sampling.EndTime))
+	if traceabilityTriggerHandler, ok := h.agentResourceManager.GetHandler().(TraceabilityTriggerHandler); ok {
+		traceabilityTriggerHandler.TriggerTraceability()
+	}
+	return nil
+}
+
+func (h *agentResourceHandler) handleCompliance(action proto.Event_Type, subres string, resource *v1.ResourceInstance) error {
+	if action == proto.Event_UPDATED {
+		h.agentResourceManager.SetAgentResource(resource)
+	}
 	return nil
 }

--- a/pkg/agent/handler/agentresource_test.go
+++ b/pkg/agent/handler/agentresource_test.go
@@ -2,22 +2,51 @@ package handler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent/resource"
 	"github.com/Axway/agent-sdk/pkg/apic"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	catalog "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/catalog/v1alpha1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
 	"github.com/stretchr/testify/assert"
 )
 
+type fakeSampler struct {
+	enabled bool
+}
+
+func (f *fakeSampler) EnableSampling(samplingLimit int32, samplingEndTime time.Time) {
+	f.enabled = true
+}
+
+type fakeAgent struct {
+	triggeredCompliance   bool
+	triggeredTraceability bool
+}
+
+func (f *fakeAgent) TriggerProcessing() {
+	f.triggeredCompliance = true
+}
+
+func (f *fakeAgent) TriggerTraceability() {
+	f.triggeredTraceability = true
+}
+
 func TestAgentResourceHandler(t *testing.T) {
 	tests := []struct {
-		name     string
-		hasError bool
-		resource *v1.ResourceInstance
-		action   proto.Event_Type
+		name                         string
+		hasError                     bool
+		resource                     *v1.ResourceInstance
+		expectResourceUpdate         bool
+		subresName                   string
+		action                       proto.Event_Type
+		fakeAgentHandler             *fakeAgent
+		expectComplianceProcessing   bool
+		expectTraceabilityProcessing bool
 	}{
 		{
 			name:     "should save DiscoveryAgent",
@@ -32,11 +61,12 @@ func TestAgentResourceHandler(t *testing.T) {
 					},
 					GroupVersionKind: v1.GroupVersionKind{
 						GroupKind: v1.GroupKind{
-							Kind: discoveryAgent,
+							Kind: management.DiscoveryAgentGVK().Kind,
 						},
 					},
 				},
 			},
+			expectResourceUpdate: true,
 		},
 		{
 			name:     "should save TraceabilityAgent",
@@ -51,11 +81,148 @@ func TestAgentResourceHandler(t *testing.T) {
 					},
 					GroupVersionKind: v1.GroupVersionKind{
 						GroupKind: v1.GroupKind{
-							Kind: traceabilityAgent,
+							Kind: management.TraceabilityAgentGVK().Kind,
 						},
 					},
 				},
 			},
+			expectResourceUpdate: true,
+			fakeAgentHandler:     &fakeAgent{},
+		},
+		{
+			name:       "should not trigger TraceabilityAgent processing on agent state subresource when sampling disabled",
+			hasError:   false,
+			action:     proto.Event_SUBRESOURCEUPDATED,
+			subresName: management.TraceabilityAgentAgentstateSubResourceName,
+			resource: &v1.ResourceInstance{
+				ResourceMeta: v1.ResourceMeta{
+					Name:  "name",
+					Title: "title",
+					Metadata: v1.Metadata{
+						ID: "123",
+					},
+					GroupVersionKind: v1.GroupVersionKind{
+						GroupKind: v1.GroupKind{
+							Kind: management.TraceabilityAgentGVK().Kind,
+						},
+					},
+					SubResources: map[string]interface{}{
+						management.TraceabilityAgentAgentstateSubResourceName: map[string]interface{}{
+							"sampling": map[string]interface{}{
+								"enabled": false,
+								"limit":   100,
+								"endTime": v1.Time(time.Now()),
+							},
+						},
+					},
+				},
+			},
+			fakeAgentHandler: &fakeAgent{},
+		},
+		{
+			name:       "should trigger TraceabilityAgent processing on agent state subresource when sampling enabled",
+			hasError:   false,
+			action:     proto.Event_SUBRESOURCEUPDATED,
+			subresName: management.TraceabilityAgentAgentstateSubResourceName,
+			resource: &v1.ResourceInstance{
+				ResourceMeta: v1.ResourceMeta{
+					Name:  "name",
+					Title: "title",
+					Metadata: v1.Metadata{
+						ID: "123",
+					},
+					GroupVersionKind: v1.GroupVersionKind{
+						GroupKind: v1.GroupKind{
+							Kind: management.TraceabilityAgentGVK().Kind,
+						},
+					},
+					SubResources: map[string]interface{}{
+						management.TraceabilityAgentAgentstateSubResourceName: map[string]interface{}{
+							"sampling": map[string]interface{}{
+								"enabled": true,
+								"limit":   100,
+								"endTime": v1.Time(time.Now()),
+							},
+						},
+					},
+				},
+			},
+			fakeAgentHandler:             &fakeAgent{},
+			expectTraceabilityProcessing: true,
+		},
+		{
+			name:     "should save ComplianceAgent",
+			hasError: false,
+			action:   proto.Event_UPDATED,
+			resource: &v1.ResourceInstance{
+				ResourceMeta: v1.ResourceMeta{
+					Name:  "name",
+					Title: "title",
+					Metadata: v1.Metadata{
+						ID: "123",
+					},
+					GroupVersionKind: v1.GroupVersionKind{
+						GroupKind: v1.GroupKind{
+							Kind: management.ComplianceAgentGVK().Kind,
+						},
+					},
+				},
+			},
+			expectResourceUpdate: true,
+			fakeAgentHandler:     &fakeAgent{},
+		},
+		{
+			name:       "should not trigger ComplianceAgent processing on x-agent-details subresource",
+			hasError:   false,
+			action:     proto.Event_SUBRESOURCEUPDATED,
+			subresName: definitions.XAgentDetails,
+			resource: &v1.ResourceInstance{
+				ResourceMeta: v1.ResourceMeta{
+					Name:  "name",
+					Title: "title",
+					Metadata: v1.Metadata{
+						ID: "123",
+					},
+					GroupVersionKind: v1.GroupVersionKind{
+						GroupKind: v1.GroupKind{
+							Kind: management.ComplianceAgentGVK().Kind,
+						},
+					},
+					SubResources: map[string]interface{}{
+						definitions.XAgentDetails: map[string]interface{}{
+							definitions.ComplianceAgentTrigger: "false",
+						},
+					},
+				},
+			},
+			fakeAgentHandler: &fakeAgent{},
+		},
+		{
+			name:       "should trigger ComplianceAgent processing",
+			hasError:   false,
+			action:     proto.Event_SUBRESOURCEUPDATED,
+			subresName: definitions.XAgentDetails,
+			resource: &v1.ResourceInstance{
+				ResourceMeta: v1.ResourceMeta{
+					Name:  "name",
+					Title: "title",
+					Metadata: v1.Metadata{
+						ID: "123",
+					},
+					GroupVersionKind: v1.GroupVersionKind{
+						GroupKind: v1.GroupKind{
+							Kind: management.ComplianceAgentGVK().Kind,
+						},
+					},
+					SubResources: map[string]interface{}{
+						definitions.XAgentDetails: map[string]interface{}{
+							definitions.ComplianceAgentTrigger: "true",
+						},
+					},
+				},
+			},
+			fakeAgentHandler:           &fakeAgent{},
+			expectComplianceProcessing: true,
 		},
 		{
 			name:     "should ignore processing agent resource",
@@ -81,16 +248,38 @@ func TestAgentResourceHandler(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			resourceManager := &mockResourceManager{}
+			if tc.fakeAgentHandler != nil {
+				resourceManager.fakeHandler = tc.fakeAgentHandler
+			}
 
-			handler := NewAgentResourceHandler(resourceManager, nil)
+			sampler := &fakeSampler{}
+			handler := NewAgentResourceHandler(resourceManager, sampler)
 
-			err := handler.Handle(NewEventContext(tc.action, nil, tc.resource.Kind, tc.resource.Name), nil, tc.resource)
+			err := handler.Handle(NewEventContext(tc.action, nil, tc.resource.Kind, tc.resource.Name), &proto.EventMeta{Subresource: tc.subresName}, tc.resource)
 			if tc.hasError {
 				assert.Nil(t, err)
 				assert.Nil(t, resourceManager.resource)
-			} else {
+			}
+			// resource update
+			if tc.expectResourceUpdate {
 				assert.Nil(t, err)
 				assert.Equal(t, resourceManager.resource, tc.resource)
+			}
+
+			// agent processing
+			switch {
+			case tc.fakeAgentHandler != nil && tc.expectComplianceProcessing:
+				assert.True(t, tc.fakeAgentHandler.triggeredCompliance)
+				assert.False(t, tc.fakeAgentHandler.triggeredTraceability)
+				assert.False(t, sampler.enabled)
+			case tc.fakeAgentHandler != nil && tc.expectTraceabilityProcessing:
+				assert.False(t, tc.fakeAgentHandler.triggeredCompliance)
+				assert.True(t, tc.fakeAgentHandler.triggeredTraceability)
+				assert.True(t, sampler.enabled)
+			case tc.fakeAgentHandler != nil:
+				assert.False(t, tc.fakeAgentHandler.triggeredCompliance)
+				assert.False(t, tc.fakeAgentHandler.triggeredTraceability)
+				assert.False(t, sampler.enabled)
 			}
 		})
 	}
@@ -104,6 +293,7 @@ type EventSyncCache interface {
 type mockResourceManager struct {
 	resource     *v1.ResourceInstance
 	rebuildCache resource.EventSyncCache
+	fakeHandler  interface{}
 }
 
 func (m *mockResourceManager) SetAgentResource(agentResource *v1.ResourceInstance) {
@@ -133,5 +323,5 @@ func (m *mockResourceManager) SetRebuildCacheFunc(rebuildCache resource.EventSyn
 func (m *mockResourceManager) RegisterHandler(handler interface{}) {}
 
 func (m *mockResourceManager) GetHandler() interface{} {
-	return nil
+	return m.fakeHandler
 }

--- a/pkg/agent/handler/watchresource_test.go
+++ b/pkg/agent/handler/watchresource_test.go
@@ -52,7 +52,7 @@ func TestWatchResourceHandler(t *testing.T) {
 	}}
 
 	cm := agentcache.NewAgentCacheManager(&config.CentralConfiguration{}, false)
-	handler := NewWatchResourceHandler(cm, features)
+	handler := NewWatchResourceHandler(cm, WithWatchTopicFeatures(features))
 
 	res := createWatchResource(mv1.SecretGVK().Group, mv1.SecretGVK().Kind, "secret-id-1", "secret-name-1")
 	// not cached resource

--- a/pkg/agent/resource/complianceagents.go
+++ b/pkg/agent/resource/complianceagents.go
@@ -6,6 +6,14 @@ import (
 	"github.com/Axway/agent-sdk/pkg/config"
 )
 
+func MergeComplianceAgentWithConfig(agentRes *v1.ResourceInstance, centralCfg config.CentralConfig) {
+	cfg, ok := centralCfg.(*config.CentralConfiguration)
+	if !ok {
+		return
+	}
+	mergeComplianceAgentWithConfig(agentRes, cfg)
+}
+
 func complianceAgent(res *v1.ResourceInstance) *management.ComplianceAgent {
 	agentRes := &management.ComplianceAgent{}
 	agentRes.FromInstance(res)

--- a/pkg/agent/resource/complianceagents.go
+++ b/pkg/agent/resource/complianceagents.go
@@ -1,0 +1,18 @@
+package resource
+
+import (
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1alpha1"
+	"github.com/Axway/agent-sdk/pkg/config"
+)
+
+func complianceAgent(res *v1.ResourceInstance) *management.ComplianceAgent {
+	agentRes := &management.ComplianceAgent{}
+	agentRes.FromInstance(res)
+
+	return agentRes
+}
+
+func mergeComplianceAgentWithConfig(agentRes *v1.ResourceInstance, cfg *config.CentralConfiguration) {
+	applyResConfigToCentralConfig(cfg, "", "", "")
+}

--- a/pkg/agent/resource/complianceagents.go
+++ b/pkg/agent/resource/complianceagents.go
@@ -14,5 +14,7 @@ func complianceAgent(res *v1.ResourceInstance) *management.ComplianceAgent {
 }
 
 func mergeComplianceAgentWithConfig(agentRes *v1.ResourceInstance, cfg *config.CentralConfiguration) {
-	applyResConfigToCentralConfig(cfg, "", "", "")
+	ca := complianceAgent(agentRes)
+
+	applyResConfigToCentralConfig(cfg, "", "", "", ca.Spec.Config.ManagedEnvironments)
 }

--- a/pkg/agent/resource/discoveryagents.go
+++ b/pkg/agent/resource/discoveryagents.go
@@ -23,5 +23,5 @@ func mergeDiscoveryAgentWithConfig(agentRes *v1.ResourceInstance, cfg *config.Ce
 		resCfgTeamID = da.Spec.Config.Owner.ID
 	}
 	resCfgLogLevel := da.Spec.Logging.Level
-	applyResConfigToCentralConfig(cfg, resCfgAdditionalTags, resCfgTeamID, resCfgLogLevel)
+	applyResConfigToCentralConfig(cfg, resCfgAdditionalTags, resCfgTeamID, resCfgLogLevel, nil)
 }

--- a/pkg/agent/resource/manager.go
+++ b/pkg/agent/resource/manager.go
@@ -290,7 +290,7 @@ func newDAStatus(rm apiv1.ResourceMeta, status, prevStatus, message string) mana
 	return daStatus
 }
 
-func applyResConfigToCentralConfig(cfg *config.CentralConfiguration, resCfgAdditionalTags, resCfgTeamID, resCfgLogLevel string) {
+func applyResConfigToCentralConfig(cfg *config.CentralConfiguration, resCfgAdditionalTags, resCfgTeamID, resCfgLogLevel string, managedEnvs []string) {
 	agentResLogLevel := log.GlobalLoggerConfig.GetLevel()
 	if resCfgLogLevel != "" && !strings.EqualFold(agentResLogLevel, resCfgLogLevel) {
 		log.GlobalLoggerConfig.Level(resCfgLogLevel).Apply()
@@ -304,6 +304,8 @@ func applyResConfigToCentralConfig(cfg *config.CentralConfiguration, resCfgAddit
 	if resCfgTeamID != "" && cfg.TeamName == "" {
 		cfg.SetTeamID(resCfgTeamID)
 	}
+
+	cfg.SetManagedEnvironments(managedEnvs)
 }
 
 func (a *agentResourceManager) onResourceChange() {

--- a/pkg/agent/resource/manager.go
+++ b/pkg/agent/resource/manager.go
@@ -60,7 +60,6 @@ type agentResourceManager struct {
 
 // NewAgentResourceManager - Create a new agent resource manager
 func NewAgentResourceManager(cfg config.CentralConfig, apicClient executeAPIClient, agentResourceChangeHandler func()) (Manager, error) {
-
 	logger := log.NewFieldLogger().
 		WithPackage("sdk.agent").
 		WithComponent("agentResourceManager")

--- a/pkg/agent/resource/manager.go
+++ b/pkg/agent/resource/manager.go
@@ -340,6 +340,10 @@ func (a *agentResourceManager) getAgentResourceType() *v1.ResourceInstance {
 		res := management.NewTraceabilityAgent(a.cfg.GetAgentName(), a.cfg.GetEnvironmentName())
 		res.Spec.DataplaneType = config.AgentDataPlaneType
 		agentRes = res
+	case config.ComplianceAgent:
+		res := management.NewComplianceAgent(a.cfg.GetAgentName(), a.cfg.GetEnvironmentName())
+		res.Spec.DataplaneType = config.AgentDataPlaneType
+		agentRes = res
 	}
 	var agentInstance *v1.ResourceInstance
 	if agentRes != nil {
@@ -380,6 +384,12 @@ func (a *agentResourceManager) checkAgentResource() (*v1.ResourceInstance, error
 		currDataplaneType = ta.Spec.DataplaneType
 		ta.Spec.DataplaneType = config.AgentDataPlaneType
 		agentRes = ta
+	} else if a.agentResource.Kind == management.ComplianceAgentGVK().Kind {
+		ca := management.NewComplianceAgent("", "")
+		ca.FromInstance(a.agentResource)
+		currDataplaneType = ca.Spec.DataplaneType
+		ca.Spec.DataplaneType = config.AgentDataPlaneType
+		agentRes = ca
 	}
 
 	// nothing to update
@@ -412,6 +422,8 @@ func (a *agentResourceManager) mergeResourceWithConfig() {
 		mergeDiscoveryAgentWithConfig(a.GetAgentResource(), a.cfg.(*config.CentralConfiguration))
 	case management.TraceabilityAgentGVK().Kind:
 		mergeTraceabilityAgentWithConfig(a.GetAgentResource(), a.cfg.(*config.CentralConfiguration))
+	case management.ComplianceAgentGVK().Kind:
+		mergeComplianceAgentWithConfig(a.GetAgentResource(), a.cfg.(*config.CentralConfiguration))
 	default:
 		panic(ErrUnsupportedAgentType)
 	}

--- a/pkg/agent/resource/manager_test.go
+++ b/pkg/agent/resource/manager_test.go
@@ -62,6 +62,25 @@ func createTraceabilityAgentRes(id, name, dataplane, teamID string) *v1.Resource
 	return instance
 }
 
+func createComplianceAgentRes(id, name, dataplane, env string) *v1.ResourceInstance {
+	res := &management.ComplianceAgent{
+		ResourceMeta: v1.ResourceMeta{
+			Name: name,
+			Metadata: v1.Metadata{
+				ID: id,
+			},
+		},
+		Spec: management.ComplianceAgentSpec{
+			DataplaneType: dataplane,
+			Config: management.ComplianceAgentSpecConfig{
+				ManagedEnvironments: []string{env},
+			},
+		},
+	}
+	instance, _ := res.AsInstance()
+	return instance
+}
+
 func TestNewManager(t *testing.T) {
 	cfg := &config.CentralConfiguration{}
 	m, err := NewAgentResourceManager(cfg, nil, nil)
@@ -118,6 +137,13 @@ func TestAgentConfigOverride(t *testing.T) {
 			agentName:       "Test-TA",
 			resource:        createTraceabilityAgentRes("111", "Test-TA", "test-dataplane", ""),
 			updatedResource: createTraceabilityAgentRes("111", "Test-TA", "test-dataplane", "TestTeam"),
+		},
+		{
+			name:            "ComplianceAgent override",
+			agentType:       config.ComplianceAgent,
+			agentName:       "Test-CA",
+			resource:        createComplianceAgentRes("111", "Test-TA", "test-dataplane", ""),
+			updatedResource: createComplianceAgentRes("111", "Test-TA", "test-dataplane", "reference-env"),
 		},
 	}
 
@@ -186,6 +212,12 @@ func TestAgentUpdateStatus(t *testing.T) {
 			resource:  createTraceabilityAgentRes("111", "Test-TA", "test-dataplane", ""),
 		},
 		{
+			name:      "ComplianceAgent override",
+			agentType: config.ComplianceAgent,
+			agentName: "Test-CA",
+			resource:  createComplianceAgentRes("111", "Test-CA", "test-dataplane", ""),
+		},
+		{
 			name:      "Create DA resource",
 			agentType: config.DiscoveryAgent,
 			agentName: "env-da",
@@ -195,6 +227,12 @@ func TestAgentUpdateStatus(t *testing.T) {
 			name:      "Create TA resource",
 			agentType: config.TraceabilityAgent,
 			agentName: "env-ta",
+			resource:  nil,
+		},
+		{
+			name:      "Create CA resource",
+			agentType: config.ComplianceAgent,
+			agentName: "env-ca",
 			resource:  nil,
 		},
 	}

--- a/pkg/agent/resource/traceabilityagents.go
+++ b/pkg/agent/resource/traceabilityagents.go
@@ -20,5 +20,5 @@ func mergeTraceabilityAgentWithConfig(agentRes *v1.ResourceInstance, cfg *config
 		resCfgTeamID = ta.Spec.Config.Owner.ID
 	}
 	resCfgLogLevel := ta.Spec.Logging.Level
-	applyResConfigToCentralConfig(cfg, "", resCfgTeamID, resCfgLogLevel)
+	applyResConfigToCentralConfig(cfg, "", resCfgTeamID, resCfgLogLevel, nil)
 }

--- a/pkg/apic/definitions/definitions.go
+++ b/pkg/apic/definitions/definitions.go
@@ -41,6 +41,7 @@ const (
 	Subscription                     = "Subscription"
 	MarketplaceMigration             = "marketplace-migration"
 	InstanceMigration                = "instance-migration"
+	ComplianceAgentTrigger           = "triggerProcessing"
 )
 
 // market place provisioning migration

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -128,6 +128,26 @@ func TestRootCmdFlags(t *testing.T) {
 	assertStringCmdFlag(t, rootCmd, "central.ssl.maxVersion", "centralSslMaxVersion", "0", "Maximum acceptable SSL/TLS protocol version")
 	assertBooleanCmdFlag(t, rootCmd, "central.migration.cleanInstances", "centralMigrationCleanInstances", false, "Set this to clean all but latest instance, per stage, within an API Service")
 
+	// Compliance Agent
+	rootCmd = NewRootCmd("Test", "TestRootCmd", nil, nil, corecfg.ComplianceAgent)
+	assertStringCmdFlag(t, rootCmd, "central.deployment", "centralDeployment", "", "Amplify Central")       // assert to empty "" - set by region settings
+	assertStringCmdFlag(t, rootCmd, "central.url", "centralUrl", "", "URL of Amplify Central")              // assert to empty "" - set by region settings
+	assertStringCmdFlag(t, rootCmd, "central.platformURL", "centralPlatformURL", "", "URL of the platform") // assert to empty "" - set by region settings
+	assertStringCmdFlag(t, rootCmd, "central.singleURL", "centralSingleURL", "", "Alternate Connection for Agent if using static IP")
+	assertStringCmdFlag(t, rootCmd, "central.organizationID", "centralOrganizationID", "", "Tenant ID for the owner of the environment")
+	assertStringCmdFlag(t, rootCmd, "central.auth.privateKey", "centralAuthPrivateKey", "/etc/private_key.pem", "Path to the private key for Amplify Central Authentication")
+	assertStringCmdFlag(t, rootCmd, "central.auth.publicKey", "centralAuthPublicKey", "/etc/public_key", "Path to the public key for Amplify Central Authentication")
+	assertStringCmdFlag(t, rootCmd, "central.auth.keyPassword", "centralAuthKeyPassword", "", "Path to the password file required by the private key for Amplify Central Authentication")
+	assertStringCmdFlag(t, rootCmd, "central.auth.url", "centralAuthUrl", "", "Amplify Central authentication URL") // assert to empty "" - set by region settings
+	assertStringCmdFlag(t, rootCmd, "central.auth.realm", "centralAuthRealm", "Broker", "Amplify Central authentication Realm")
+	assertStringCmdFlag(t, rootCmd, "central.auth.clientId", "centralAuthClientId", "", "Client ID for the service account")
+	assertDurationCmdFlag(t, rootCmd, "central.auth.timeout", "centralAuthTimeout", 10*time.Second, "Timeout waiting for AxwayID response")
+	assertStringSliceCmdFlag(t, rootCmd, "central.ssl.nextProtos", "centralSslNextProtos", []string{}, "List of supported application level protocols, comma separated")
+	assertBooleanCmdFlag(t, rootCmd, "central.ssl.insecureSkipVerify", "centralSslInsecureSkipVerify", false, "Controls whether a client verifies the server's certificate chain and host name")
+	assertStringSliceCmdFlag(t, rootCmd, "central.ssl.cipherSuites", "centralSslCipherSuites", corecfg.TLSDefaultCipherSuitesStringSlice(), "List of supported cipher suites, comma separated")
+	assertStringCmdFlag(t, rootCmd, "central.ssl.minVersion", "centralSslMinVersion", corecfg.TLSDefaultMinVersionString(), "Minimum acceptable SSL/TLS protocol version")
+	assertStringCmdFlag(t, rootCmd, "central.ssl.maxVersion", "centralSslMaxVersion", "0", "Maximum acceptable SSL/TLS protocol version")
+
 	// Traceability Agent
 	rootCmd = NewRootCmd("Test", "TestRootCmd", nil, nil, corecfg.TraceabilityAgent)
 	assertStringCmdFlag(t, rootCmd, "central.deployment", "centralDeployment", "", "Amplify Central")       // assert to empty "" - set by region settings
@@ -228,6 +248,22 @@ func TestRootCmdConfigDefault(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rootCmd.RootCmd().SetErr(errBuf)
 	assert.Contains(t, "Test return error from init config handler, Discovery Agent", errBuf.String())
+
+	// Compliance
+	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", traceabilityInitConfigHandler, nil, corecfg.ComplianceAgent)
+	viper.AddConfigPath("./testdata")
+	err = rootCmd.Execute()
+
+	// should NOT be FileNotFound error
+	assert.NotNil(t, err, err.Error())
+	if err != nil {
+		_, ok := err.(viper.ConfigFileNotFoundError)
+		assert.False(t, ok, "Incorrect error returned: %s", err.Error())
+	}
+
+	errBuf = new(bytes.Buffer)
+	rootCmd.RootCmd().SetErr(errBuf)
+	assert.Contains(t, "Test return error from init config handler, Compliance Agent", errBuf.String())
 
 	// Traceability
 	rootCmd = NewRootCmd("test_with_non_defaults", "test_with_non_defaults", traceabilityInitConfigHandler, nil, corecfg.TraceabilityAgent)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -177,7 +177,7 @@ func NewCmd(rootCmd *cobra.Command, exeName, desc string, initConfigHandler Init
 	c.rootCmd.PreRunE = c.initialize
 
 	c.props = properties.NewPropertiesWithSecretResolver(c.rootCmd, c.secretResolver)
-	if agentType == config.TraceabilityAgent {
+	if agentType == config.TraceabilityAgent || agentType == config.ComplianceAgent {
 		properties.SetAliasKeyPrefix(c.agentName)
 	}
 
@@ -418,7 +418,7 @@ func (c *agentRootCommand) run(cmd *cobra.Command, args []string) (err error) {
 			// Setup logp to use beats logger.
 			// Setting up late here as log entries for agent/command initialization are not logged
 			// as the beats logger is initialized only when the beat instance is created.
-			if c.agentType == config.TraceabilityAgent {
+			if c.agentType == config.TraceabilityAgent || c.agentType == config.ComplianceAgent {
 				properties.SetAliasKeyPrefix(c.agentName)
 				log.SetIsLogP()
 			}

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -202,6 +202,8 @@ type CentralConfig interface {
 	GetWatchResourceFilters() []ResourceFilter
 	SetWatchResourceFilters([]ResourceFilter) error
 	GetCredentialConfig() CredentialConfig
+	SetManagedEnvironments([]string)
+	GetManagedEnvironments() []string
 }
 
 // CentralConfiguration - Structure to hold the central config
@@ -239,6 +241,7 @@ type CentralConfiguration struct {
 	CacheStoragePath          string                `config:"cacheStoragePath"`
 	CacheStorageInterval      time.Duration         `config:"cacheStorageInterval"`
 	CredentialConfig          CredentialConfig      `config:"credential"`
+	managedEnvironments       []string
 	JobExecutionTimeout       time.Duration
 	environmentID             string
 	teamID                    string
@@ -624,6 +627,14 @@ func (c *CentralConfiguration) SetWatchResourceFilters(filters []ResourceFilter)
 	}
 
 	return nil
+}
+
+func (c *CentralConfiguration) SetManagedEnvironments(envs []string) {
+	c.managedEnvironments = envs
+}
+
+func (c *CentralConfiguration) GetManagedEnvironments() []string {
+	return c.managedEnvironments
 }
 
 const (

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -86,6 +86,8 @@ const (
 	DiscoveryAgent AgentType = iota + 1
 	// TraceabilityAgent - Type definition for traceability agent
 	TraceabilityAgent
+	// ComplianceAgent - Type definition for compliance agent
+	ComplianceAgent
 	// GenericService - Type for a generic service
 	GenericService
 )
@@ -93,11 +95,13 @@ const (
 var agentTypeNamesMap = map[AgentType]string{
 	DiscoveryAgent:    "discoveryagent",
 	TraceabilityAgent: "traceabilityagent",
+	ComplianceAgent:   "compliance",
 }
 
 var agentTypeShortNamesMap = map[AgentType]string{
 	DiscoveryAgent:    "da",
 	TraceabilityAgent: "ta",
+	ComplianceAgent:   "ca",
 }
 
 func (agentType AgentType) ToString() string {
@@ -293,7 +297,7 @@ func NewTestCentralConfig(agentType AgentType) CentralConfig {
 	config.environmentID = "env-id"
 	config.Auth = newTestAuthConfig()
 	config.MigrationSettings = newTestMigrationConfig()
-	if agentType == TraceabilityAgent {
+	if agentType == TraceabilityAgent || agentType == ComplianceAgent {
 		config.APICDeployment = "deployment"
 	}
 	return config
@@ -963,5 +967,5 @@ func ParseCentralConfig(props properties.Properties, agentType AgentType) (Centr
 }
 
 func supportsTraceability(agentType AgentType) bool {
-	return agentType == TraceabilityAgent
+	return agentType == TraceabilityAgent || agentType == ComplianceAgent
 }

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -95,7 +95,7 @@ const (
 var agentTypeNamesMap = map[AgentType]string{
 	DiscoveryAgent:    "discoveryagent",
 	TraceabilityAgent: "traceabilityagent",
-	ComplianceAgent:   "compliance",
+	ComplianceAgent:   "complianceagent",
 }
 
 var agentTypeShortNamesMap = map[AgentType]string{

--- a/pkg/config/logconfig.go
+++ b/pkg/config/logconfig.go
@@ -40,12 +40,12 @@ func (l *LogConfiguration) setupLogger(agentType AgentType) error {
 		MaxSize(l.File.MaxSize).
 		MaxBackups(l.File.MaxBackups).
 		MaxAge(l.File.MaxAge).
-		Metrics(agentType == TraceabilityAgent && l.MetricFile.Enabled).
+		Metrics(agentType != DiscoveryAgent && l.MetricFile.Enabled).
 		MetricFilename(l.MetricFile.Name).
 		MaxMetricSize(l.MetricFile.MaxSize).
 		MaxMetricBackups(l.MetricFile.MaxBackups).
 		MaxMetricAge(l.MetricFile.MaxAge).
-		Usage(agentType == TraceabilityAgent && l.UsageFile.Enabled).
+		Usage(agentType != DiscoveryAgent && l.UsageFile.Enabled).
 		UsageFilename(l.UsageFile.Name).
 		MaxUsageSize(l.UsageFile.MaxSize).
 		MaxUsageBackups(l.UsageFile.MaxBackups).
@@ -149,7 +149,7 @@ func ParseAndSetupLogConfig(props properties.Properties, agentType AgentType) (L
 		},
 	}
 
-	if agentType == TraceabilityAgent {
+	if agentType == TraceabilityAgent || agentType == ComplianceAgent {
 		cfg.MetricFile = LogFileConfiguration{
 			Enabled:    props.BoolPropertyValue(pathLogMetricsFileEnabled),
 			Name:       props.StringPropertyValue(pathLogMetricsFileName),

--- a/pkg/config/logconfig_test.go
+++ b/pkg/config/logconfig_test.go
@@ -41,6 +41,10 @@ func TestDefaultLogConfig(t *testing.T) {
 			agentType: TraceabilityAgent,
 			logName:   "traceability_agent.log",
 		},
+		"default compliance agent configuration": {
+			agentType: ComplianceAgent,
+			logName:   "compliance_agent.log",
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -65,7 +69,7 @@ func TestDefaultLogConfig(t *testing.T) {
 			assert.Equal(t, defMaxAge, props.IntPropertyValue(pathLogFileMaxAge))
 			assert.Equal(t, defMaxFiles, props.IntPropertyValue(pathLogFileMaxBackups))
 
-			if tc.agentType == TraceabilityAgent {
+			if tc.agentType == TraceabilityAgent || tc.agentType == ComplianceAgent {
 				assert.Equal(t, defMetricName, props.StringPropertyValue(pathLogMetricsFileName))
 				assert.Equal(t, defMetricMaxSize, props.IntPropertyValue(pathLogMetricsFileMaxSize))
 				assert.Equal(t, defMetricMaxAge, props.IntPropertyValue(pathLogMetricsFileMaxAge))
@@ -126,6 +130,12 @@ func TestLogConfigValidations(t *testing.T) {
 		"success": {
 			metricsEnabled: true,
 			usageEnabled:   true,
+		},
+		"expect err, compliance agent, bad metric log size": {
+			agentType:      ComplianceAgent,
+			metricsEnabled: true,
+			errInfo:        "log.metricfile.rotateeverybytes",
+			metricMaxSize:  1,
 		},
 		"expect err, traceability agent, bad metric log size": {
 			agentType:      TraceabilityAgent,
@@ -220,7 +230,7 @@ func TestLogConfigValidations(t *testing.T) {
 			props.AddIntProperty(pathLogFileMaxBackups, tc.maxBackups, "")
 			props.AddIntProperty(pathLogFileMaxAge, tc.maxAge, "")
 
-			if tc.agentType == TraceabilityAgent && tc.metricsEnabled {
+			if tc.agentType != DiscoveryAgent && tc.metricsEnabled {
 				props.AddBoolProperty(pathLogMetricsFileEnabled, true, "")
 				props.AddStringProperty(pathLogMetricsFileName, "metrics.log", "")
 				props.AddIntProperty(pathLogMetricsFileMaxSize, tc.metricMaxSize, "")
@@ -228,7 +238,7 @@ func TestLogConfigValidations(t *testing.T) {
 				props.AddIntProperty(pathLogMetricsFileMaxAge, tc.metricMaxAge, "")
 			}
 
-			if tc.agentType == TraceabilityAgent && tc.usageEnabled {
+			if tc.agentType != DiscoveryAgent && tc.usageEnabled {
 				props.AddBoolProperty(pathLogUsageFileEnabled, true, "")
 				props.AddStringProperty(pathLogUsageFileName, "usage.log", "")
 				props.AddIntProperty(pathLogUsageFileMaxSize, tc.usageMaxSize, "")

--- a/pkg/customunit/handler.go
+++ b/pkg/customunit/handler.go
@@ -228,7 +228,7 @@ func (h *CustomUnitHandler) getServiceInstance(ar *management.AccessRequest) (*v
 }
 
 func (m *CustomUnitHandler) HandleMetricReporting(metricCollector metricCollector) {
-	if m.agentType != config.TraceabilityAgent {
+	if m.agentType == config.DiscoveryAgent {
 		return
 	}
 	if len(m.servicesConfigs) > 0 {

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -859,7 +859,7 @@ func (c *collector) handleGroupedMetric(logger log.FieldLogger, groupedMetricInt
 		logger := logger.WithField("status", k)
 		metric, ok := groupMap[k]
 		if !ok {
-			logger.Error("no metrics in map for status")
+			logger.Info("no metrics in map for status")
 			continue
 		}
 		c.setMetricsFromHistogram(metric, histo)

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -56,7 +56,6 @@ func getFutureTime() time.Time {
 }
 
 func createCentralCfg(url, env string) *config.CentralConfiguration {
-
 	cfg := config.NewCentralConfig(config.TraceabilityAgent).(*config.CentralConfiguration)
 	cfg.URL = url
 	cfg.SingleURL = url


### PR DESCRIPTION
- Handle ComplianceAgent similar to Traceability Agent, minus marketplace functionality
- Create watch topic and auto subscribe to managed environments as well as api service instances in managed environments
- Utilize agent resource manage to trigger compliance agent processing
- Update watch resource handler to generate group/kind map via watch resources and/or directly sent in group/kind array
- Do not trigger credential validator in non-discovery agents
- Compliance agent resource apply config handling