### PR TITLE
APIGOV-30833 - Handling Transactions and Metrics with an empty API ID

### DIFF
--- a/pkg/transaction/definitions.go
+++ b/pkg/transaction/definitions.go
@@ -49,6 +49,8 @@ const (
 
 const (
 	unknown = "unknown"
+	// UnknownAPIID - Constant for transactions with no API ID or API Name
+	UnknownAPIID = "unknown-api-id"
 )
 
 // LogEvent - Log event to be sent to Condor

--- a/pkg/transaction/logeventbuilder.go
+++ b/pkg/transaction/logeventbuilder.go
@@ -512,7 +512,14 @@ func (b *transactionSummaryBuilder) SetProxyWithStageVersion(proxyID, proxyName,
 	if b.err != nil {
 		return b
 	}
-	if proxyID == "" {
+	// If both proxyID and proxyName are empty, this transaction has no API ID or API Name
+	// and should be added to the Unknown API ID bucket
+	if proxyID == "" && proxyName == "" {
+		proxyID = UnknownAPIID
+	} else if proxyID == "" {
+		// If only proxyID is empty but proxyName exists, use "unknown" as before
+		// This maintains existing behavior for cases where Gateway has API Name but
+		// agent hasn't discovered the API yet (should use sanitized API Name as ID)
 		proxyID = "unknown"
 	}
 	b.logEvent.TransactionSummary.Proxy = &Proxy{

--- a/pkg/transaction/logeventbuilder_test.go
+++ b/pkg/transaction/logeventbuilder_test.go
@@ -450,4 +450,21 @@ func TestLogRedactionOverride(t *testing.T) {
 	assert.False(t, redactionConfig.requestHeadersRedactionCalled)
 	assert.False(t, redactionConfig.responseHeadersRedactionCalled)
 	assert.False(t, redactionConfig.jmsPropertiesRedactionCalled)
+
+	// Test case for transactions with no API ID or API Name (should use UnknownAPIID)
+	logEvent, err = NewTransactionSummaryBuilder().
+		SetTransactionID("33333").
+		SetTimestamp(timeStamp).
+		SetStatus(TxSummaryStatusSuccess, "200").
+		SetDuration(10).
+		SetProxy("", "", 1). // Both proxyID and proxyName are empty
+		SetEntryPoint("http", "GET", "/unknown-api", "somehost.com").
+		Build()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, logEvent)
+	assert.NotNil(t, logEvent.TransactionSummary.Proxy)
+	assert.Equal(t, "unknown-api-id", logEvent.TransactionSummary.Proxy.ID)
+	assert.Equal(t, "", logEvent.TransactionSummary.Proxy.Name)
+	assert.Equal(t, 1, logEvent.TransactionSummary.Proxy.Revision)
 }

--- a/pkg/transaction/metric/util.go
+++ b/pkg/transaction/metric/util.go
@@ -10,6 +10,11 @@ import (
 	transutil "github.com/Axway/agent-sdk/pkg/transaction/util"
 )
 
+const (
+	// unknownAPIID - Constant for transactions with no API ID or API Name
+	unknownAPIID = "unknown-api-id"
+)
+
 func centralMetricFromAPIMetric(in *APIMetric) *centralMetric {
 	if in == nil {
 		return nil
@@ -93,7 +98,7 @@ func centralMetricFromAPIMetric(in *APIMetric) *centralMetric {
 		}
 	}
 
-	if in.API.ID != unknown && in.API.ID != "" {
+	if in.API.ID != unknown && in.API.ID != unknownAPIID && in.API.ID != "" {
 		out.API = &models.APIResourceReference{
 			ResourceReference: models.ResourceReference{
 				ID: in.API.ID,


### PR DESCRIPTION
1. Valid data: Transactions with no API ID or API Name are still considered valid and will be processed
2. These transactions will be grouped under the "unknown-api-id" identifier
3. Transactions where only the API ID is missing but API Name exists continue to use "unknown" as before
4. The metrics system properly excludes both "unknown" and "unknown-api-id" from detailed API processing while still tracking the transaction data