### PR TITLE
APIGOV-31178 - do not stop request queue within request queue

### DIFF
--- a/pkg/agent/events/requestqueue.go
+++ b/pkg/agent/events/requestqueue.go
@@ -52,10 +52,8 @@ func (q *requestQueue) Stop() {
 	}
 
 	defer q.isActive.Store(false)
-	if q.cancel != nil {
-		q.cancel()
-		close(q.receiveCh)
-	}
+	q.cancel()
+	close(q.receiveCh)
 }
 
 func (q *requestQueue) IsActive() bool {
@@ -79,7 +77,6 @@ func (q *requestQueue) Start() {
 
 		for {
 			if q.process() {
-				q.Stop()
 				break
 			}
 		}


### PR DESCRIPTION
Remove the stopping of the request queue from the main loop of the request queue. An outside process will cancel the context or stop the request queue directly. 