### PR TITLE
APIGOV-30809 - resource meta self link changes

### DIFF
--- a/pkg/apic/apiserver/models/api/v1/resourcemeta.go
+++ b/pkg/apic/apiserver/models/api/v1/resourcemeta.go
@@ -118,7 +118,7 @@ func (rm *ResourceMeta) GetKindLink() string {
 			scopePlural, _ := GetPluralFromKind(scope)
 			pathItems = append(pathItems, []string{scopePlural, rm.Metadata.Scope.Name}...)
 		}
-	} else {
+	} else if rm.Metadata.Scope.Name != "" {
 		scopePlural, _ := GetPluralFromKind(rm.Metadata.Scope.Kind)
 		pathItems = append(pathItems, []string{scopePlural, rm.Metadata.Scope.Name}...)
 	}

--- a/pkg/apic/apiserver/models/api/v1/resourcemeta_test.go
+++ b/pkg/apic/apiserver/models/api/v1/resourcemeta_test.go
@@ -268,11 +268,12 @@ func TestResourceMetaGetSelfLink(t *testing.T) {
 	link = meta.GetSelfLink()
 	assert.Equal(t, "/group/v1/kinds/name", link)
 
-	meta.Metadata.Scope = MetadataScope{
-		Name: "scope",
-		Kind: "scopeKind",
-	}
+	// no scope name
+	meta.Metadata.Scope.Kind = "scopeKind"
+	link = meta.GetSelfLink()
+	assert.Equal(t, "/group/v1/kinds/name", link)
 
+	meta.Metadata.Scope.Name = "scope"
 	scopeKindMap[meta.GroupKind] = "scopeKind"
 
 	// no scope kind


### PR DESCRIPTION
Changes to get the proper kind link for trying to get resources of a specific kind which are scoped by default, but don't have a scope name(Ex: ApiServiceInstances)