### PR TITLE
APIGOV-30479 - update apigee spec to add service endpoint to allow data residency

### DIFF
--- a/pkg/apic/apiserver/models/catalog/v1/model_application_profile_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_application_profile_status_reasons.go
@@ -21,7 +21,7 @@ type ApplicationProfileStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1.ApplicationProfile)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1/model_document_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_document_status_error.go
@@ -21,7 +21,7 @@ type DocumentStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time              `json:"timestamp"`
 	Meta      map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1/model_document_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_document_status_success.go
@@ -19,7 +19,7 @@ import (
 // DocumentStatusSuccess struct for DocumentStatusSuccess
 type DocumentStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                 `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_error.go
@@ -21,7 +21,7 @@ type ProductReleaseStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                       `json:"timestamp"`
 	Meta      ProductReleaseStatusPendingMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_pending.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_pending.go
@@ -19,7 +19,7 @@ import (
 // ProductReleaseStatusPending struct for ProductReleaseStatusPending
 type ProductReleaseStatusPending struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// Reason for being in Pending.
 	Detail string                          `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_product_release_status_success.go
@@ -19,7 +19,7 @@ import (
 // ProductReleaseStatusSuccess struct for ProductReleaseStatusSuccess
 type ProductReleaseStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                          `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1/model_product_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_product_status_reasons.go
@@ -21,7 +21,7 @@ type ProductStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time         `json:"timestamp"`
 	Meta      ProductStatusMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1/model_quota_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_quota_status_error.go
@@ -21,7 +21,7 @@ type QuotaStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1/model_quota_status_pending.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_quota_status_pending.go
@@ -21,7 +21,7 @@ type QuotaStatusPending struct {
 	Type string `json:"type"`
 	// Details of the Pending status.
 	Detail string `json:"detail"`
-	// Time when the resource moved to Pending.
+	// Time when the resource moved to Pending in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1/model_quota_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1/model_quota_status_success.go
@@ -19,7 +19,7 @@ import (
 // QuotaStatusSuccess struct for QuotaStatusSuccess
 type QuotaStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// Details of the result.
 	Detail string                 `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_application_profile_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_application_profile_status_reasons.go
@@ -21,7 +21,7 @@ type ApplicationProfileStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.ApplicationProfile)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_release_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_release_status_reasons.go
@@ -21,7 +21,7 @@ type AssetReleaseStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time              `json:"timestamp"`
 	Meta      AssetReleaseStatusMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_request_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_request_status_reasons.go
@@ -21,7 +21,7 @@ type AssetRequestStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.AssetRequest)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_asset_status_reasons.go
@@ -21,7 +21,7 @@ type AssetStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time       `json:"timestamp"`
 	Meta      AssetStatusMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_credential_policies_expiry.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_credential_policies_expiry.go
@@ -18,6 +18,6 @@ import (
 
 // CredentialPoliciesExpiry  (catalog.v1alpha1.Credential)
 type CredentialPoliciesExpiry struct {
-	// Time when the Credential is set to be expired.
+	// Time when the Credential is set to be expired in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_credential_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_credential_status_reasons.go
@@ -22,7 +22,7 @@ type CredentialStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the type.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.Credential)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_document_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_document_status_error.go
@@ -21,7 +21,7 @@ type DocumentStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time              `json:"timestamp"`
 	Meta      map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_document_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_document_status_success.go
@@ -19,7 +19,7 @@ import (
 // DocumentStatusSuccess struct for DocumentStatusSuccess
 type DocumentStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                 `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_job_spec_when.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_job_spec_when.go
@@ -18,6 +18,6 @@ import (
 
 // ProductPlanJobSpecWhen Describes when to execute the action. (catalog.v1alpha1.ProductPlanJob)
 type ProductPlanJobSpecWhen struct {
-	// Time when the migration should execute.
+	// Time when the migration should execute in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_job_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_job_status_reasons.go
@@ -21,7 +21,7 @@ type ProductPlanJobStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.ProductPlanJob)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_plan_status_reasons.go
@@ -21,7 +21,7 @@ type ProductPlanStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.ProductPlan)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_error.go
@@ -21,7 +21,7 @@ type ProductReleaseStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                       `json:"timestamp"`
 	Meta      ProductReleaseStatusPendingMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_pending.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_pending.go
@@ -19,7 +19,7 @@ import (
 // ProductReleaseStatusPending struct for ProductReleaseStatusPending
 type ProductReleaseStatusPending struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// Reason for being in Pending.
 	Detail string                          `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_release_status_success.go
@@ -19,7 +19,7 @@ import (
 // ProductReleaseStatusSuccess struct for ProductReleaseStatusSuccess
 type ProductReleaseStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                          `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_product_status_reasons.go
@@ -21,7 +21,7 @@ type ProductStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time         `json:"timestamp"`
 	Meta      ProductStatusMeta `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_published_product_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_published_product_status_reasons.go
@@ -21,7 +21,7 @@ type PublishedProductStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.PublishedProduct)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_error.go
@@ -21,7 +21,7 @@ type QuotaStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_pending.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_pending.go
@@ -21,7 +21,7 @@ type QuotaStatusPending struct {
 	Type string `json:"type"`
 	// Details of the Pending status.
 	Detail string `json:"detail"`
-	// Time when the resource moved to Pending.
+	// Time when the resource moved to Pending in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_quota_status_success.go
@@ -19,7 +19,7 @@ import (
 // QuotaStatusSuccess struct for QuotaStatusSuccess
 type QuotaStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// Details of the result.
 	Detail string                 `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_error.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_error.go
@@ -21,7 +21,7 @@ type ReleaseTagStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_pending.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_pending.go
@@ -19,7 +19,7 @@ import (
 // ReleaseTagStatusPending struct for ReleaseTagStatusPending
 type ReleaseTagStatusPending struct {
 	Type string `json:"type"`
-	// Time when the change occurred.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the pending status
 	Detail string                            `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_success.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_release_tag_status_success.go
@@ -19,7 +19,7 @@ import (
 // ReleaseTagStatusSuccess struct for ReleaseTagStatusSuccess
 type ReleaseTagStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occurred.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                      `json:"detail"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_custom.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_custom.go
@@ -23,9 +23,9 @@ type SubscriptionInvoiceBillingPaymentTypeCustom struct {
 	Id string `json:"id,omitempty"`
 	// Custom Invoice number.
 	Number string `json:"number,omitempty"`
-	// Due date of the invoice.
+	// Due date of the invoice in ISO 8601 format with numeric timezone offset.
 	DueDate time.Time `json:"dueDate,omitempty"`
-	// Issue date of the invoice.
+	// Issue date of the invoice in ISO 8601 format with numeric timezone offset.
 	IssueDate time.Time                                         `json:"issueDate,omitempty"`
 	Amount    SubscriptionInvoiceBillingPaymentTypeCustomAmount `json:"amount,omitempty"`
 	// Link where the payment can be done.

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_my_fatoorah.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_my_fatoorah.go
@@ -23,9 +23,9 @@ type SubscriptionInvoiceBillingPaymentTypeMyFatoorah struct {
 	Id string `json:"id,omitempty"`
 	// Custom Invoice number.
 	Number string `json:"number,omitempty"`
-	// Due date of the invoice.
+	// Due date of the invoice in ISO 8601 format with numeric timezone offset.
 	DueDate time.Time `json:"dueDate,omitempty"`
-	// Issue date of the invoice.
+	// Issue date of the invoice in ISO 8601 format with numeric timezone offset.
 	IssueDate time.Time                                             `json:"issueDate,omitempty"`
 	Amount    SubscriptionInvoiceBillingPaymentTypeMyFatoorahAmount `json:"amount,omitempty"`
 	// Link where the payment can be done.

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_stripe.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_billing_payment_type_stripe.go
@@ -23,9 +23,9 @@ type SubscriptionInvoiceBillingPaymentTypeStripe struct {
 	Id string `json:"id,omitempty"`
 	// Stripe Invoice number.
 	Number string `json:"number,omitempty"`
-	// Due date of the invoice.
+	// Due date of the invoice in ISO 8601 format with numeric timezone offset.
 	DueDate time.Time `json:"dueDate,omitempty"`
-	// Issue date of the invoice.
+	// Issue date of the invoice in ISO 8601 format with numeric timezone offset.
 	IssueDate time.Time                                         `json:"issueDate,omitempty"`
 	Amount    SubscriptionInvoiceBillingPaymentTypeStripeAmount `json:"amount,omitempty"`
 	// Link where the payment can be done.

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_cost_plan_items.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_cost_plan_items.go
@@ -24,9 +24,9 @@ type SubscriptionInvoiceSpecCostPlanItems struct {
 	Units int32 `json:"units,omitempty"`
 	// The cost of a billed unit for the quota or specific quota interval.
 	ItemCost float64 `json:"itemCost,omitempty"`
-	// Start time of the invoice item.
+	// Start time of the invoice item in ISO 8601 format with numeric timezone offset.
 	From time.Time `json:"from,omitempty"`
-	// End time of the invoice item.
+	// End time of the invoice item in ISO 8601 format with numeric timezone offset.
 	To time.Time `json:"to,omitempty"`
 	// The description of the invoice item for the quota.
 	Description string `json:"description,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_intervals.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_intervals.go
@@ -18,7 +18,7 @@ import (
 
 // SubscriptionInvoiceSpecIntervals  (catalog.v1alpha1.SubscriptionInvoice)
 type SubscriptionInvoiceSpecIntervals struct {
-	// The start of the interval.
+	// The start of the interval in ISO 8601 format with numeric timezone offset.
 	From time.Time `json:"from"`
 	// Number of consumed units in the interval.
 	Units int32 `json:"units"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_period.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_spec_period.go
@@ -18,8 +18,8 @@ import (
 
 // SubscriptionInvoiceSpecPeriod Describes the period for which the invoice was created. Initial invoice for a subscription does not contain a period. (catalog.v1alpha1.SubscriptionInvoice)
 type SubscriptionInvoiceSpecPeriod struct {
-	// Start time of the invoice.
+	// Start time of the invoice in ISO 8601 format with numeric timezone offset.
 	From time.Time `json:"from"`
-	// End time of the invoice.
+	// End time of the invoice in ISO 8601 format with numeric timezone offset.
 	To time.Time `json:"to"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_invoice_status_reasons.go
@@ -21,7 +21,7 @@ type SubscriptionInvoiceStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.SubscriptionInvoice)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_job_spec_when.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_job_spec_when.go
@@ -18,6 +18,6 @@ import (
 
 // SubscriptionJobSpecWhen Describes when to execute the action. (catalog.v1alpha1.SubscriptionJob)
 type SubscriptionJobSpecWhen struct {
-	// Time when the migration should execute.
+	// Time when the migration should execute in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_job_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_job_status_reasons.go
@@ -21,7 +21,7 @@ type SubscriptionJobStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.SubscriptionJob)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_state_when.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_state_when.go
@@ -18,6 +18,6 @@ import (
 
 // SubscriptionStateWhen Describes when to execute the scheduled action or when it was executed. Only valid for scheduled actions. (catalog.v1alpha1.Subscription)
 type SubscriptionStateWhen struct {
-	// Time when the scheduled action should execute or was executed.
+	// Time when the scheduled action should execute or was executed in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_status_reasons.go
+++ b/pkg/apic/apiserver/models/catalog/v1alpha1/model_subscription_status_reasons.go
@@ -21,7 +21,7 @@ type SubscriptionStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (catalog.v1alpha1.Subscription)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/model_component_spec_latest.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/model_component_spec_latest.go
@@ -20,8 +20,8 @@ import (
 type ComponentSpecLatest struct {
 	// A version for the component
 	Version string `json:"version"`
-	// The date this version was released
+	// The date this version was released in ISO 8601 format with numeric timezone offset.
 	ReleaseDate time.Time `json:"releaseDate"`
-	// The date that support for this version will cease
+	// The date that support for this version will cease in ISO 8601 format with numeric timezone offset.
 	EndOfSupportDate time.Time `json:"endOfSupportDate,omitempty"`
 }

--- a/pkg/apic/apiserver/models/definitions/v1alpha1/model_component_spec_supported.go
+++ b/pkg/apic/apiserver/models/definitions/v1alpha1/model_component_spec_supported.go
@@ -20,8 +20,8 @@ import (
 type ComponentSpecSupported struct {
 	// A version for the component
 	Version string `json:"version"`
-	// The date this version was released
+	// The date this version was released in ISO 8601 format with numeric timezone offset
 	ReleaseDate time.Time `json:"releaseDate"`
-	// The date that support for this version will cease
+	// The date that support for this version will cease in ISO 8601 format with numeric timezone offset
 	EndOfSupportDate time.Time `json:"endOfSupportDate,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1/model_api_spec_linting_job_state.go
+++ b/pkg/apic/apiserver/models/management/v1/model_api_spec_linting_job_state.go
@@ -22,6 +22,6 @@ type ApiSpecLintingJobState struct {
 	Name string `json:"name"`
 	// Details of the state.
 	Message string `json:"message,omitempty"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1/model_managed_application_profile_status_reasons.go
+++ b/pkg/apic/apiserver/models/management/v1/model_managed_application_profile_status_reasons.go
@@ -21,7 +21,7 @@ type ManagedApplicationProfileStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (management.v1.ManagedApplicationProfile)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_access_request_status_reasons.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_access_request_status_reasons.go
@@ -21,7 +21,7 @@ type AccessRequestStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (management.v1alpha1.AccessRequest)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_instance_compliance_runtime_status_result.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_instance_compliance_runtime_status_result.go
@@ -18,7 +18,7 @@ import (
 
 // ApiServiceInstanceComplianceRuntimeStatusResult APIServiceInstance runtime results.
 type ApiServiceInstanceComplianceRuntimeStatusResult struct {
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 	// Grade result from the results summary.
 	Grade string `json:"grade,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_instance_source_runtime_status_result.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_instance_source_runtime_status_result.go
@@ -18,7 +18,7 @@ import (
 
 // ApiServiceInstanceSourceRuntimeStatusResult APIServiceInstance runtime results.
 type ApiServiceInstanceSourceRuntimeStatusResult struct {
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 	// The average risk score in the runtime compliance result.
 	// GENERATE: The following code has been modified after code generation

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_status_error.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_api_service_status_error.go
@@ -21,7 +21,7 @@ type ApiServiceStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the change occurred.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_api_spec_linting_job_state.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_api_spec_linting_job_state.go
@@ -22,6 +22,6 @@ type ApiSpecLintingJobState struct {
 	Name string `json:"name"`
 	// Details of the state.
 	Message string `json:"message,omitempty"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_compliance_agent_status.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_compliance_agent_status.go
@@ -27,7 +27,7 @@ type ComplianceAgentStatus struct {
 	PreviousState string `json:"previousState,omitempty"`
 	// A way to communicate details about the current status by the agent
 	Message string `json:"message,omitempty"`
-	// The last updated event timestamp provided by the agent
+	// The last updated event timestamp provided by the agent in ISO 8601 format with numeric timezone offset
 	LastActivityTime time.Time `json:"lastActivityTime,omitempty"`
 	// Version name for the SDK revision.
 	SdkVersion string `json:"sdkVersion,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_credential_policies_expiry.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_credential_policies_expiry.go
@@ -18,6 +18,6 @@ import (
 
 // CredentialPoliciesExpiry  (management.v1alpha1.Credential)
 type CredentialPoliciesExpiry struct {
-	// Time when the Credential is set to be expired.
+	// Time when the Credential is set to be expired in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_credential_status_reasons.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_credential_status_reasons.go
@@ -21,7 +21,7 @@ type CredentialStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (management.v1alpha1.Credential)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_secret_status_error.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_secret_status_error.go
@@ -21,7 +21,7 @@ type DataplaneSecretStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time              `json:"timestamp"`
 	Meta      map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_secret_status_success.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_secret_status_success.go
@@ -19,7 +19,7 @@ import (
 // DataplaneSecretStatusSuccess struct for DataplaneSecretStatusSuccess
 type DataplaneSecretStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occured.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail string                 `json:"detail"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_apigee.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_apigee.go
@@ -12,8 +12,8 @@ package management
 // DataplaneSpecApigee The configuration common to all Apigee agents that use this dataplane
 type DataplaneSpecApigee struct {
 	Type string `json:"type"`
-	// The data residency service endpoint is a base URL that specifies the network address of an API service
-	DataResidency string `json:"dataResidency"`
+	// The service endpoint is a base URL that specifies the network address of an API service
+	ServiceEndpoint string `json:"serviceEndpoint"`
 	// The Project ID on GCP that Apigee is configured in
 	ProjectId string `json:"projectId"`
 	// The Developer that will own all Apigee Applications created by the agent

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_apigee.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_dataplane_spec_apigee.go
@@ -12,6 +12,8 @@ package management
 // DataplaneSpecApigee The configuration common to all Apigee agents that use this dataplane
 type DataplaneSpecApigee struct {
 	Type string `json:"type"`
+	// The data residency service endpoint is a base URL that specifies the network address of an API service
+	DataResidency string `json:"dataResidency"`
 	// The Project ID on GCP that Apigee is configured in
 	ProjectId string `json:"projectId"`
 	// The Developer that will own all Apigee Applications created by the agent

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_discovery_agent_status.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_discovery_agent_status.go
@@ -27,7 +27,7 @@ type DiscoveryAgentStatus struct {
 	PreviousState string `json:"previousState,omitempty"`
 	// A way to communicate details about the current status by the agent
 	Message string `json:"message,omitempty"`
-	// The last updated event timestamp provided by the agent
+	// The last updated event timestamp provided by the agent in ISO 8601 format with numeric timezone offset
 	LastActivityTime time.Time `json:"lastActivityTime,omitempty"`
 	// Version name for the SDK revision.
 	SdkVersion string `json:"sdkVersion,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_error.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_error.go
@@ -21,7 +21,7 @@ type IdentityProviderStatusError struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time                         `json:"timestamp"`
 	Meta      map[string]map[string]interface{} `json:"meta,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_pending.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_pending.go
@@ -19,7 +19,7 @@ import (
 // IdentityProviderStatusPending struct for IdentityProviderStatusPending
 type IdentityProviderStatusPending struct {
 	Type string `json:"type"`
-	// Time when the change occurred.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the pending status
 	Detail string                            `json:"detail"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_success.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_identity_provider_status_success.go
@@ -19,7 +19,7 @@ import (
 // IdentityProviderStatusSuccess struct for IdentityProviderStatusSuccess
 type IdentityProviderStatusSuccess struct {
 	Type string `json:"type"`
-	// Time when the change occurred.
+	// Time when the change occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	// message of the result
 	Detail map[string]interface{} `json:"detail"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_managed_application_profile_status_reasons.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_managed_application_profile_status_reasons.go
@@ -21,7 +21,7 @@ type ManagedApplicationProfileStatusReasons struct {
 	Type string `json:"type"`
 	// Details of the error.
 	Detail string `json:"detail"`
-	// Time when the update occurred.
+	// Time when the update occurred in ISO 8601 format with numeric timezone offset.
 	Timestamp time.Time `json:"timestamp"`
 	//  (management.v1alpha1.ManagedApplicationProfile)
 	Meta map[string]map[string]interface{} `json:"meta,omitempty"`

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_traceability_agent_agentstate_sampling.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_traceability_agent_agentstate_sampling.go
@@ -20,10 +20,10 @@ import (
 type TraceabilityAgentAgentstateSampling struct {
 	// When sampling is approved by the controller, enabled will be set to true then automatically set to false after the time period
 	Enabled bool `json:"enabled,omitempty"`
-	// The time that the agent will stop sampling
+	// The time that the agent will stop sampling in ISO 8601 format with numeric timezone offset
 	EndTime time.Time `json:"endTime,omitempty"`
 	// The upper limit of transactions, in a 1 minute period, the agent may sample
 	Limit int32 `json:"limit,omitempty"`
-	// The time after which the sampling can be triggered again
+	// The time after which the sampling can be triggered again in ISO 8601 format with numeric timezone offset
 	DisabledUntil time.Time `json:"disabledUntil,omitempty"`
 }

--- a/pkg/apic/apiserver/models/management/v1alpha1/model_traceability_agent_status.go
+++ b/pkg/apic/apiserver/models/management/v1alpha1/model_traceability_agent_status.go
@@ -27,7 +27,7 @@ type TraceabilityAgentStatus struct {
 	PreviousState string `json:"previousState,omitempty"`
 	// A way to communicate details about the current status by the agent
 	Message string `json:"message,omitempty"`
-	// The last updated event timestamp provided by the agent
+	// The last updated event timestamp provided by the agent in ISO 8601 format with numeric timezone offset
 	LastActivityTime time.Time `json:"lastActivityTime,omitempty"`
 	// Version name for the SDK revision.
 	SdkVersion string `json:"sdkVersion,omitempty"`


### PR DESCRIPTION
Currently ApigeeX, service endpoint is hardcoded to apigee.googleapis.com.  In this case, there is no data residency.  Data residency comes into play when the agent needs to point to a certain control plane/region.  This update will add a service endpoint to the config which will allow the customer to edit this service endpoint for data residency. For example eu-apigee.googleapis.com, fr-apigee.googleapis.com.

Update model with ServiceEndpoint