### PR TITLE
APIGOV-31098 - Add runtimeID to user-agent and update process to rebuild cache

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -89,8 +89,8 @@ type agentData struct {
 	// profiling
 	profileDone chan struct{}
 
-	// runtimeId is a unique identifier for the agent instance
-	runtimeId string
+	// runtimeID is a unique identifier for the agent instance
+	runtimeID string
 }
 
 var agent agentData
@@ -101,11 +101,11 @@ func init() {
 	agent.proxyResourceHandler = handler.NewStreamWatchProxyHandler()
 	agentMutex = sync.RWMutex{}
 	agent.publishingLock = &sync.Mutex{}
-	agent.runtimeId = uuid.New().String()
+	agent.runtimeID = uuid.New().String()
 	logger = log.NewFieldLogger().
 		WithPackage("sdk.agent").
 		WithComponent("agent").
-		WithField("runtimeId", agent.runtimeId)
+		WithField("runtimeID", agent.runtimeID)
 }
 
 // Initialize - Initializes the agent
@@ -601,7 +601,7 @@ func GetUserAgent() string {
 		envName,
 		agentName,
 		isGRPC,
-		agent.runtimeId).FormatUserAgent()
+		agent.runtimeID).FormatUserAgent()
 }
 
 // setCentralConfig - Sets the central config

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -89,8 +89,8 @@ type agentData struct {
 	// profiling
 	profileDone chan struct{}
 
-	// runtimeID is a unique identifier for the agent instance
-	runtimeID string
+	// runtimeId is a unique identifier for the agent instance
+	runtimeId string
 }
 
 var agent agentData
@@ -101,11 +101,11 @@ func init() {
 	agent.proxyResourceHandler = handler.NewStreamWatchProxyHandler()
 	agentMutex = sync.RWMutex{}
 	agent.publishingLock = &sync.Mutex{}
-	agent.runtimeID = uuid.New().String()
+	agent.runtimeId = uuid.New().String()
 	logger = log.NewFieldLogger().
 		WithPackage("sdk.agent").
 		WithComponent("agent").
-		WithField("runtimeID", agent.runtimeID)
+		WithField("runtimeId", agent.runtimeId)
 }
 
 // Initialize - Initializes the agent
@@ -601,7 +601,7 @@ func GetUserAgent() string {
 		envName,
 		agentName,
 		isGRPC,
-		agent.runtimeID).FormatUserAgent()
+		agent.runtimeId).FormatUserAgent()
 }
 
 // setCentralConfig - Sets the central config

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -88,21 +88,24 @@ type agentData struct {
 
 	// profiling
 	profileDone chan struct{}
+
+	// runtimeID is a unique identifier for the agent instance
+	runtimeID string
 }
 
 var agent agentData
 var agentMutex sync.RWMutex
 var logger log.FieldLogger
-var runtimeID string
 
 func init() {
-	logger = log.NewFieldLogger().
-		WithPackage("sdk.agent").
-		WithComponent("agent")
 	agent.proxyResourceHandler = handler.NewStreamWatchProxyHandler()
 	agentMutex = sync.RWMutex{}
 	agent.publishingLock = &sync.Mutex{}
-	runtimeID = uuid.New().String()
+	agent.runtimeID = uuid.New().String()
+	logger = log.NewFieldLogger().
+		WithPackage("sdk.agent").
+		WithComponent("agent").
+		WithField("runtimeID", agent.runtimeID)
 }
 
 // Initialize - Initializes the agent
@@ -598,7 +601,7 @@ func GetUserAgent() string {
 		envName,
 		agentName,
 		isGRPC,
-		GetRuntimeID()).FormatUserAgent()
+		getRuntimeID()).FormatUserAgent()
 }
 
 // setCentralConfig - Sets the central config
@@ -631,8 +634,8 @@ func GetResourceManager() resource.Manager {
 	return agent.agentResourceManager
 }
 
-func GetRuntimeID() string {
-	return runtimeID
+func getRuntimeID() string {
+	return agent.runtimeID
 }
 
 // GetAgentResource - Returns Agent resource

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/util/errors"
 	hc "github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	"github.com/Axway/agent-sdk/pkg/util/log"
+	"github.com/google/uuid"
 )
 
 // AgentStatus - status for Agent resource
@@ -91,8 +92,8 @@ type agentData struct {
 
 var agent agentData
 var agentMutex sync.RWMutex
-
 var logger log.FieldLogger
+var runtimeID string
 
 func init() {
 	logger = log.NewFieldLogger().
@@ -101,6 +102,7 @@ func init() {
 	agent.proxyResourceHandler = handler.NewStreamWatchProxyHandler()
 	agentMutex = sync.RWMutex{}
 	agent.publishingLock = &sync.Mutex{}
+	runtimeID = uuid.New().String()
 }
 
 // Initialize - Initializes the agent
@@ -589,13 +591,16 @@ func GetUserAgent() string {
 		agentName = agent.cfg.GetAgentName()
 		isGRPC = agent.cfg.IsUsingGRPC()
 	}
-	return util.NewUserAgent(
+	ua := util.NewUserAgent(
 		config.AgentTypeName,
 		config.AgentVersion,
 		config.SDKVersion,
 		envName,
 		agentName,
-		isGRPC).FormatUserAgent()
+		isGRPC,
+		GetRuntimeID()).FormatUserAgent()
+
+	return ua
 }
 
 // setCentralConfig - Sets the central config
@@ -626,6 +631,10 @@ func GetResourceManager() resource.Manager {
 		return nil
 	}
 	return agent.agentResourceManager
+}
+
+func GetRuntimeID() string {
+	return runtimeID
 }
 
 // GetAgentResource - Returns Agent resource

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -591,7 +591,7 @@ func GetUserAgent() string {
 		agentName = agent.cfg.GetAgentName()
 		isGRPC = agent.cfg.IsUsingGRPC()
 	}
-	ua := util.NewUserAgent(
+	return util.NewUserAgent(
 		config.AgentTypeName,
 		config.AgentVersion,
 		config.SDKVersion,
@@ -599,8 +599,6 @@ func GetUserAgent() string {
 		agentName,
 		isGRPC,
 		GetRuntimeID()).FormatUserAgent()
-
-	return ua
 }
 
 // setCentralConfig - Sets the central config

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -601,7 +601,7 @@ func GetUserAgent() string {
 		envName,
 		agentName,
 		isGRPC,
-		getRuntimeID()).FormatUserAgent()
+		agent.runtimeID).FormatUserAgent()
 }
 
 // setCentralConfig - Sets the central config
@@ -632,10 +632,6 @@ func GetResourceManager() resource.Manager {
 		return nil
 	}
 	return agent.agentResourceManager
-}
-
-func getRuntimeID() string {
-	return agent.runtimeID
 }
 
 // GetAgentResource - Returns Agent resource

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"encoding/json"
+	"os"
 	"sync"
 
 	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
@@ -422,4 +423,6 @@ func (c *cacheManager) Flush() {
 	c.subscriptionMap.Flush()
 	c.watchResourceMap.Flush()
 	c.SaveCache()
+	// delete the cache file in case the agent is restarted here
+	os.Remove(c.cacheFilename)
 }

--- a/pkg/agent/eventsync.go
+++ b/pkg/agent/eventsync.go
@@ -162,7 +162,10 @@ func (es *EventSync) waitForCacheRebuild() {
 			return
 		}
 
-		logger.WithError(err).WithField("waitTime", currentBackoff).Error("failed to rebuild cache, retrying after waitTime")
+		logger.
+			WithError(err).
+			WithField("waitTime", currentBackoff.String()).
+			Error("failed to rebuild cache, retrying after waitTime")
 		time.Sleep(currentBackoff)
 		currentBackoff = time.Duration(math.Min(float64(maxBackoff), float64(currentBackoff)*float64(adjustment)))
 	}

--- a/pkg/agent/resource/manager.go
+++ b/pkg/agent/resource/manager.go
@@ -163,10 +163,12 @@ func (a *agentResourceManager) UpdateAgentStatus(status, prevStatus, message str
 	// using discovery agent status here, but all agent status resources have the same structure
 	agentStatus := newDAStatus(agentInstance.ResourceMeta, status, prevStatus, message)
 
-	// See if we need to rebuildCache
-	timeToRebuild, _ := a.shouldRebuildCache()
-	if timeToRebuild && a.rebuildCache != nil {
-		a.rebuildCache.RebuildCache()
+	// Only perform periodic/self-healing cache rebuild for non-gRPC agents
+	if a.cfg != nil && !a.cfg.IsUsingGRPC() {
+		timeToRebuild, _ := a.shouldRebuildCache()
+		if timeToRebuild && a.rebuildCache != nil {
+			a.rebuildCache.RebuildCache()
+		}
 	}
 
 	subResources := make(map[string]interface{})

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -239,12 +239,14 @@ func TestSend(t *testing.T) {
 		agentName         string
 		isDocker          bool
 		isGRPC            bool
+		runtimeID         string
 	}{
 		{
-			name:   "invalid-url",
-			url:    "socks://invalid-url",
-			method: GET,
-			isErr:  true,
+			name:      "invalid-url",
+			url:       "socks://invalid-url",
+			method:    GET,
+			isErr:     true,
+			runtimeID: "af17ec18-3fb3-4571-9914-300eb5224865",
 		},
 		{
 			name:              "get-request-with-queryparam-header",
@@ -257,8 +259,9 @@ func TestSend(t *testing.T) {
 			envName:           "env",
 			isDocker:          false,
 			isGRPC:            true,
+			runtimeID:         "af17ec18-3fb3-4571-9914-300eb5224865",
 			agentName:         "agent",
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s) runtimeID/af17ec18-3fb3-4571-9914-300eb5224865", hostname),
 		},
 		{
 			name:              "post-request-with-response",
@@ -270,7 +273,8 @@ func TestSend(t *testing.T) {
 			envName:           "env",
 			isDocker:          true,
 			agentName:         "agent",
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
+			runtimeID:         "af17ec18-3fb3-4571-9914-300eb5224865",
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s) runtimeID/af17ec18-3fb3-4571-9914-300eb5224865", hostname),
 		},
 		{
 			name:              "override-user-agent",
@@ -282,6 +286,7 @@ func TestSend(t *testing.T) {
 			envName:           "env",
 			isDocker:          true,
 			agentName:         "agent",
+			runtimeID:         "af17ec18-3fb3-4571-9914-300eb5224865",
 			expectedUserAgent: "test",
 		},
 	}
@@ -293,7 +298,9 @@ func TestSend(t *testing.T) {
 				config.SDKVersion,
 				tc.envName,
 				tc.agentName,
-				tc.isGRPC).FormatUserAgent()
+				tc.isGRPC,
+				tc.runtimeID,
+			).FormatUserAgent()
 			SetConfigAgent(ua, httpServer.server.URL, []string{"http://test"})
 			httpServer.reset()
 			httpServer.respBody = tc.respBody

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -224,7 +224,7 @@ func TestSend(t *testing.T) {
 	config.SDKVersion = "1.0"
 	httpServer := newMockHTTPServer()
 	hostname, _ := os.Hostname()
-	runtimeID := uuid.New().String()
+	runtimeId := uuid.New().String()
 
 	tests := []struct {
 		name              string
@@ -240,7 +240,7 @@ func TestSend(t *testing.T) {
 		agentName         string
 		isDocker          bool
 		isGRPC            bool
-		runtimeID         string
+		runtimeId         string
 	}{
 		{
 			name:   "invalid-url",
@@ -259,8 +259,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeID:         runtimeID,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 		},
 		{
 			name:              "post-request-with-response",
@@ -273,8 +273,8 @@ func TestSend(t *testing.T) {
 			isDocker:          true,
 			agentName:         "agent",
 			isGRPC:            false,
-			runtimeID:         runtimeID,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 		},
 		{
 			name:              "override-user-agent",
@@ -287,11 +287,11 @@ func TestSend(t *testing.T) {
 			isDocker:          true,
 			agentName:         "agent",
 			isGRPC:            false,
-			runtimeID:         runtimeID,
+			runtimeId:         runtimeId,
 			expectedUserAgent: "test",
 		},
 		{
-			name:              "get-request-with-runtimeID",
+			name:              "get-request-with-runtimeId",
 			url:               "http://test",
 			method:            GET,
 			queryParam:        map[string]string{"param1": "value1"},
@@ -302,11 +302,11 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeID:         runtimeID,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 		},
 		{
-			name:              "post-request-with-runtimeID",
+			name:              "post-request-with-runtimeId",
 			url:               "http://test",
 			method:            POST,
 			body:              []byte("test-req"),
@@ -316,11 +316,11 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeID:         runtimeID,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 		},
 		{
-			name:              "non-grpc-with-runtimeID",
+			name:              "non-grpc-with-runtimeId",
 			url:               "http://test",
 			method:            GET,
 			respCode:          200,
@@ -329,8 +329,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            false,
 			agentName:         "agent",
-			runtimeID:         runtimeID,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 		},
 	}
 	for _, tc := range tests {
@@ -342,7 +342,7 @@ func TestSend(t *testing.T) {
 				tc.envName,
 				tc.agentName,
 				tc.isGRPC,
-				tc.runtimeID,
+				tc.runtimeId,
 			).FormatUserAgent()
 			SetConfigAgent(ua, httpServer.server.URL, []string{"http://test"})
 			httpServer.reset()
@@ -372,7 +372,7 @@ func TestSend(t *testing.T) {
 				assert.Equal(t, tc.respBody, res.Body)
 				assert.Equal(t, tc.method, httpServer.reqMethod)
 
-				// Always check for the new user agent pattern with runtimeID
+				// Always check for the new user agent pattern with runtimeId
 				if tc.expectedUserAgent == "test" {
 					assert.Equal(t, tc.expectedUserAgent, httpServer.reqUserAgent)
 				} else {

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -224,7 +224,7 @@ func TestSend(t *testing.T) {
 	config.SDKVersion = "1.0"
 	httpServer := newMockHTTPServer()
 	hostname, _ := os.Hostname()
-	runtimeId := uuid.New().String()
+	runtimeID := uuid.New().String()
 
 	tests := []struct {
 		name              string
@@ -240,7 +240,7 @@ func TestSend(t *testing.T) {
 		agentName         string
 		isDocker          bool
 		isGRPC            bool
-		runtimeId         string
+		runtimeID         string
 	}{
 		{
 			name:   "invalid-url",
@@ -259,8 +259,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeId:         runtimeId,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 		},
 		{
 			name:              "post-request-with-response",
@@ -273,8 +273,8 @@ func TestSend(t *testing.T) {
 			isDocker:          true,
 			agentName:         "agent",
 			isGRPC:            false,
-			runtimeId:         runtimeId,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 		},
 		{
 			name:              "override-user-agent",
@@ -287,7 +287,7 @@ func TestSend(t *testing.T) {
 			isDocker:          true,
 			agentName:         "agent",
 			isGRPC:            false,
-			runtimeId:         runtimeId,
+			runtimeID:         runtimeID,
 			expectedUserAgent: "test",
 		},
 		{
@@ -302,8 +302,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeId:         runtimeId,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 		},
 		{
 			name:              "post-request-with-runtimeId",
@@ -316,8 +316,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            true,
 			agentName:         "agent",
-			runtimeId:         runtimeId,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 		},
 		{
 			name:              "non-grpc-with-runtimeId",
@@ -329,8 +329,8 @@ func TestSend(t *testing.T) {
 			isDocker:          false,
 			isGRPC:            false,
 			agentName:         "agent",
-			runtimeId:         runtimeId,
-			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0 (sdkVer:1.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 		},
 	}
 	for _, tc := range tests {
@@ -342,7 +342,7 @@ func TestSend(t *testing.T) {
 				tc.envName,
 				tc.agentName,
 				tc.isGRPC,
-				tc.runtimeId,
+				tc.runtimeID,
 			).FormatUserAgent()
 			SetConfigAgent(ua, httpServer.server.URL, []string{"http://test"})
 			httpServer.reset()

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	agentInfoRe   = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([a-z0-9]*?) SDK/(\d*.\d*.\d.*) ([a-z][a-zA-Z0-9-]*) ([a-z][a-zA-Z0-9-.]*) (binary|docker)[ ]?(reactive)?`)
-	agentInfoReV2 = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([-a-z0-9A-Z]*?) \(sdkVer:(\d*.\d*.\d.*)\; env:([a-zA-Z0-9-]*)\; agent:([a-zA-Z0-9-.]*)\; reactive:(true|false)\; hostname:([a-zA-Z0-9-_.]*); runtimeID:([a-zA-Z0-9-_.]*)\) ??(grpc-go.*\/\d*.\d*.\d*)?$`)
+	agentInfoReV2 = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([-a-z0-9A-Z]*?) \(sdkVer:(\d*.\d*.\d.*)\; env:([a-zA-Z0-9-]*)\; agent:([a-zA-Z0-9-.]*)\; reactive:(true|false)\; hostname:([a-zA-Z0-9-_.]*)(; runtimeID:([a-zA-Z0-9-_.]*))?\) ??(grpc-go.*\/\d*.\d*.\d*)?$`)
 )
 
 type CentralUserAgent struct {
@@ -88,7 +88,7 @@ func ParseUserAgent(userAgent string) *CentralUserAgent {
 			IsGRPC:              isGRPC,
 			HostName:            matches[8],
 			UseGRPCStatusUpdate: isGRPC,
-			RuntimeID:           matches[9],
+			RuntimeID:           matches[10],
 		}
 	}
 

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -46,6 +46,7 @@ func (ca *CentralUserAgent) FormatUserAgent() string {
 			reactive = "true"
 		}
 		ua = fmt.Sprintf("%s/%s (sdkVer:%s; env:%s; agent:%s; reactive:%s; hostname:%s)", ca.AgentType, ca.Version, ca.SDKVersion, ca.Environment, ca.AgentName, reactive, hostName)
+		// runtimeID is only included if it's set
 		if ca.RuntimeID != "" {
 			ua = ua + " runtimeID/" + ca.RuntimeID
 		}

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	agentInfoRe   = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([a-z0-9]*?) SDK/(\d*.\d*.\d.*) ([a-z][a-zA-Z0-9-]*) ([a-z][a-zA-Z0-9-.]*) (binary|docker)[ ]?(reactive)?`)
-	agentInfoReV2 = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([-a-z0-9A-Z]*?) \(sdkVer:(\d*.\d*.\d.*)\; env:([a-zA-Z0-9-]*)\; agent:([a-zA-Z0-9-.]*)\; reactive:(true|false)\; hostname:([a-zA-Z0-9-_.]*)(; runtimeID:([a-zA-Z0-9-_.]*))?\) ??(grpc-go.*\/\d*.\d*.\d*)?$`)
+	agentInfoReV2 = regexp.MustCompile(`^([a-zA-Z0-9]*)\/(\d*.\d*.\d*)[-]?([-a-z0-9A-Z]*?) \(sdkVer:(\d*.\d*.\d.*)\; env:([a-zA-Z0-9-]*)\; agent:([a-zA-Z0-9-.]*)\; reactive:(true|false)\; hostname:([a-zA-Z0-9-_.]*)(; runtimeId:([a-zA-Z0-9-_.]*))?\) ??(grpc-go.*\/\d*.\d*.\d*)?$`)
 )
 
 type CentralUserAgent struct {
@@ -22,10 +22,10 @@ type CentralUserAgent struct {
 	IsGRPC              bool   `json:"reactive"`
 	HostName            string `json:"hostname,omitempty"`
 	UseGRPCStatusUpdate bool   `json:"-"`
-	RuntimeID           string `json:"runtimeId,omitempty"`
+	RuntimeId           string `json:"runtimeId,omitempty"`
 }
 
-func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName string, isGRPC bool, runtimeID string) *CentralUserAgent {
+func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName string, isGRPC bool, runtimeId string) *CentralUserAgent {
 	return &CentralUserAgent{
 		AgentType:   agentType,
 		Version:     strings.TrimPrefix(version, "v"),
@@ -33,7 +33,7 @@ func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName str
 		Environment: environmentName,
 		AgentName:   agentName,
 		IsGRPC:      isGRPC,
-		RuntimeID:   runtimeID,
+		RuntimeId:   runtimeId,
 	}
 }
 
@@ -45,7 +45,7 @@ func (ca *CentralUserAgent) FormatUserAgent() string {
 	}
 
 	ua := fmt.Sprintf(
-		"%s/%s (sdkVer:%s; env:%s; agent:%s; reactive:%s; hostname:%s; runtimeID:%s)",
+		"%s/%s (sdkVer:%s; env:%s; agent:%s; reactive:%s; hostname:%s; runtimeId:%s)",
 		ca.AgentType,
 		ca.Version,
 		ca.SDKVersion,
@@ -53,7 +53,7 @@ func (ca *CentralUserAgent) FormatUserAgent() string {
 		ca.AgentName,
 		reactive,
 		hostName,
-		ca.RuntimeID,
+		ca.RuntimeId,
 	)
 	return ua
 }
@@ -88,7 +88,7 @@ func ParseUserAgent(userAgent string) *CentralUserAgent {
 			IsGRPC:              isGRPC,
 			HostName:            matches[8],
 			UseGRPCStatusUpdate: isGRPC,
-			RuntimeID:           matches[10],
+			RuntimeId:           matches[10],
 		}
 	}
 

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -22,10 +22,10 @@ type CentralUserAgent struct {
 	IsGRPC              bool   `json:"reactive"`
 	HostName            string `json:"hostname,omitempty"`
 	UseGRPCStatusUpdate bool   `json:"-"`
-	RuntimeId           string `json:"runtimeId,omitempty"`
+	RuntimeID           string `json:"runtimeId,omitempty"`
 }
 
-func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName string, isGRPC bool, runtimeId string) *CentralUserAgent {
+func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName string, isGRPC bool, runtimeID string) *CentralUserAgent {
 	return &CentralUserAgent{
 		AgentType:   agentType,
 		Version:     strings.TrimPrefix(version, "v"),
@@ -33,7 +33,7 @@ func NewUserAgent(agentType, version, sdkVersion, environmentName, agentName str
 		Environment: environmentName,
 		AgentName:   agentName,
 		IsGRPC:      isGRPC,
-		RuntimeId:   runtimeId,
+		RuntimeID:   runtimeID,
 	}
 }
 
@@ -53,7 +53,7 @@ func (ca *CentralUserAgent) FormatUserAgent() string {
 		ca.AgentName,
 		reactive,
 		hostName,
-		ca.RuntimeId,
+		ca.RuntimeID,
 	)
 	return ua
 }
@@ -88,7 +88,7 @@ func ParseUserAgent(userAgent string) *CentralUserAgent {
 			IsGRPC:              isGRPC,
 			HostName:            matches[8],
 			UseGRPCStatusUpdate: isGRPC,
-			RuntimeId:           matches[10],
+			RuntimeID:           matches[10],
 		}
 	}
 

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -13,6 +13,7 @@ func TestFormatUserAgents(t *testing.T) {
 	agentVersion := "1.0.0"
 	sdkVersion := "1.0.0"
 	hostname, _ := os.Hostname()
+
 	tests := []struct {
 		name              string
 		userAgent         string
@@ -22,6 +23,7 @@ func TestFormatUserAgents(t *testing.T) {
 		agentVersion      string
 		sdkVersion        string
 		isGRPC            bool
+		runtimeID         string
 	}{
 		{
 			name:              "test-1",
@@ -30,7 +32,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      "v1.0.0-125678e",
 			sdkVersion:        "v1.1.100",
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			runtimeID:         "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname),
 		},
 		{
 			name:              "test-1",
@@ -39,7 +42,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			runtimeID:         "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname),
 		},
 		{
 			name:              "test-2",
@@ -47,7 +51,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
+			runtimeID:         "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname),
 		},
 		{
 			name:              "test-3",
@@ -55,7 +60,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent.da.test",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:false; hostname:%s)", hostname),
+			runtimeID:         "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:false; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname),
 		},
 	}
 	for _, tc := range tests {
@@ -66,7 +72,9 @@ func TestFormatUserAgents(t *testing.T) {
 				tc.sdkVersion,
 				tc.envName,
 				tc.agentName,
-				tc.isGRPC)
+				tc.isGRPC,
+				tc.runtimeID,
+			)
 			formattedUserAgent := ua.FormatUserAgent()
 			assert.Equal(t, tc.expectedUserAgent, formattedUserAgent)
 		})
@@ -82,8 +90,11 @@ func TestParseUserAgents(t *testing.T) {
 		expectedUA *CentralUserAgent
 	}{
 		{
-			name:      "test-1",
-			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			name: "test-1",
+			userAgent: fmt.Sprintf(
+				"Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5",
+				hostname,
+			),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -94,6 +105,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 			},
 		},
 		{
@@ -112,7 +124,7 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-3",
-			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -121,6 +133,7 @@ func TestParseUserAgents(t *testing.T) {
 				Environment:         "env",
 				AgentName:           "agent",
 				IsGRPC:              false,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 				HostName:            hostname,
 				UseGRPCStatusUpdate: false,
 			},
@@ -135,6 +148,7 @@ func TestParseUserAgents(t *testing.T) {
 				Environment:         "env",
 				AgentName:           "agent",
 				IsGRPC:              true,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 				UseGRPCStatusUpdate: false,
 			},
 		},
@@ -148,6 +162,7 @@ func TestParseUserAgents(t *testing.T) {
 				Environment:         "env",
 				AgentName:           "agent",
 				IsGRPC:              false,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 				UseGRPCStatusUpdate: false,
 			},
 		},
@@ -173,7 +188,7 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-7",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s)", hostname2),
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s) runtimeID/c2f4113f-8cf7-41c7-af66-3121d493d3c5", hostname2),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -182,6 +197,7 @@ func TestParseUserAgents(t *testing.T) {
 				Environment:         "wso2",
 				AgentName:           "wso2-da",
 				IsGRPC:              true,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
 			},
@@ -197,6 +213,7 @@ func TestParseUserAgents(t *testing.T) {
 				Environment:         "wso2",
 				AgentName:           "wso2.da.test",
 				IsGRPC:              true,
+				RuntimeID:           "c2f4113f-8cf7-41c7-af66-3121d493d3c5",
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
 			},

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -3,9 +3,9 @@ package util
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +14,7 @@ func TestFormatUserAgents(t *testing.T) {
 	agentVersion := "1.0.0"
 	sdkVersion := "1.0.0"
 	hostname, _ := os.Hostname()
+	runtimeID := uuid.New().String()
 	tests := []struct {
 		name              string
 		userAgent         string
@@ -33,7 +34,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      "v1.0.0-125678e",
 			sdkVersion:        "v1.1.100",
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, ""),
 			runtimeID:         "",
 			expectRuntimeID:   false,
 		},
@@ -44,7 +45,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, ""),
 			runtimeID:         "",
 			expectRuntimeID:   false,
 		},
@@ -54,7 +55,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, ""),
 			isGRPC:            false,
 			runtimeID:         "",
 			expectRuntimeID:   false,
@@ -65,7 +66,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent.da.test",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:false; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:false; hostname:%s; runtimeID:%s)", hostname, ""),
 			isGRPC:            false,
 			runtimeID:         "",
 			expectRuntimeID:   false,
@@ -77,8 +78,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
-			runtimeID:         "test-runtimeID-123",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 			expectRuntimeID:   true,
 		},
 		{
@@ -88,8 +89,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
-			runtimeID:         "test-runtimeID-non-grpc",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 			expectRuntimeID:   true,
 		},
 		{
@@ -99,8 +100,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent.da.test",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s)", hostname),
-			runtimeID:         "test-runtimeID-dots",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 			expectRuntimeID:   true,
 		},
 		{
@@ -110,8 +111,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s)", hostname),
-			runtimeID:         "test-runtimeID-prod",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 			expectRuntimeID:   true,
 		},
 		{
@@ -121,7 +122,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz"),
 			runtimeID:         "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz",
 			expectRuntimeID:   true,
 		},
@@ -132,7 +133,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s)", hostname),
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-empty-agent"),
 			runtimeID:         "test-runtimeID-empty-agent",
 			expectRuntimeID:   true,
 		},
@@ -149,19 +150,8 @@ func TestFormatUserAgents(t *testing.T) {
 				tc.runtimeID,
 			)
 			formattedUserAgent := ua.FormatUserAgent()
-			if tc.expectRuntimeID {
-				assert.True(t, strings.HasPrefix(formattedUserAgent, tc.expectedUserAgent+" runtimeID/"),
-					"User-Agent should start with expected value and have runtimeID. Got: %s, Expected prefix: %s", formattedUserAgent, tc.expectedUserAgent)
-				assert.Contains(t, formattedUserAgent, tc.runtimeID)
-			} else {
-				// Allow for optional runtimeID suffix
-				if strings.Contains(formattedUserAgent, "runtimeID/") {
-					assert.True(t, strings.HasPrefix(formattedUserAgent, tc.expectedUserAgent+" runtimeID/"),
-						"User-Agent should start with expected value. Got: %s, Expected prefix: %s", formattedUserAgent, tc.expectedUserAgent)
-				} else {
-					assert.Equal(t, tc.expectedUserAgent, formattedUserAgent)
-				}
-			}
+			assert.Equal(t, tc.expectedUserAgent, formattedUserAgent,
+				"User-Agent should match expected value. Got: %s, Expected: %s", formattedUserAgent, tc.expectedUserAgent)
 		})
 	}
 }
@@ -169,6 +159,7 @@ func TestFormatUserAgents(t *testing.T) {
 func TestParseUserAgents(t *testing.T) {
 	hostname, _ := os.Hostname()
 	hostname2 := "test-test.abc.com"
+	runtimeID := uuid.New().String()
 	tests := []struct {
 		name       string
 		userAgent  string
@@ -176,7 +167,7 @@ func TestParseUserAgents(t *testing.T) {
 	}{
 		{
 			name:      "test-1",
-			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:)", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -187,11 +178,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-2",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s) grpc-go/1.65.0", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:) grpc-go/1.65.0", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -201,11 +193,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-3",
-			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:)", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -216,6 +209,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              false,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: false,
+				RuntimeID:           "",
 			},
 		},
 		{
@@ -251,7 +245,7 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-7",
-			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s)", hostname2),
+			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:)", hostname2),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -262,11 +256,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              false,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: false,
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-8",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s)", hostname2),
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeID:)", hostname2),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -277,11 +272,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-9",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:%s; reactive:true; hostname:%s)", "wso2.da.test", hostname2),
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:%s; reactive:true; hostname:%s; runtimeID:)", "wso2.da.test", hostname2),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -292,11 +288,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-10",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s) runtimeID/test-runtimeID-123", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -306,7 +303,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           "test-runtimeID-123",
+				RuntimeID:           runtimeID,
 			},
 		},
 	}

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -17,7 +17,6 @@ func TestFormatUserAgents(t *testing.T) {
 	runtimeID := uuid.New().String()
 	tests := []struct {
 		name              string
-		userAgent         string
 		expectedUserAgent string
 		envName           string
 		agentName         string
@@ -25,7 +24,6 @@ func TestFormatUserAgents(t *testing.T) {
 		sdkVersion        string
 		isGRPC            bool
 		runtimeID         string
-		expectRuntimeID   bool
 	}{
 		{
 			name:              "test-1",
@@ -34,56 +32,11 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      "v1.0.0-125678e",
 			sdkVersion:        "v1.1.100",
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, ""),
-			runtimeID:         "",
-			expectRuntimeID:   false,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 		},
 		{
 			name:              "test-2",
-			envName:           "env",
-			isGRPC:            true,
-			agentName:         "agent",
-			agentVersion:      agentVersion,
-			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, ""),
-			runtimeID:         "",
-			expectRuntimeID:   false,
-		},
-		{
-			name:              "test-3",
-			envName:           "env",
-			agentName:         "agent",
-			agentVersion:      agentVersion,
-			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, ""),
-			isGRPC:            false,
-			runtimeID:         "",
-			expectRuntimeID:   false,
-		},
-		{
-			name:              "test-4",
-			envName:           "env",
-			agentName:         "agent.da.test",
-			agentVersion:      agentVersion,
-			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:false; hostname:%s; runtimeID:%s)", hostname, ""),
-			isGRPC:            false,
-			runtimeID:         "",
-			expectRuntimeID:   false,
-		},
-		{
-			name:              "test-with-runtimeID",
-			envName:           "env",
-			isGRPC:            true,
-			agentName:         "agent",
-			agentVersion:      agentVersion,
-			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			runtimeID:         runtimeID,
-			expectRuntimeID:   true,
-		},
-		{
-			name:              "test-non-grpc-with-runtimeID",
 			envName:           "env",
 			isGRPC:            false,
 			agentName:         "agent",
@@ -91,10 +44,9 @@ func TestFormatUserAgents(t *testing.T) {
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, runtimeID),
 			runtimeID:         runtimeID,
-			expectRuntimeID:   true,
 		},
 		{
-			name:              "test-agentname-dots-with-runtimeID",
+			name:              "test-3",
 			envName:           "env",
 			isGRPC:            true,
 			agentName:         "agent.da.test",
@@ -102,10 +54,9 @@ func TestFormatUserAgents(t *testing.T) {
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
 			runtimeID:         runtimeID,
-			expectRuntimeID:   true,
 		},
 		{
-			name:              "test-different-env-with-runtimeID",
+			name:              "test-4",
 			envName:           "prod",
 			isGRPC:            true,
 			agentName:         "agent",
@@ -113,10 +64,9 @@ func TestFormatUserAgents(t *testing.T) {
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
 			runtimeID:         runtimeID,
-			expectRuntimeID:   true,
 		},
 		{
-			name:              "test-long-runtimeID",
+			name:              "test-5",
 			envName:           "env",
 			isGRPC:            true,
 			agentName:         "agent",
@@ -124,10 +74,9 @@ func TestFormatUserAgents(t *testing.T) {
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz"),
 			runtimeID:         "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz",
-			expectRuntimeID:   true,
 		},
 		{
-			name:              "test-empty-agentname-with-runtimeID",
+			name:              "test-6",
 			envName:           "env",
 			isGRPC:            true,
 			agentName:         "",
@@ -135,7 +84,6 @@ func TestFormatUserAgents(t *testing.T) {
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-empty-agent"),
 			runtimeID:         "test-runtimeID-empty-agent",
-			expectRuntimeID:   true,
 		},
 	}
 	for _, tc := range tests {
@@ -167,7 +115,7 @@ func TestParseUserAgents(t *testing.T) {
 	}{
 		{
 			name:      "test-1",
-			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:)", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -178,15 +126,16 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           "",
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
 			name:      "test-2",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:) grpc-go/1.65.0", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s)", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
+				CommitSHA:           "7e7eb72d",
 				SDKVersion:          "1.0.0",
 				Environment:         "env",
 				AgentName:           "agent",
@@ -198,22 +147,36 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-3",
-			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:)", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s) grpc-go/1.65.0", hostname, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
-				CommitSHA:           "7e7eb72d",
 				SDKVersion:          "1.0.0",
 				Environment:         "env",
 				AgentName:           "agent",
-				IsGRPC:              false,
+				IsGRPC:              true,
 				HostName:            hostname,
-				UseGRPCStatusUpdate: false,
-				RuntimeID:           "",
+				UseGRPCStatusUpdate: true,
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
 			name:      "test-4",
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s) grpc-go/1.65.0", hostname),
+			expectedUA: &CentralUserAgent{
+				AgentType:           "Test",
+				Version:             "1.0.0",
+				SDKVersion:          "1.0.0",
+				Environment:         "env",
+				AgentName:           "agent",
+				IsGRPC:              true,
+				HostName:            hostname,
+				UseGRPCStatusUpdate: true,
+				RuntimeID:           "",
+			},
+		},
+		{
+			name:      "test-5",
 			userAgent: "Test/1.0.0 SDK/1.0.0 env agent docker reactive",
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
@@ -226,7 +189,7 @@ func TestParseUserAgents(t *testing.T) {
 			},
 		},
 		{
-			name:      "test-5",
+			name:      "test-6",
 			userAgent: "Test/1.0.0 SDK/1.0.0 env agent binary",
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
@@ -239,29 +202,29 @@ func TestParseUserAgents(t *testing.T) {
 			},
 		},
 		{
-			name:       "test-6",
+			name:       "test-7",
 			userAgent:  "invalid user-agent",
 			expectedUA: nil,
 		},
 		{
-			name:      "test-7",
-			userAgent: fmt.Sprintf("Test/1.0.0-APIGOV-Test (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:)", hostname2),
+			name:      "test-8",
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeID:%s)", hostname2, runtimeID),
 			expectedUA: &CentralUserAgent{
-				AgentType:           "Test",
+				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
-				CommitSHA:           "7e7eb72d",
-				SDKVersion:          "1.0.0",
-				Environment:         "env",
-				AgentName:           "agent",
-				IsGRPC:              false,
+				CommitSHA:           "65a0b4c",
+				SDKVersion:          "1.1.110",
+				Environment:         "wso2",
+				AgentName:           "wso2-da",
+				IsGRPC:              true,
 				HostName:            hostname2,
-				UseGRPCStatusUpdate: false,
-				RuntimeID:           "",
+				UseGRPCStatusUpdate: true,
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
-			name:      "test-8",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeID:)", hostname2),
+			name:      "test-9",
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s)", hostname2),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -273,37 +236,6 @@ func TestParseUserAgents(t *testing.T) {
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
 				RuntimeID:           "",
-			},
-		},
-		{
-			name:      "test-9",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:%s; reactive:true; hostname:%s; runtimeID:)", "wso2.da.test", hostname2),
-			expectedUA: &CentralUserAgent{
-				AgentType:           "WSO2DiscoveryAgent",
-				Version:             "1.0.0",
-				CommitSHA:           "65a0b4c",
-				SDKVersion:          "1.1.110",
-				Environment:         "wso2",
-				AgentName:           "wso2.da.test",
-				IsGRPC:              true,
-				HostName:            hostname2,
-				UseGRPCStatusUpdate: true,
-				RuntimeID:           "",
-			},
-		},
-		{
-			name:      "test-10",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			expectedUA: &CentralUserAgent{
-				AgentType:           "Test",
-				Version:             "1.0.0",
-				SDKVersion:          "1.0.0",
-				Environment:         "env",
-				AgentName:           "agent.da.test",
-				IsGRPC:              true,
-				HostName:            hostname,
-				UseGRPCStatusUpdate: true,
-				RuntimeID:           runtimeID,
 			},
 		},
 	}

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -14,7 +14,7 @@ func TestFormatUserAgents(t *testing.T) {
 	agentVersion := "1.0.0"
 	sdkVersion := "1.0.0"
 	hostname, _ := os.Hostname()
-	runtimeId := uuid.New().String()
+	runtimeID := uuid.New().String()
 	tests := []struct {
 		name              string
 		expectedUserAgent string
@@ -23,7 +23,7 @@ func TestFormatUserAgents(t *testing.T) {
 		agentVersion      string
 		sdkVersion        string
 		isGRPC            bool
-		runtimeId         string
+		runtimeID         string
 	}{
 		{
 			name:              "test-1",
@@ -32,8 +32,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      "v1.0.0-125678e",
 			sdkVersion:        "v1.1.100",
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
-			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 		},
 		{
 			name:              "test-2",
@@ -42,8 +42,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
-			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 		},
 		{
 			name:              "test-3",
@@ -52,8 +52,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent.da.test",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
-			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 		},
 		{
 			name:              "test-4",
@@ -62,8 +62,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
-			runtimeId:         runtimeId,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
+			runtimeID:         runtimeID,
 		},
 		{
 			name:              "test-5",
@@ -73,7 +73,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, "test-runtimeId-1234567890-abcdefghijklmnopqrstuvwxyz"),
-			runtimeId:         "test-runtimeId-1234567890-abcdefghijklmnopqrstuvwxyz",
+			runtimeID:         "test-runtimeId-1234567890-abcdefghijklmnopqrstuvwxyz",
 		},
 		{
 			name:              "test-6",
@@ -83,7 +83,7 @@ func TestFormatUserAgents(t *testing.T) {
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
 			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s; runtimeId:%s)", hostname, "test-runtimeId-empty-agent"),
-			runtimeId:         "test-runtimeId-empty-agent",
+			runtimeID:         "test-runtimeId-empty-agent",
 		},
 	}
 	for _, tc := range tests {
@@ -95,7 +95,7 @@ func TestFormatUserAgents(t *testing.T) {
 				tc.envName,
 				tc.agentName,
 				tc.isGRPC,
-				tc.runtimeId,
+				tc.runtimeID,
 			)
 			formattedUserAgent := ua.FormatUserAgent()
 			assert.Equal(t, tc.expectedUserAgent, formattedUserAgent,
@@ -107,7 +107,7 @@ func TestFormatUserAgents(t *testing.T) {
 func TestParseUserAgents(t *testing.T) {
 	hostname, _ := os.Hostname()
 	hostname2 := "test-test.abc.com"
-	runtimeId := uuid.New().String()
+	runtimeID := uuid.New().String()
 	tests := []struct {
 		name       string
 		userAgent  string
@@ -115,7 +115,7 @@ func TestParseUserAgents(t *testing.T) {
 	}{
 		{
 			name:      "test-1",
-			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -126,7 +126,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           runtimeId,
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
@@ -142,12 +142,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           "",
+				RuntimeID:           "",
 			},
 		},
 		{
 			name:      "test-3",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s) grpc-go/1.65.0", hostname, runtimeId),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s) grpc-go/1.65.0", hostname, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -157,7 +157,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           runtimeId,
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           "",
+				RuntimeID:           "",
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-8",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeId:%s)", hostname2, runtimeId),
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeId:%s)", hostname2, runtimeID),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -219,7 +219,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           runtimeId,
+				RuntimeID:           runtimeID,
 			},
 		},
 		{
@@ -235,7 +235,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
-				RuntimeId:           "",
+				RuntimeID:           "",
 			},
 		},
 	}
@@ -255,7 +255,7 @@ func TestParseUserAgents(t *testing.T) {
 			assert.Equal(t, tc.expectedUA.IsGRPC, ua.IsGRPC)
 			assert.Equal(t, tc.expectedUA.HostName, ua.HostName)
 			assert.Equal(t, tc.expectedUA.UseGRPCStatusUpdate, ua.UseGRPCStatusUpdate)
-			assert.Equal(t, tc.expectedUA.RuntimeId, ua.RuntimeId)
+			assert.Equal(t, tc.expectedUA.RuntimeID, ua.RuntimeID)
 		})
 	}
 }

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -296,13 +296,13 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-10",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s) runtimeID/test-runtimeID-123", hostname),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s) runtimeID/test-runtimeID-123", hostname),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
 				SDKVersion:          "1.0.0",
 				Environment:         "env",
-				AgentName:           "agent",
+				AgentName:           "agent.da.test",
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,

--- a/pkg/util/useragent_test.go
+++ b/pkg/util/useragent_test.go
@@ -14,7 +14,7 @@ func TestFormatUserAgents(t *testing.T) {
 	agentVersion := "1.0.0"
 	sdkVersion := "1.0.0"
 	hostname, _ := os.Hostname()
-	runtimeID := uuid.New().String()
+	runtimeId := uuid.New().String()
 	tests := []struct {
 		name              string
 		expectedUserAgent string
@@ -23,7 +23,7 @@ func TestFormatUserAgents(t *testing.T) {
 		agentVersion      string
 		sdkVersion        string
 		isGRPC            bool
-		runtimeID         string
+		runtimeId         string
 	}{
 		{
 			name:              "test-1",
@@ -32,8 +32,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      "v1.0.0-125678e",
 			sdkVersion:        "v1.1.100",
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0-125678e (sdkVer:1.1.100; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeId:         runtimeId,
 		},
 		{
 			name:              "test-2",
@@ -42,8 +42,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:false; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeId:         runtimeId,
 		},
 		{
 			name:              "test-3",
@@ -52,8 +52,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent.da.test",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent.da.test; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeId:         runtimeId,
 		},
 		{
 			name:              "test-4",
@@ -62,8 +62,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
-			runtimeID:         runtimeID,
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:prod; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
+			runtimeId:         runtimeId,
 		},
 		{
 			name:              "test-5",
@@ -72,8 +72,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "agent",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz"),
-			runtimeID:         "test-runtimeID-1234567890-abcdefghijklmnopqrstuvwxyz",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, "test-runtimeId-1234567890-abcdefghijklmnopqrstuvwxyz"),
+			runtimeId:         "test-runtimeId-1234567890-abcdefghijklmnopqrstuvwxyz",
 		},
 		{
 			name:              "test-6",
@@ -82,8 +82,8 @@ func TestFormatUserAgents(t *testing.T) {
 			agentName:         "",
 			agentVersion:      agentVersion,
 			sdkVersion:        sdkVersion,
-			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s; runtimeID:%s)", hostname, "test-runtimeID-empty-agent"),
-			runtimeID:         "test-runtimeID-empty-agent",
+			expectedUserAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:; reactive:true; hostname:%s; runtimeId:%s)", hostname, "test-runtimeId-empty-agent"),
+			runtimeId:         "test-runtimeId-empty-agent",
 		},
 	}
 	for _, tc := range tests {
@@ -95,7 +95,7 @@ func TestFormatUserAgents(t *testing.T) {
 				tc.envName,
 				tc.agentName,
 				tc.isGRPC,
-				tc.runtimeID,
+				tc.runtimeId,
 			)
 			formattedUserAgent := ua.FormatUserAgent()
 			assert.Equal(t, tc.expectedUserAgent, formattedUserAgent,
@@ -107,7 +107,7 @@ func TestFormatUserAgents(t *testing.T) {
 func TestParseUserAgents(t *testing.T) {
 	hostname, _ := os.Hostname()
 	hostname2 := "test-test.abc.com"
-	runtimeID := uuid.New().String()
+	runtimeId := uuid.New().String()
 	tests := []struct {
 		name       string
 		userAgent  string
@@ -115,7 +115,7 @@ func TestParseUserAgents(t *testing.T) {
 	}{
 		{
 			name:      "test-1",
-			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s)", hostname, runtimeID),
+			userAgent: fmt.Sprintf("Test/1.0.0-7e7eb72d (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s)", hostname, runtimeId),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -126,7 +126,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           runtimeID,
+				RuntimeId:           runtimeId,
 			},
 		},
 		{
@@ -142,12 +142,12 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           "",
+				RuntimeId:           "",
 			},
 		},
 		{
 			name:      "test-3",
-			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeID:%s) grpc-go/1.65.0", hostname, runtimeID),
+			userAgent: fmt.Sprintf("Test/1.0.0 (sdkVer:1.0.0; env:env; agent:agent; reactive:true; hostname:%s; runtimeId:%s) grpc-go/1.65.0", hostname, runtimeId),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "Test",
 				Version:             "1.0.0",
@@ -157,7 +157,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           runtimeID,
+				RuntimeId:           runtimeId,
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           "",
+				RuntimeId:           "",
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestParseUserAgents(t *testing.T) {
 		},
 		{
 			name:      "test-8",
-			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeID:%s)", hostname2, runtimeID),
+			userAgent: fmt.Sprintf("WSO2DiscoveryAgent/1.0.0-65a0b4c (sdkVer:1.1.110; env:wso2; agent:wso2-da; reactive:true; hostname:%s; runtimeId:%s)", hostname2, runtimeId),
 			expectedUA: &CentralUserAgent{
 				AgentType:           "WSO2DiscoveryAgent",
 				Version:             "1.0.0",
@@ -219,7 +219,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           runtimeID,
+				RuntimeId:           runtimeId,
 			},
 		},
 		{
@@ -235,7 +235,7 @@ func TestParseUserAgents(t *testing.T) {
 				IsGRPC:              true,
 				HostName:            hostname2,
 				UseGRPCStatusUpdate: true,
-				RuntimeID:           "",
+				RuntimeId:           "",
 			},
 		},
 	}
@@ -255,7 +255,7 @@ func TestParseUserAgents(t *testing.T) {
 			assert.Equal(t, tc.expectedUA.IsGRPC, ua.IsGRPC)
 			assert.Equal(t, tc.expectedUA.HostName, ua.HostName)
 			assert.Equal(t, tc.expectedUA.UseGRPCStatusUpdate, ua.UseGRPCStatusUpdate)
-			assert.Equal(t, tc.expectedUA.RuntimeID, ua.RuntimeID)
+			assert.Equal(t, tc.expectedUA.RuntimeId, ua.RuntimeId)
 		})
 	}
 }

--- a/samples/watchclient/pkg/client/client.go
+++ b/samples/watchclient/pkg/client/client.go
@@ -10,6 +10,7 @@ import (
 	corecfg "github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/harvester"
 	"github.com/Axway/agent-sdk/pkg/util"
+	"github.com/google/uuid"
 
 	"github.com/sirupsen/logrus"
 
@@ -141,7 +142,7 @@ func NewWatchClient(config *Config, logger logrus.FieldLogger) (*WatchClient, er
 		Port:        uint32(ccfg.GRPCCfg.Port),
 		TenantID:    config.TenantID,
 		TokenGetter: ta.GetToken,
-		UserAgent:   util.NewUserAgent("SampleClient", "0.0.1", "0.0.1", "testenvironment", "testagent", true).FormatUserAgent(),
+		UserAgent:   util.NewUserAgent("SampleClient", "0.0.1", "0.0.1", "testenvironment", "testagent", true, uuid.New().String()).FormatUserAgent(),
 	}
 
 	w, err := wm.New(cfg, watchOptions...)


### PR DESCRIPTION
1. create runtime ID at startup
2. add it to the user agent
3. update process to rebuild cache
4. hardening to ensure cache is built properly