### PR TITLE
APIGOV-SDB01 - fix deatlock found in unit test

### DIFF
--- a/pkg/traceability/sampling/sample.go
+++ b/pkg/traceability/sampling/sample.go
@@ -138,10 +138,14 @@ func (s *sample) sampleEndpointAndOnlyErrors(apiID string) (bool, bool) {
 	return true, s.endpointsSampling.endpointsInfo[apiID] // endpoint found, return onlyErrors
 }
 
-func (s *sample) resetEndpointSampling() {
+func (s *sample) hasRemainingEndpoints() bool {
 	s.endpointsSampling.endpointsLock.Lock()
 	defer s.endpointsSampling.endpointsLock.Unlock()
-	if len(s.endpointsSampling.endpointsInfo) > 0 {
+	return len(s.endpointsSampling.endpointsInfo) > 0
+}
+
+func (s *sample) resetEndpointSampling() {
+	if s.hasRemainingEndpoints() {
 		return
 	}
 	s.endpointsSampling.enabled.Store(false)


### PR DESCRIPTION
resetEndpointSampling was holding endpointsLock across a call to stopCounterResetter(), which does a blocking channel send. This caused a deadlock: the channel receiver (samplingCounterReset) was blocked on samplingLock, which was held by ShouldSampleTransaction goroutines that were in turn waiting on endpointsLock.

Fixed by extracting hasRemainingEndpoints() to scope the lock to just the map read — defer now fires at the right time, and the channel send in stopCounterResetter() happens completely lock-free.