### PR TITLE
APIGOV-31305 use registration client uri when available

### DIFF
--- a/pkg/apic/provisioning/idp/provisioner.go
+++ b/pkg/apic/provisioning/idp/provisioner.go
@@ -147,6 +147,8 @@ func (p *provisioner) RegisterClient() error {
 	p.credentialData.clientID = resClientMetadata.GetClientID()
 	p.credentialData.clientSecret = resClientMetadata.GetClientSecret()
 
+	util.SetAgentDetailsKey(p.credential, "registrationClientURI", resClientMetadata.GetRegistrationClientURI())
+
 	return nil
 }
 
@@ -155,7 +157,9 @@ func (p *provisioner) UnregisterClient() error {
 		return nil
 	}
 
-	err := p.idpProvider.UnregisterClient(p.credentialData.GetClientID(), p.credentialData.registrationAccessToken)
+	registrationClientURI, _ := util.GetAgentDetailsValue(p.credential, "registrationClientURI")
+
+	err := p.idpProvider.UnregisterClient(p.credentialData.GetClientID(), p.credentialData.registrationAccessToken, registrationClientURI)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/oauth/clientmetadata.go
+++ b/pkg/authz/oauth/clientmetadata.go
@@ -46,6 +46,7 @@ type ClientMetadata interface {
 	GetTLSClientAuthSanIP() string
 	GetTLSClientAuthSanURI() string
 	GetRegistrationAccessToken() string
+	GetRegistrationClientURI() string
 }
 
 type clientMetadata struct {
@@ -72,6 +73,7 @@ type clientMetadata struct {
 	TLSClientAuthSanIP      string                 `json:"tls_client_auth_san_ip,omitempty"`
 	TLSClientAuthSanURI     string                 `json:"tls_client_auth_san_uri,omitempty"`
 	RegistrationAccessToken string                 `json:"registration_access_token,omitempty"`
+	RegistrationClientURI   string                 `json:"registration_client_uri,omitempty"`
 	extraProperties         map[string]string      `json:"-"`
 }
 
@@ -181,6 +183,10 @@ func (c *clientMetadata) GetTLSClientAuthSanURI() string {
 
 func (c *clientMetadata) GetRegistrationAccessToken() string {
 	return c.RegistrationAccessToken
+}
+
+func (c *clientMetadata) GetRegistrationClientURI() string {
+	return c.RegistrationClientURI
 }
 
 // MarshalJSON serialize the client metadata with provider metadata

--- a/pkg/authz/oauth/mockidpserver.go
+++ b/pkg/authz/oauth/mockidpserver.go
@@ -24,6 +24,7 @@ type MockIDPServer interface {
 	SetTokenResponse(accessToken string, expiry time.Duration, statusCode int)
 	SetRegistrationResponseCode(statusCode int)
 	SetUseRegistrationAccessToken(useRegistrationAccessToken bool)
+	SetRegistrationClientURI(registrationClientURI string)
 	GetTokenRequestHeaders() http.Header
 	GetTokenQueryParams() url.Values
 	GetTokenRequestValues() url.Values
@@ -38,6 +39,7 @@ type mockIDPServer struct {
 	registerResponseCode       int
 	useRegistrationAccessToken bool
 	accessToken                string
+	registrationClientURI      string
 	tokenExpiry                time.Duration
 	serverMetadata             *AuthorizationServerMetadata
 	server                     *httptest.Server
@@ -129,6 +131,9 @@ func (m *mockIDPServer) handleRequest(resp http.ResponseWriter, req *http.Reques
 			if m.useRegistrationAccessToken {
 				cl.RegistrationAccessToken = uuid.New().String()
 			}
+			if m.registrationClientURI != "" {
+				cl.RegistrationClientURI = m.registrationClientURI
+			}
 			clientBuf, _ = json.Marshal(cl)
 			resp.Write(clientBuf)
 		}
@@ -178,6 +183,10 @@ func (m *mockIDPServer) SetRegistrationResponseCode(statusCode int) {
 
 func (m *mockIDPServer) SetUseRegistrationAccessToken(useRegistrationAccessToken bool) {
 	m.useRegistrationAccessToken = useRegistrationAccessToken
+}
+
+func (m *mockIDPServer) SetRegistrationClientURI(registrationClientURI string) {
+	m.registrationClientURI = registrationClientURI
 }
 
 func (m *mockIDPServer) GetTokenRequestHeaders() http.Header {

--- a/pkg/authz/oauth/provider_test.go
+++ b/pkg/authz/oauth/provider_test.go
@@ -146,6 +146,7 @@ func TestProvider(t *testing.T) {
 				extraProperties: map[string]string{
 					"key": "value",
 				},
+				RegistrationClientURI: "https://idp.example.com/clients/test-client-id",
 			},
 			authServerMetadata:         &AuthorizationServerMetadata{},
 			registrationResponseCode:   http.StatusCreated,
@@ -200,6 +201,11 @@ func TestProvider(t *testing.T) {
 			}
 
 			s.SetRegistrationResponseCode(tc.registrationResponseCode)
+
+			if tc.expectedClient != nil && tc.expectedClient.RegistrationClientURI != "" {
+				s.SetRegistrationClientURI(tc.expectedClient.RegistrationClientURI)
+			}
+
 			cr, err := p.RegisterClient(tc.clientRequest)
 			if tc.expectRegistrationErr {
 				assert.NotNil(t, err)
@@ -220,8 +226,9 @@ func TestProvider(t *testing.T) {
 			assert.Equal(t, strings.Join(tc.expectedClient.GetScopes(), ","), strings.Join(cr.GetScopes(), ","))
 			assert.Equal(t, tc.expectedClient.GetJwksURI(), cr.GetJwksURI())
 			assert.Equal(t, len(tc.expectedClient.GetExtraProperties()), len(cr.GetExtraProperties()))
+			assert.Equal(t, tc.expectedClient.RegistrationClientURI, cr.GetRegistrationClientURI())
 			s.SetRegistrationResponseCode(tc.unRegistrationResponseCode)
-			err = p.UnregisterClient(cr.GetClientID(), cr.GetRegistrationAccessToken())
+			err = p.UnregisterClient(cr.GetClientID(), cr.GetRegistrationAccessToken(), tc.expectedClient.GetRegistrationClientURI())
 			if tc.expectUnRegistrationErr {
 				assert.NotNil(t, err)
 				return


### PR DESCRIPTION
When IDP unregistration is happening, some IDPs provide the whole registration client uri. In that case, we don't need to compose the unregistration url ourselves, but instead use that registration client uri