### PR TITLE
APIGOV-30306 - New region settings

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -152,11 +152,14 @@ func InitializeWithAgentFeatures(centralCfg config.CentralConfig, agentFeaturesC
 	}
 
 	singleEntryFilter := []string{
-		// Traceability host URL will be added by the traceability factory
 		centralCfg.GetURL(),
 		centralCfg.GetPlatformURL(),
 		centralCfg.GetAuthConfig().GetTokenURL(),
 		centralCfg.GetUsageReportingConfig().GetURL(),
+	}
+	if centralCfg.GetTraceabilityProtocol() == "https" {
+		// add the traceability host to the single entry filter for https only
+		singleEntryFilter = append(singleEntryFilter, fmt.Sprintf("https://%s", centralCfg.GetTraceabilityHost()))
 	}
 	api.SetConfigAgent(
 		GetUserAgent(),

--- a/pkg/agent/handler/agentresource.go
+++ b/pkg/agent/handler/agentresource.go
@@ -95,7 +95,7 @@ func (h *agentResourceHandler) handleTraceabilitySampling(resource *v1.ResourceI
 		return err
 	}
 
-	if !ta.Agentstate.Sampling.Enabled {
+	if ta.Agentstate.Sampling == nil || !ta.Agentstate.Sampling.Enabled {
 		return nil
 	}
 

--- a/pkg/apic/service.go
+++ b/pkg/apic/service.go
@@ -89,7 +89,7 @@ func (c *ServiceClient) PublishService(serviceBody *ServiceBody) (*management.AP
 		}
 	}
 	ri, _ := apiSvc.AsInstance()
-	c.caches.AddAPIService(ri)
+	err = c.caches.AddAPIService(ri)
 	if err != nil {
 		logger.WithError(err).Error("adding service to cache")
 	}

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -420,6 +420,14 @@ func (c *CentralConfiguration) GetTraceabilityProtocol() string {
 	if c.isRegionSet {
 		return c.RegionSettings.TraceabilityProtocol
 	}
+	if c.SingleURL != "" {
+		// Using single URL and not region, find the expected protocol
+		for _, region := range regionalSettingsMap {
+			if region.SingleURL == c.SingleURL {
+				return region.TraceabilityProtocol
+			}
+		}
+	}
 	return ""
 }
 

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -24,18 +24,21 @@ const (
 	US Region = iota + 1
 	EU
 	AP
+	EU2
 )
 
 var regionNamesMap = map[Region]string{
-	US: "US",
-	EU: "EU",
-	AP: "AP",
+	US:  "US",
+	EU:  "EU",
+	AP:  "AP",
+	EU2: "EU2",
 }
 
 var nameToRegionMap = map[string]Region{
-	"US": US,
-	"EU": EU,
-	"AP": AP,
+	"US":  US,
+	"EU":  EU,
+	"AP":  AP,
+	"EU2": EU2,
 }
 
 func (r Region) ToString() string {
@@ -43,38 +46,51 @@ func (r Region) ToString() string {
 }
 
 type regionalSettings struct {
-	SingleURL        string
-	CentralURL       string
-	AuthURL          string
-	PlatformURL      string
-	TraceabilityHost string
-	Deployment       string
+	SingleURL            string
+	CentralURL           string
+	AuthURL              string
+	PlatformURL          string
+	TraceabilityHost     string
+	TraceabilityProtocol string
+	Deployment           string
 }
 
 var regionalSettingsMap = map[Region]regionalSettings{
 	US: {
-		SingleURL:        "https://ingestion.platform.axway.com",
-		CentralURL:       "https://apicentral.axway.com",
-		AuthURL:          "https://login.axway.com/auth",
-		PlatformURL:      "https://platform.axway.com",
-		TraceabilityHost: "ingestion.datasearch.axway.com:5044",
-		Deployment:       "prod",
+		SingleURL:            "https://ingestion.platform.axway.com",
+		CentralURL:           "https://apicentral.axway.com",
+		AuthURL:              "https://login.axway.com/auth",
+		PlatformURL:          "https://platform.axway.com",
+		TraceabilityHost:     "ingestion.datasearch.axway.com:5044",
+		TraceabilityProtocol: "tcp",
+		Deployment:           "prod",
 	},
 	EU: {
-		SingleURL:        "https://ingestion-eu.platform.axway.com",
-		CentralURL:       "https://central.eu-fr.axway.com",
-		AuthURL:          "https://login.axway.com/auth",
-		PlatformURL:      "https://platform.axway.com",
-		TraceabilityHost: "ingestion.visibility.eu-fr.axway.com:5044",
-		Deployment:       "prod-eu",
+		SingleURL:            "https://ingestion-eu.platform.axway.com",
+		CentralURL:           "https://central.eu-fr.axway.com",
+		AuthURL:              "https://login.axway.com/auth",
+		PlatformURL:          "https://platform.axway.com",
+		TraceabilityHost:     "ingestion.visibility.eu-fr.axway.com:5044",
+		TraceabilityProtocol: "tcp",
+		Deployment:           "prod-eu",
 	},
 	AP: {
-		SingleURL:        "https://ingestion-ap-sg.platform.axway.com",
-		CentralURL:       "https://central.ap-sg.axway.com",
-		AuthURL:          "https://login.axway.com/auth",
-		PlatformURL:      "https://platform.axway.com",
-		TraceabilityHost: "ingestion.visibility.ap-sg.axway.com:5044",
-		Deployment:       "prod-ap",
+		SingleURL:            "https://ingestion-ap-sg.platform.axway.com",
+		CentralURL:           "https://central.ap-sg.axway.com",
+		AuthURL:              "https://login.axway.com/auth",
+		PlatformURL:          "https://platform.axway.com",
+		TraceabilityHost:     "ingestion.visibility.ap-sg.axway.com:5044",
+		TraceabilityProtocol: "tcp",
+		Deployment:           "prod-ap",
+	},
+	EU2: {
+		SingleURL:            "https://ingestion-eu-fr.platform.axway.com",
+		CentralURL:           "https://engage.eu-fr.axway.com",
+		AuthURL:              "https://login.eu-fr.axway.com/auth",
+		PlatformURL:          "https://platform.eu-fr.axway.com",
+		TraceabilityHost:     "ingestion.visibility.eu-fr.axway.com:443",
+		TraceabilityProtocol: "https",
+		Deployment:           "prod-eu2",
 	},
 }
 
@@ -164,6 +180,7 @@ type CentralConfig interface {
 	SetTeamID(teamID string)
 	GetURL() string
 	GetTraceabilityHost() string
+	GetTraceabilityProtocol() string
 	GetPlatformURL() string
 	GetAPIServerURL() string
 	GetEnvironmentURL() string
@@ -394,6 +411,14 @@ func (c *CentralConfiguration) GetURL() string {
 func (c *CentralConfiguration) GetTraceabilityHost() string {
 	if c.isRegionSet {
 		return c.RegionSettings.TraceabilityHost
+	}
+	return ""
+}
+
+// GetTraceabilityProtocol - Returns the central traceability protocol
+func (c *CentralConfiguration) GetTraceabilityProtocol() string {
+	if c.isRegionSet {
+		return c.RegionSettings.TraceabilityProtocol
 	}
 	return ""
 }

--- a/pkg/config/tlsconfig.go
+++ b/pkg/config/tlsconfig.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	log "github.com/Axway/agent-sdk/pkg/util/log"
 
@@ -238,7 +238,7 @@ func (c *TLSConfiguration) BuildTLSConfig() *tls.Config {
 		NextProtos:         c.NextProtos,
 	}
 	if c.RootCertificatePath != "" {
-		caCert, err := ioutil.ReadFile(c.RootCertificatePath)
+		caCert, err := os.ReadFile(c.RootCertificatePath)
 		if err == nil { // config validated in ValidateCfg
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(caCert)
@@ -353,7 +353,7 @@ func (c *TLSConfiguration) validateConfig() {
 		exception.Throw(errors.New("ssl.cipherSuites not valid in config"))
 	}
 	if c.RootCertificatePath != "" {
-		_, err := ioutil.ReadFile(c.RootCertificatePath)
+		_, err := os.ReadFile(c.RootCertificatePath)
 		if err != nil {
 			exception.Throw(errors.New("ssl.rootCertificatePath not valid in config"))
 		}

--- a/pkg/traceability/config.go
+++ b/pkg/traceability/config.go
@@ -78,7 +78,7 @@ func DefaultConfig() *Config {
 			Max:  60 * time.Second,
 		},
 		EscapeHTML: false,
-		Protocol:   "tcp",
+		Protocol:   "https",
 		Redaction:  redaction.DefaultConfig(),
 		Sampling:   sampling.DefaultConfig(),
 	}
@@ -96,8 +96,8 @@ func readConfig(cfg *common.Config, info beat.Info) (*Config, error) {
 		return nil, err
 	}
 
-	if agent.GetCentralConfig().GetTraceabilityHost() != "" {
-		outputConfig.Protocol = "tcp"
+	if agent.GetCentralConfig().GetTraceabilityHost() != "" && len(outputConfig.Hosts) == 0 {
+		outputConfig.Protocol = agent.GetCentralConfig().GetTraceabilityProtocol()
 		outputConfig.Hosts = []string{agent.GetCentralConfig().GetTraceabilityHost()}
 	}
 
@@ -148,6 +148,14 @@ func IsHTTPTransport() bool {
 		return false
 	}
 	return (outputConfig.Protocol == "https" || outputConfig.Protocol == "http")
+}
+
+// IsTCPTransport - Returns true if the protocol is set to tcp
+func IsTCPTransport() bool {
+	if outputConfig == nil {
+		return false
+	}
+	return outputConfig.Protocol == "tcp"
 }
 
 // GetMaxRetries - Returns the max retries configured for transport

--- a/pkg/traceability/httpclient.go
+++ b/pkg/traceability/httpclient.go
@@ -13,14 +13,14 @@ import (
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
-	"github.com/Axway/agent-sdk/pkg/util"
+	"github.com/Axway/agent-sdk/pkg/api"
+	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/outputs/outil"
 	"github.com/elastic/beats/v7/libbeat/outputs/transport"
 	"github.com/elastic/beats/v7/libbeat/publisher"
-	"github.com/google/uuid"
 )
 
 const (
@@ -54,6 +54,7 @@ type HTTPClientSettings struct {
 	Observer         outputs.Observer
 	Headers          map[string]string
 	UserAgent        string
+	IsSingleEntry    bool
 }
 
 // Connection struct
@@ -61,6 +62,7 @@ type Connection struct {
 	sync.Mutex
 	URL       string
 	http      *http.Client
+	api       api.Client
 	connected bool
 	encoder   bodyEncoder
 	userAgent string
@@ -84,16 +86,18 @@ func NewHTTPClient(s HTTPClientSettings) (*HTTPClient, error) {
 		WithPackage("sdk.traceability").
 		WithComponent("HTTPClient")
 
+	opts := []api.ClientOpt{api.WithTimeout(s.Timeout)}
+	if s.IsSingleEntry {
+		opts = append(opts, api.WithSingleURL())
+	}
+
+	tlsCfg := config.NewTLSConfig().(*config.TLSConfiguration)
+	tlsCfg.LoadFrom(s.TLS.ToConfig())
+
 	client := &HTTPClient{
 		Connection: Connection{
-			URL: s.URL,
-			http: &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: s.TLS.ToConfig(),
-					Proxy:           util.GetProxyURL(s.Proxy),
-				},
-				Timeout: s.Timeout,
-			},
+			URL:       s.URL,
+			api:       api.NewClient(tlsCfg, s.Proxy.String(), opts...),
 			encoder:   encoder,
 			userAgent: s.UserAgent,
 		},
@@ -219,67 +223,50 @@ func (conn *Connection) request(body interface{}, headers map[string]string, eve
 }
 
 func (conn *Connection) execRequest(url string, body io.Reader, headers map[string]string, eventTime time.Time) (int, []byte, error) {
-	req, err := http.NewRequest("POST", url, body)
-	if log.IsHTTPLogTraceEnabled() {
-		req = log.NewRequestWithTraceContext(uuid.New().String(), req)
+	data := make([]byte, 0)
+	if body != nil {
+		var err error
+		data, err = io.ReadAll(body)
+		if err != nil {
+			return 0, nil, err
+		}
 	}
 
+	err := conn.addHeaders(headers, eventTime)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	err = conn.addHeaders(&req.Header, body, eventTime)
-	if err != nil {
-		return 0, nil, err
+	req := api.Request{
+		Method:  http.MethodPost,
+		URL:     url,
+		Body:    data,
+		Headers: headers,
 	}
 
-	return conn.execHTTPRequest(req, headers)
+	return conn.execHTTPRequest(req)
 }
 
-func (conn *Connection) addHeaders(header *http.Header, body io.Reader, eventTime time.Time) error {
+func (conn *Connection) addHeaders(headers map[string]string, eventTime time.Time) error {
 	token, err := agent.GetCentralAuthToken()
 	if err != nil {
 		return err
 	}
 
-	header.Add("Authorization", "Bearer "+token)
-	header.Add("Capture-Org-ID", agent.GetCentralConfig().GetTenantID())
-	header.Add("User-Agent", conn.userAgent)
-	header.Add("Timestamp", strconv.FormatInt(eventTime.UTC().Unix(), 10))
+	headers["Authorization"] = "Bearer " + token
+	headers["Capture-Org-ID"] = agent.GetCentralConfig().GetTenantID()
+	headers["User-Agent"] = conn.userAgent
+	headers["Timestamp"] = strconv.FormatInt(eventTime.UTC().Unix(), 10)
 
-	if body != nil {
-		conn.encoder.AddHeader(header)
-	}
 	return nil
 }
 
-func (conn *Connection) execHTTPRequest(req *http.Request, headers map[string]string) (int, []byte, error) {
-	for key, value := range headers {
-		req.Header.Add(key, value)
-	}
-
-	resp, err := conn.http.Do(req)
+func (conn *Connection) execHTTPRequest(req api.Request) (int, []byte, error) {
+	resp, err := conn.api.Send(req)
 	if err != nil {
-		conn.updateConnected(false)
 		return 0, nil, err
 	}
-	defer closing(resp.Body)
-
-	status := resp.StatusCode
-	if status >= 300 {
-		conn.updateConnected(false)
-		return status, nil, fmt.Errorf("%v", resp.Status)
-	}
-	obj, err := io.ReadAll(resp.Body)
-	if err != nil {
-		conn.updateConnected(false)
-		return status, nil, err
-	}
-	return status, obj, nil
-}
-
-func closing(c io.Closer) {
-	c.Close()
+	return resp.Code, resp.Body, nil
 }
 
 func (client *HTTPClient) makeHTTPEvent(v *beat.Event) json.RawMessage {

--- a/pkg/traceability/traceability.go
+++ b/pkg/traceability/traceability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -44,7 +45,8 @@ var pathDataMutex sync.Mutex = sync.Mutex{}
 const (
 	minWindowSize             int = 1
 	defaultStartMaxWindowSize int = 10
-	defaultPort                   = 5044
+	defaultPort                   = "443"
+	tcpPort                       = "5044"
 	traceabilityStr               = "traceability"
 	HealthCheckEndpoint           = traceabilityStr
 )
@@ -145,6 +147,11 @@ func makeTraceabilityAgent(
 
 	logger.Trace("reading config")
 	traceCfg, err = readConfig(libbeatCfg, beat)
+	if err != nil {
+		agent.UpdateStatusWithPrevious(agent.AgentFailed, agent.AgentRunning, err.Error())
+		logger.WithError(err).Error("reading config")
+		return outputs.Fail(err)
+	}
 
 	defer func() {
 		if err != nil {
@@ -160,11 +167,7 @@ func makeTraceabilityAgent(
 		}
 	}()
 
-	if err != nil {
-		agent.UpdateStatusWithPrevious(agent.AgentFailed, agent.AgentRunning, err.Error())
-		logger.WithError(err).Error("reading config")
-		return outputs.Fail(err)
-	}
+	validateProtocolPort()
 	logger = logger.WithField("config", traceCfg)
 
 	if err := libbeatCfg.Merge(HostConfig{Hosts: traceCfg.Hosts, Protocol: traceCfg.Protocol}); err != nil {
@@ -174,53 +177,51 @@ func makeTraceabilityAgent(
 	}
 
 	hosts, err := outputs.ReadHostList(libbeatCfg)
-
 	if err != nil {
 		agent.UpdateStatusWithPrevious(agent.AgentFailed, agent.AgentRunning, err.Error())
 		logger.WithError(err).Error("reading hosts")
 		return outputs.Fail(err)
 	}
-	logger = logger.WithField("hosts", hosts)
+
+	logger = logger.WithField("hosts", hosts).WithField("config", traceCfg)
+	logger.Tracef("initializing traceability client")
 
 	var transportGroup outputs.Group
-	logger.Tracef("initializing traceability client")
 	isSingleEntry := agent.GetCentralConfig().GetSingleURL() != ""
-	if !isSingleEntry && IsHTTPTransport() {
-		transportGroup, err = makeHTTPClient(beat, observer, traceCfg, hosts, agent.GetUserAgent())
-	} else {
-		// For Single entry point register dialer factory for sni scheme and set the
-		// proxy url with sni scheme. When libbeat will register its dialer and sees
-		// proxy url with sni scheme, it will invoke the factory to construct the dialer
-		// The dialer will be invoked as proxy dialer in the libbeat dialer chain
-		// (proxy dialer, stat dialer, tls dialer).
-		if isSingleEntry {
-			if IsHTTPTransport() {
-				traceCfg.Protocol = "tcp"
-				logger.Warn("switching to tcp protocol instead of http because agent will use single entry endpoint")
+
+	// For Single entry point register dialer factory for sni scheme and set the
+	// proxy url with sni scheme. When libbeat will register its dialer and sees
+	// proxy url with sni scheme, it will invoke the factory to construct the dialer
+	// The dialer will be invoked as proxy dialer in the libbeat dialer chain
+	// (proxy dialer, stat dialer, tls dialer).
+	if isSingleEntry {
+		// Register dialer factory with sni scheme for single entry point
+		proxy.RegisterDialerType("sni", ingestionSingleEntryDialer)
+		// If real proxy configured(not the sni proxy set here), validate the scheme
+		// since libbeats proxy dialer will not be invoked.
+		if traceCfg.Proxy.URL != "" {
+			proxCfg := &transport.ProxyConfig{
+				URL:          traceCfg.Proxy.URL,
+				LocalResolve: traceCfg.Proxy.LocalResolve,
 			}
-			// Register dialer factory with sni scheme for single entry point
-			proxy.RegisterDialerType("sni", ingestionSingleEntryDialer)
-			// If real proxy configured(not the sni proxy set here), validate the scheme
-			// since libbeats proxy dialer will not be invoked.
-			if traceCfg.Proxy.URL != "" {
-				proxCfg := &transport.ProxyConfig{
-					URL:          traceCfg.Proxy.URL,
-					LocalResolve: traceCfg.Proxy.LocalResolve,
-				}
-				err := proxCfg.Validate()
-				if err != nil {
-					logger.WithError(err).Error("validating proxy config")
-					outputs.Fail(err)
-				}
+			err := proxCfg.Validate()
+			if err != nil {
+				logger.WithError(err).Error("validating proxy config")
+				outputs.Fail(err)
 			}
-			// Replace the proxy URL to sni by setting the environment variable
-			// Libbeat parses the yaml file and replaces the value from yaml
-			// with overridden environment variable.
-			// Set the sni host to the ingestion service host to allow the
-			// single entry dialer to receive the target address
-			os.Setenv("TRACEABILITY_PROXYURL", "sni://"+traceCfg.Hosts[0])
 		}
+		// Replace the proxy URL to sni by setting the environment variable
+		// Libbeat parses the yaml file and replaces the value from yaml
+		// with overridden environment variable.
+		// Set the sni host to the ingestion service host to allow the
+		// single entry dialer to receive the target address
+		os.Setenv("TRACEABILITY_PROXYURL", "sni://"+traceCfg.Hosts[0])
+	}
+
+	if IsTCPTransport() {
 		transportGroup, err = makeLogstashClient(indexManager, beat, observer, libbeatCfg)
+	} else {
+		transportGroup, err = makeHTTPClient(beat, observer, traceCfg, hosts, agent.GetUserAgent(), isSingleEntry)
 	}
 
 	if err != nil {
@@ -244,6 +245,23 @@ func makeTraceabilityAgent(
 	}
 	traceabilityGroup.Clients = clients
 	return traceabilityGroup, nil
+}
+
+// validateProtocolPort - validate the protocol matches the port
+func validateProtocolPort() {
+	isSingleEntry := agent.GetCentralConfig().GetSingleURL() != ""
+	if isSingleEntry {
+		// get the expected protocol for single entry host
+		traceCfg.Protocol = agent.GetCentralConfig().GetTraceabilityProtocol()
+	}
+
+	// Validate that the port matches the
+	h, p := splitHostPort()
+	if p == tcpPort && IsHTTPTransport() {
+		traceCfg.Hosts[0] = fmt.Sprintf("%s:%s", h, defaultPort)
+	} else if p == defaultPort && IsTCPTransport() {
+		traceCfg.Hosts[0] = fmt.Sprintf("%s:%s", h, tcpPort)
+	}
 }
 
 func makeLogstashClient(indexManager outputs.IndexManager,
@@ -290,7 +308,7 @@ func ingestionSingleEntryDialer(proxyURL *url.URL, parentDialer proxy.Dialer) (p
 	return dialer, nil
 }
 
-func makeHTTPClient(beat beat.Info, observer outputs.Observer, traceCfg *Config, hosts []string, userAgent string) (outputs.Group, error) {
+func makeHTTPClient(beat beat.Info, observer outputs.Observer, traceCfg *Config, hosts []string, userAgent string, isSingleEntry bool) (outputs.Group, error) {
 	tls, err := tlscommon.LoadTLSConfig(traceCfg.TLS)
 	if err != nil {
 		agent.UpdateStatusWithPrevious(agent.AgentFailed, agent.AgentRunning, err.Error())
@@ -317,6 +335,7 @@ func makeHTTPClient(beat beat.Info, observer outputs.Observer, traceCfg *Config,
 			CompressionLevel: traceCfg.CompressionLevel,
 			Observer:         observer,
 			UserAgent:        userAgent,
+			IsSingleEntry:    isSingleEntry,
 		})
 
 		if err != nil {
@@ -458,4 +477,13 @@ func registerHealthCheckers(config *Config) error {
 		return err
 	}
 	return nil
+}
+
+func splitHostPort() (string, string) {
+	// Split the host and port from the URL
+	host, port, err := net.SplitHostPort(traceCfg.Hosts[0])
+	if err != nil {
+		return "", fmt.Sprint(defaultPort)
+	}
+	return host, port
 }

--- a/pkg/traceability/traceability_test.go
+++ b/pkg/traceability/traceability_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -118,7 +117,7 @@ func newMockHTTPServer() *mockHTTPServer {
 				if contentEncoding != nil && contentEncoding[0] == "gzip" {
 					body, _ = mockServer.decompressGzipContent(req.Body)
 				} else {
-					body, _ = ioutil.ReadAll(req.Body)
+					body, _ = io.ReadAll(req.Body)
 				}
 				json.Unmarshal(body, &mockServer.serverMessages)
 				resp.Write([]byte("ok"))
@@ -153,7 +152,7 @@ func (s *mockHTTPServer) decompressGzipContent(gzipBufferReader io.Reader) ([]by
 	if err != nil {
 		return nil, err
 	}
-	plainContent, err := ioutil.ReadAll(gzipReader)
+	plainContent, err := io.ReadAll(gzipReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/dialer.go
+++ b/pkg/util/dialer.go
@@ -62,9 +62,6 @@ func NewDialer(proxyURL *url.URL, singleEntryHostMap map[string]string) Dialer {
 // Dial- manages the connections to proxy and single entry point for tcp transports
 func (d *dialer) Dial(network string, addr string) (net.Conn, error) {
 	conn, err := d.DialContext(context.Background(), network, addr)
-	if err == nil && len(d.singleEntryHostMap) > 0 && addr != conn.RemoteAddr().String() {
-		log.Tracef("routing the traffic for %s via %s", addr, conn.RemoteAddr().String())
-	}
 	return conn, err
 }
 
@@ -101,6 +98,9 @@ func (d *dialer) DialContext(ctx context.Context, network string, addr string) (
 				return nil, err
 			}
 		}
+	}
+	if originalAddr != addr {
+		log.Tracef("routing the traffic for %s via %s", originalAddr, addr)
 	}
 	return conn, nil
 }


### PR DESCRIPTION
- Added new region defaults (Note: single entry may still need to be updated)
- Utilizing the region settings default the trace host/protocol appropriately
- When region setting is not on but single entry is use the expected host/protocol per region
- Update the port if there is a protocol/port mismatch
- Update traceability http client to use the sdk api client package