### PR TITLE
INT - updates for endpoint sampling

### DIFF
--- a/pkg/traceability/sampling/globalsampling.go
+++ b/pkg/traceability/sampling/globalsampling.go
@@ -60,7 +60,7 @@ func GetGlobalSampling() *sample {
 			counterResetStopCh: make(chan struct{}),
 			endpointsSampling: endpointsSampling{
 				enabled:       false,
-				endpointsInfo: make(map[string]*endpointSamplingInfo, 0),
+				endpointsInfo: make(map[string]bool, 0),
 				endpointsLock: sync.Mutex{},
 			},
 		}
@@ -118,7 +118,7 @@ func SetupSampling(cfg Sampling, offlineMode bool, apicDeployment string) error 
 			counterResetStopCh: make(chan struct{}),
 			endpointsSampling: endpointsSampling{
 				enabled:       false,
-				endpointsInfo: make(map[string]*endpointSamplingInfo, 0),
+				endpointsInfo: make(map[string]bool, 0),
 				endpointsLock: sync.Mutex{},
 			},
 		}

--- a/pkg/traceability/sampling/sampling_test.go
+++ b/pkg/traceability/sampling/sampling_test.go
@@ -132,150 +132,161 @@ func TestShouldSample(t *testing.T) {
 		successCount int
 	}
 	testCases := []struct {
-		name                   string
-		apiTransactions        map[string]transactionCount
-		expectedSampled        int
-		config                 Sampling
-		subIDs                 map[string]string
-		limit                  int32
-		duration               time.Duration
-		counterResetPeriod     time.Duration
-		endpointsInfo          map[string]management.TraceabilityAgentAgentstateSamplingEndpoints
-		additionalEndpontsInfo map[string]management.TraceabilityAgentAgentstateSamplingEndpoints
+		skip                     bool
+		name                     string
+		globalSampling           bool
+		apiTransactions          map[string]transactionCount
+		maxSampled               int
+		config                   Sampling
+		subIDs                   map[string]string
+		limit                    int32
+		duration                 time.Duration
+		counterResetPeriod       time.Duration
+		endpointsInfo            map[string]management.TraceabilityAgentAgentstateSamplingEndpoints
+		additionalEndpointsInfo  map[string]management.TraceabilityAgentAgentstateSamplingEndpoints
+		expectedEndpointsSampled map[string]struct{}
 	}{
 		{
-			name: "Limit sampling to 10 per period",
+			skip:           false,
+			name:           "Limit sampling to 10 per period",
+			globalSampling: true,
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 			},
-			expectedSampled:    50,
+			maxSampled:         60,
 			limit:              10,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 		},
 		{
-			name: "Limit sampling to 100 per period",
+			skip:           false,
+			name:           "Limit sampling to 100 per period",
+			globalSampling: true,
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 			},
-			expectedSampled:    500,
+			maxSampled:         600,
 			limit:              100,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 		},
 		{
-			name: "Limit sampling to 1000 per period",
+			skip:           false,
+			name:           "Limit sampling to 1000 per period",
+			globalSampling: true,
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 			},
-			expectedSampled:    5000,
+			maxSampled:         6000,
 			limit:              1000,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 		},
 		{
-			name: "Limit sampling to 0",
+			skip:           false,
+			name:           "Limit sampling to 0",
+			globalSampling: true,
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 			},
-			expectedSampled:    0,
+			maxSampled:         0,
 			limit:              0,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 		},
 		{
+			skip: false,
 			name: "Endpoints sampling enabled",
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 				"id2": {successCount: 1000},
+				"id3": {successCount: 1000},
+				"id4": {successCount: 1000},
 			},
-			expectedSampled:    500,
+			maxSampled:         600,
 			limit:              100,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 			endpointsInfo: map[string]management.TraceabilityAgentAgentstateSamplingEndpoints{
-				"id1": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v1",
-				},
-				"id2": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v2",
-				},
+				"id1": {BasePath: "/api/v1"},
+				"id2": {BasePath: "/api/v2"},
 			},
+			expectedEndpointsSampled: map[string]struct{}{"id1": {}, "id2": {}},
 		},
 		{
+			skip: false,
 			name: "Endpoints sampling enabled with additional endpoints",
 			apiTransactions: map[string]transactionCount{
 				"id1": {successCount: 1000},
 				"id2": {successCount: 1000},
 				"id3": {successCount: 1000},
+				"id4": {successCount: 1000},
+				"id5": {successCount: 1000},
+				"id6": {successCount: 1000},
 			},
-			expectedSampled:    500,
+			maxSampled:         800,
 			limit:              100,
 			duration:           time.Second / 2,
 			counterResetPeriod: time.Second / 10,
 			endpointsInfo: map[string]management.TraceabilityAgentAgentstateSamplingEndpoints{
-				"id1": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v1",
-				},
-				"id2": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v2",
-				},
+				"id1": {BasePath: "/api/v1"},
+				"id2": {BasePath: "/api/v2"},
 			},
-			additionalEndpontsInfo: map[string]management.TraceabilityAgentAgentstateSamplingEndpoints{
-				"id1": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v1",
-				},
-				"id2": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v2",
-				},
-				"id3": {
-					EndTime:  v1Time.Time(time.Now().Add(time.Second / 2)),
-					BasePath: "/api/v3",
-				},
+			additionalEndpointsInfo: map[string]management.TraceabilityAgentAgentstateSamplingEndpoints{
+				"id1": {BasePath: "/api/v1"},
+				"id2": {BasePath: "/api/v2"},
+				"id3": {BasePath: "/api/v3"},
 			},
+			expectedEndpointsSampled: map[string]struct{}{"id1": {}, "id2": {}, "id3": {}},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skip {
+				t.Skip("skipping test")
+			}
 			waitGroup := sync.WaitGroup{}
 			sampleCounterLock := sync.Mutex{}
 
-			err := SetupSampling(test.config, false, "")
-			endTime := time.Now().Truncate(test.counterResetPeriod).Add(test.duration)
-			done := time.NewTicker(time.Until(endTime))
+			testEnd := time.Now().Truncate(test.counterResetPeriod).Add(test.duration)
+			done := time.NewTicker(time.Until(testEnd))
 			defer done.Stop()
+
+			err := SetupSampling(test.config, false, "")
+			endTime := time.Now().Add(-1 * time.Second) // reset endTime to avoid issues with the test
+			if test.globalSampling {
+				endTime = testEnd
+			}
 
 			period := &atomic.Int64{}
 			period.Store(int64(test.counterResetPeriod))
 			agentSamples.counterResetPeriod = period
+			// update the endtime in the endpoints
+			for i := range test.endpointsInfo {
+				test.endpointsInfo[i] = management.TraceabilityAgentAgentstateSamplingEndpoints{
+					BasePath:   test.endpointsInfo[i].BasePath,
+					EndTime:    v1Time.Time(testEnd),
+					OnlyErrors: test.endpointsInfo[i].OnlyErrors,
+				}
+			}
 			agentSamples.EnableSampling(test.limit, endTime, test.endpointsInfo)
 			assert.Nil(t, err)
 
-			if len(test.endpointsInfo) > 0 {
-				agentSamples.endpointsSampling.endpointsLock.Lock()
-				assert.Equal(t, len(test.endpointsInfo), len(agentSamples.endpointsSampling.endpointsInfo),
-					"Endpoints sampling should be enabled with the correct number of endpoints")
-				agentSamples.endpointsSampling.endpointsLock.Unlock()
-			}
-
-			if len(test.additionalEndpontsInfo) > 0 {
-				agentSamples.EnableSampling(test.limit, endTime, test.additionalEndpontsInfo)
-
-				agentSamples.endpointsSampling.endpointsLock.Lock()
-				assert.Equal(t, len(test.additionalEndpontsInfo), len(agentSamples.endpointsSampling.endpointsInfo),
-					"Endpoints sampling should be enabled with the additional endpoints")
-				agentSamples.endpointsSampling.endpointsLock.Unlock()
+			if len(test.additionalEndpointsInfo) > 0 {
+				for i := range test.additionalEndpointsInfo {
+					test.additionalEndpointsInfo[i] = management.TraceabilityAgentAgentstateSamplingEndpoints{
+						BasePath:   test.endpointsInfo[i].BasePath,
+						EndTime:    v1Time.Time(testEnd),
+						OnlyErrors: test.endpointsInfo[i].OnlyErrors,
+					}
+				}
+				agentSamples.EnableSampling(test.limit, endTime, test.additionalEndpointsInfo)
 			}
 
 			sampled := 0
 
+			endpointsSampled := map[string]struct{}{}
 			for apiID, numCalls := range test.apiTransactions {
 				waitGroup.Add(1)
 
@@ -286,7 +297,7 @@ func TestShouldSample(t *testing.T) {
 
 				go func(wg *sync.WaitGroup, id, subID string, calls transactionCount) {
 					defer wg.Done()
-					endTimeTimer := time.NewTimer(time.Until(endTime))
+					endTimeTimer := time.NewTimer(time.Until(testEnd))
 
 					sampleFunc := func(id, subID string, status string) {
 						testDetails := TransactionDetails{
@@ -297,6 +308,7 @@ func TestShouldSample(t *testing.T) {
 						sample, err := ShouldSampleTransaction(testDetails)
 						if sample {
 							sampleCounterLock.Lock()
+							endpointsSampled[id] = struct{}{}
 							sampled++
 							sampleCounterLock.Unlock()
 						}
@@ -321,13 +333,21 @@ func TestShouldSample(t *testing.T) {
 			time.Sleep(time.Second / 2) // wait for the sampling to finish
 
 			assert.Nil(t, err)
-			assert.LessOrEqual(t, test.expectedSampled, sampled)
-			assert.GreaterOrEqual(t, test.expectedSampled+int(test.limit), sampled)
+			assert.LessOrEqual(t, sampled, test.maxSampled, "sampled transactions should be less than max sampled")
 			if len(test.endpointsInfo) > 0 {
 				agentSamples.endpointsSampling.endpointsLock.Lock()
 				assert.Equal(t, 0, len(agentSamples.endpointsSampling.endpointsInfo),
 					"Endpoints sampling should be disabled after the test")
 				agentSamples.endpointsSampling.endpointsLock.Unlock()
+			}
+			// validate that only the expected endpoints are sampled
+			if len(test.expectedEndpointsSampled) > 0 {
+				for id := range endpointsSampled {
+					assert.Contains(t, test.expectedEndpointsSampled, id, "endpoint %s should not have been sampled", id)
+				}
+				for id := range test.expectedEndpointsSampled {
+					assert.Contains(t, endpointsSampled, id, "endpoint %s should have been sampled", id)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Change the endpointsInfo to use a bool in place of object value denotes only errors, existence demotes enabled
- Only enable global sampling when end time is after current time
- Set endpointSampling to false only when no endpoints in array
- Ensure the limiter is only running a single instance
- Fix validation of sampled events, use maxSampled, remove unnecessary validation
- Add validation that only endpoints expected have events that are sampled
  - Remove validation on length of enabled endpoints as its not necessary with above check 