### PR TITLE
APIGOV-32873 - IdP resource management fixes

### DIFF
--- a/pkg/apic/client.go
+++ b/pkg/apic/client.go
@@ -951,9 +951,7 @@ func (c *ServiceClient) updateSpecORCreateResourceInstance(data *apiv1.ResourceI
 		}
 	}
 
-	if existingRI == nil {
-		c.addResourceToCache(newRI)
-	}
+	c.addResourceToCache(newRI)
 	return newRI, err
 }
 

--- a/pkg/authz/oauth/idplifecycle.go
+++ b/pkg/authz/oauth/idplifecycle.go
@@ -25,6 +25,7 @@ type IDPClient interface {
 	GetAPIV1ResourceInstances(query map[string]string, URL string) ([]*apiv1.ResourceInstance, error)
 	CreateOrUpdateResource(ri apiv1.Interface) (*apiv1.ResourceInstance, error)
 	CreateSubResource(rm apiv1.ResourceMeta, subs map[string]interface{}) error
+	GetResource(url string) (*apiv1.ResourceInstance, error)
 }
 
 // IDPEngageLifecycle manages IdentityProvider and IdentityProviderMetadata resources in Engage.
@@ -87,32 +88,46 @@ func (l *idpEngageLifecycle) CreateEngageResourcesFromMetadata(idpLogger log.Fie
 		return "", err
 	}
 
-	ri, err := l.client.CreateOrUpdateResource(idpResource)
+	// Check if an IdentityProvider with the same name already exists
+	ri, err := l.client.GetResource(idpResource.GetSelfLink())
 	if err != nil {
-		idpLogger.WithError(err).Error("unable to create IdentityProvider resource in Engage")
 		return "", err
 	}
-	if err = idpResource.FromInstance(ri); err != nil {
-		idpLogger.WithError(err).Error("failed to parse created IdentityProvider resource")
-		return "", err
+
+	if ri == nil {
+		ri, err = l.client.CreateOrUpdateResource(idpResource)
+		if err != nil {
+			idpLogger.WithError(err).Error("unable to create IdentityProvider resource in Engage")
+			return "", err
+		}
+		if err = idpResource.FromInstance(ri); err != nil {
+			idpLogger.WithError(err).Error("failed to parse created IdentityProvider resource")
+			return "", err
+		}
+		if err = l.applyPolicies(idpLogger, idpResource, envPolicies); err != nil {
+			return "", err
+		}
+		idpLogger.WithField("name", ri.GetName()).Info("IdentityProvider resource created successfully")
 	}
+
 	createdName := idpResource.Name
-
-	if err = l.applyPolicies(idpLogger, idpResource, envPolicies); err != nil {
-		return "", err
+	if ri != nil {
+		createdName = ri.GetName()
 	}
 
-	if err = l.createMetadataFromServerMetadata(idpLogger, idpCfg, createdName, metadata); err != nil {
+	if idpMetadata, err = l.createMetadataFromServerMetadata(idpLogger, idpCfg, createdName, metadata); err != nil {
 		return "", err
 	}
-
-	idpLogger.WithField("name", createdName).Info("IdentityProvider resource created successfully")
+	idpLogger.WithField("idpName", createdName).
+		WithField("name", idpMetadata.GetName()).
+		Info("IdentityProviderMetadata resource created successfully")
 	return createdName, nil
 }
 
 func (l *idpEngageLifecycle) buildIdentityProviderFromMetadata(idpLogger log.FieldLogger, idpCfg corecfg.IDPConfig, idpType, idpName string) (*management.IdentityProvider, error) {
 	name := util.NormalizeNameForCentral(idpName)
 	res := management.NewIdentityProvider(name)
+	res.Title = name
 	res.Spec = management.IdentityProviderSpec{
 		ProviderType:  idpType,
 		ClientTimeout: defaultIDPClientTimeoutSeconds,
@@ -120,20 +135,20 @@ func (l *idpEngageLifecycle) buildIdentityProviderFromMetadata(idpLogger log.Fie
 	return res, nil
 }
 
-func (l *idpEngageLifecycle) createMetadataFromServerMetadata(idpLogger log.FieldLogger, idpCfg corecfg.IDPConfig, idpName string, metadata *AuthorizationServerMetadata) error {
+func (l *idpEngageLifecycle) createMetadataFromServerMetadata(idpLogger log.FieldLogger, idpCfg corecfg.IDPConfig, idpName string, metadata *AuthorizationServerMetadata) (*apiv1.ResourceInstance, error) {
 	idpLogger.WithField("name", idpName).Debug("creating IdentityProviderMetadata resource")
 
-	idpMetadata := newIdentityProviderMetadata(idpName, idpName, metadata)
+	idpMetadata := newIdentityProviderMetadata("", idpName, metadata)
 
 	ri, err := l.client.CreateOrUpdateResource(idpMetadata)
 	if err != nil {
 		idpLogger.WithField("name", idpName).WithError(err).Warn("unable to create IdentityProviderMetadata resource in Engage")
-		return err
+		return nil, err
 	}
 	l.idpCache.AddIdentityProviderMetadata(ri)
 
 	idpLogger.WithField("name", idpName).Info("IdentityProviderMetadata resource created successfully")
-	return nil
+	return ri, nil
 }
 
 func (l *idpEngageLifecycle) applyPolicies(idpLogger log.FieldLogger, idpResource *management.IdentityProvider, envPolicies management.EnvironmentPoliciesCredentials) error {
@@ -168,6 +183,7 @@ func (l *idpEngageLifecycle) applyPolicies(idpLogger log.FieldLogger, idpResourc
 
 func newIdentityProviderMetadata(name, scopeName string, m *AuthorizationServerMetadata) *management.IdentityProviderMetadata {
 	res := management.NewIdentityProviderMetadata(name, scopeName)
+	res.Title = name
 	res.Spec = management.IdentityProviderMetadataSpec{
 		Issuer:                m.Issuer,
 		AuthorizationEndpoint: m.AuthorizationEndpoint,

--- a/pkg/authz/oauth/idplifecycle_test.go
+++ b/pkg/authz/oauth/idplifecycle_test.go
@@ -18,6 +18,7 @@ type mockIDPClient struct {
 	getInstances   func(map[string]string, string) ([]*apiv1.ResourceInstance, error)
 	createOrUpdate func(apiv1.Interface) (*apiv1.ResourceInstance, error)
 	createSubRes   func(apiv1.ResourceMeta, map[string]interface{}) error
+	getResource    func(string) (*apiv1.ResourceInstance, error)
 }
 
 func (m *mockIDPClient) GetAPIV1ResourceInstances(q map[string]string, url string) ([]*apiv1.ResourceInstance, error) {
@@ -28,6 +29,12 @@ func (m *mockIDPClient) CreateOrUpdateResource(ri apiv1.Interface) (*apiv1.Resou
 }
 func (m *mockIDPClient) CreateSubResource(rm apiv1.ResourceMeta, subs map[string]interface{}) error {
 	return m.createSubRes(rm, subs)
+}
+func (m *mockIDPClient) GetResource(url string) (*apiv1.ResourceInstance, error) {
+	if m.getResource == nil {
+		return nil, nil
+	}
+	return m.getResource(url)
 }
 
 // mockIdpCache satisfies idpCache for lifecycle tests.
@@ -167,6 +174,9 @@ func TestCreateEngageResourcesIDPCreateError(t *testing.T) {
 				getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
 					return []*apiv1.ResourceInstance{}, nil
 				},
+				getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+					return nil, nil
+				},
 				createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
 					created++
 					return nil, errors.New("create error")
@@ -200,6 +210,9 @@ func TestCreateEngageResourcesPolicyError(t *testing.T) {
 			client := &mockIDPClient{
 				getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
 					return []*apiv1.ResourceInstance{}, nil
+				},
+				getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+					return nil, nil
 				},
 				createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
 					created++
@@ -240,6 +253,9 @@ func TestCreateEngageResourcesMetadataWriteError(t *testing.T) {
 			client := &mockIDPClient{
 				getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
 					return []*apiv1.ResourceInstance{}, nil
+				},
+				getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+					return nil, nil
 				},
 				createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
 					created++
@@ -287,6 +303,9 @@ func TestCreateEngageResourcesSuccess(t *testing.T) {
 				getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
 					return []*apiv1.ResourceInstance{}, nil
 				},
+				getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+					return nil, nil
+				},
 				createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
 					created++
 					inst, _ := ri.AsInstance()
@@ -313,6 +332,55 @@ func TestCreateEngageResourcesSuccess(t *testing.T) {
 			assert.Equal(t, tc.wantSubRes, subResCalled)
 		})
 	}
+}
+
+func TestCreateEngageResourcesGetResourceError(t *testing.T) {
+	created := 0
+	client := &mockIDPClient{
+		getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
+			return []*apiv1.ResourceInstance{}, nil
+		},
+		getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+			return nil, errors.New("get resource error")
+		},
+		createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
+			created++
+			inst, _ := ri.AsInstance()
+			return inst, nil
+		},
+		createSubRes: noOpCreateSubRes,
+	}
+
+	metadata, idpCfg := makeTestMetadata(t)
+	_, err := NewIDPEngageLifecycle(client, newMockIdpCache()).CreateEngageResourcesFromMetadata(newTestLogger(), idpCfg, idpCfg.GetIDPType(), idpCfg.GetIDPName(), metadata, "/env", management.EnvironmentPoliciesCredentials{})
+	assert.Error(t, err)
+	assert.Equal(t, 0, created)
+}
+
+func TestCreateEngageResourcesIDPFoundViaGetResource(t *testing.T) {
+	// When GetResource finds an existing IDP, creation is skipped but metadata is still created.
+	created := 0
+	existingIDP := idpRI("existing-idp")
+	client := &mockIDPClient{
+		getInstances: func(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
+			return []*apiv1.ResourceInstance{}, nil
+		},
+		getResource: func(_ string) (*apiv1.ResourceInstance, error) {
+			return existingIDP, nil
+		},
+		createOrUpdate: func(ri apiv1.Interface) (*apiv1.ResourceInstance, error) {
+			created++
+			inst, _ := ri.AsInstance()
+			return inst, nil
+		},
+		createSubRes: noOpCreateSubRes,
+	}
+
+	metadata, idpCfg := makeTestMetadata(t)
+	resultName, err := NewIDPEngageLifecycle(client, newMockIdpCache()).CreateEngageResourcesFromMetadata(newTestLogger(), idpCfg, idpCfg.GetIDPType(), idpCfg.GetIDPName(), metadata, "/env", management.EnvironmentPoliciesCredentials{})
+	assert.NoError(t, err)
+	assert.Equal(t, existingIDP.GetName(), resultName)
+	assert.Equal(t, 1, created, "only metadata should be created when IDP already exists")
 }
 
 func newTestLogger() log.FieldLogger {

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -559,7 +559,7 @@ func TestRootCommandLoggerStdout(t *testing.T) {
 	scanner := bufio.NewScanner(r)
 
 	level := "info"
-	msg := "Starting test_with_non_defaults version -, Amplify Agents SDK version "
+	msg := "Starting test_with_non_defaults"
 
 	for scanner.Scan() {
 		out := scanner.Text()

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/cmd/properties"
+	"github.com/Axway/agent-sdk/pkg/config"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -581,6 +582,13 @@ func TestRootCommandLoggerFile(t *testing.T) {
 
 	s := newTestServer()
 	defer s.Close()
+	defer func() {
+		config.AgentVersion = ""
+		SDKBuildVersion = ""
+	}()
+
+	config.AgentVersion = "1.2.3-abc123"
+	SDKBuildVersion = "1.0.0"
 
 	os.Setenv("CENTRAL_AUTH_PRIVATEKEY", "../transaction/testdata/private_key.pem")
 	os.Setenv("CENTRAL_AUTH_PUBLICKEY", "../transaction/testdata/public_key")
@@ -614,7 +622,7 @@ func TestRootCommandLoggerFile(t *testing.T) {
 
 	var logData map[string]string
 	level := "info"
-	msg := "Starting test_with_non_defaults version -, Amplify Agents SDK version "
+	msg := "Starting test_with_non_defaults"
 
 	for scanner.Scan() {
 		out := scanner.Text()
@@ -627,6 +635,8 @@ func TestRootCommandLoggerFile(t *testing.T) {
 
 	assert.Equal(t, level, logData["level"])
 	assert.Equal(t, msg, logData["message"])
+	assert.Equal(t, "1.2.3-abc123", logData["version"])
+	assert.Equal(t, "1.0.0", logData["sdkVersion"])
 }
 
 func TestRootCommandLoggerStdoutAndFile(t *testing.T) {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -413,7 +413,10 @@ func (c *agentRootCommand) run(cmd *cobra.Command, args []string) (err error) {
 			os.Exit(exitcode)
 		}
 
-		log.Infof("Starting %s", buildAgentInfo(c.rootCmd.Short))
+		log.NewFieldLogger().
+			WithField("version", config.AgentVersion).
+			WithField("sdkVersion", SDKBuildVersion).
+			Infof("Starting %s", c.rootCmd.Short)
 		if c.commandHandler != nil {
 			// Setup logp to use beats logger.
 			// Setting up late here as log entries for agent/command initialization are not logged


### PR DESCRIPTION
- Fix to avoid 409 conflict error when creating IdP resource
- Fix to create idp metadata resource without setting logic name to allow creating multiple idp metadata for same IdP
- Fix to cache resource with updated subresources when updating existing resource with CreateORUpdate calls