### PR TITLE
APIGOV-33315 - use environment reference to determine managed unmanaged value

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -426,6 +426,7 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	}
 
 	cfg.SetAxwayManaged(env.Spec.AxwayManaged)
+	cfg.SetUnmanagedEnvironment(len(env.References.ManagedEnvironments) > 0)
 	if cfg.GetEnvironmentID() == "" {
 		// need to save this ID for the traceability agent for later
 		cfg.SetEnvironmentID(env.Metadata.ID)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -426,7 +426,11 @@ func initEnvResources(cfg config.CentralConfig, client apic.Client) error {
 	}
 
 	cfg.SetAxwayManaged(env.Spec.AxwayManaged)
+
+	// a non-empty ManagedEnvironments list means this environment references other
+	// (managed) environments, making this one a clone, i.e. unmanaged
 	cfg.SetUnmanagedEnvironment(len(env.References.ManagedEnvironments) > 0)
+
 	if cfg.GetEnvironmentID() == "" {
 		// need to save this ID for the traceability agent for later
 		cfg.SetEnvironmentID(env.Metadata.ID)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -7,15 +7,22 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/Axway/agent-sdk/pkg/apic"
-	"github.com/Axway/agent-sdk/pkg/apic/definitions"
-
-	"github.com/Axway/agent-sdk/pkg/util/log"
-
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1"
+	"github.com/Axway/agent-sdk/pkg/apic/definitions"
 	"github.com/Axway/agent-sdk/pkg/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/Axway/agent-sdk/pkg/util/log"
+)
+
+const (
+	testDataplaneV7          = "v7-dataplane"
+	testAuthTokenResponse    = `{"access_token":"somevalue","expires_in": 12235677}`
+	testEnvironmentsV7URL    = "/apis/management/v1/environments/v7"
+	testDiscoveryAgentsV7URL = testEnvironmentsV7URL + "/discoveryagents/"
+	testPlatformTeamsURL     = "/api/v1/platformTeams"
 )
 
 func resetResources() {
@@ -139,18 +146,18 @@ func TestAgentInitialize(t *testing.T) {
 			Title:    "v7",
 		},
 	}
-	discoveryAgentRes := createDiscoveryAgentRes("111", daName, "v7-dataplane", "")
-	traceabilityAgentRes := createTraceabilityAgentRes("111", taName, "v7-dataplane", false)
+	discoveryAgentRes := createDiscoveryAgentRes("111", daName, testDataplaneV7, "")
+	traceabilityAgentRes := createTraceabilityAgentRes("111", taName, testDataplaneV7, false)
 	complianceAgentRes := createComplianceAgentRes("111", caName, "ca-dataplane")
 
 	s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.RequestURI, "/auth") {
-			token := "{\"access_token\":\"somevalue\",\"expires_in\": 12235677}"
+			token := testAuthTokenResponse
 			resp.Write([]byte(token))
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7/discoveryagents/"+daName) {
+		if strings.Contains(req.RequestURI, testDiscoveryAgentsV7URL+daName) {
 			buf, err := json.Marshal(discoveryAgentRes)
 			log.Error(err)
 			resp.Write(buf)
@@ -171,13 +178,13 @@ func TestAgentInitialize(t *testing.T) {
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7") {
+		if strings.Contains(req.RequestURI, testEnvironmentsV7URL) {
 			buf, _ := json.Marshal(environmentRes)
 			resp.Write(buf)
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/api/v1/platformTeams") {
+		if strings.Contains(req.RequestURI, testPlatformTeamsURL) {
 			buf, _ := json.Marshal(teams)
 			resp.Write(buf)
 			return
@@ -238,7 +245,7 @@ func TestAgentInitialize(t *testing.T) {
 	assert.True(t, agentCfg.resourceChanged)
 
 	// Test for resource change
-	traceabilityAgentRes = createTraceabilityAgentRes("111", taName, "v7-dataplane", true)
+	traceabilityAgentRes = createTraceabilityAgentRes("111", taName, testDataplaneV7, true)
 	resetResources()
 
 	agentResChangeHandlerCall := 0
@@ -275,29 +282,29 @@ func TestAgentEntitlements(t *testing.T) {
 			Title:    "v7",
 		},
 	}
-	discoveryAgentRes := createDiscoveryAgentRes("111", daName, "v7-dataplane", "")
+	discoveryAgentRes := createDiscoveryAgentRes("111", daName, testDataplaneV7, "")
 
 	s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.RequestURI, "/auth") {
-			token := "{\"access_token\":\"somevalue\",\"expires_in\": 12235677}"
+			token := testAuthTokenResponse
 			resp.Write([]byte(token))
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7/discoveryagents/"+daName) {
+		if strings.Contains(req.RequestURI, testDiscoveryAgentsV7URL+daName) {
 			buf, err := json.Marshal(discoveryAgentRes)
 			log.Error(err)
 			resp.Write(buf)
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7") {
+		if strings.Contains(req.RequestURI, testEnvironmentsV7URL) {
 			buf, _ := json.Marshal(environmentRes)
 			resp.Write(buf)
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/api/v1/platformTeams") {
+		if strings.Contains(req.RequestURI, testPlatformTeamsURL) {
 			buf, _ := json.Marshal(teams)
 			resp.Write(buf)
 			return
@@ -346,12 +353,12 @@ func TestInitEnvironment(t *testing.T) {
 
 	s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.RequestURI, "/auth") {
-			token := "{\"access_token\":\"somevalue\",\"expires_in\": 12235677}"
+			token := testAuthTokenResponse
 			resp.Write([]byte(token))
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7") {
+		if strings.Contains(req.RequestURI, testEnvironmentsV7URL) {
 			if req.Method == "GET" {
 				buf, _ := json.Marshal(environmentRes)
 				resp.Write(buf)
@@ -363,7 +370,7 @@ func TestInitEnvironment(t *testing.T) {
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/api/v1/platformTeams") {
+		if strings.Contains(req.RequestURI, testPlatformTeamsURL) {
 			buf, _ := json.Marshal(teams)
 			resp.Write(buf)
 			return
@@ -396,6 +403,80 @@ func TestInitEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// TestInitEnvResourcesUnmanagedEnvironment verifies that initEnvResources derives the
+// unmanaged-environment flag from the Environment resource's References.ManagedEnvironments,
+// independent of AxwayManaged (which reflects hosting location, not clone/reference status).
+func TestInitEnvResourcesUnmanagedEnvironment(t *testing.T) {
+	cases := map[string]struct {
+		managedEnvironments []string
+		axwayManaged        bool
+		wantUnmanaged       bool
+	}{
+		"no environment references reports managed": {
+			managedEnvironments: nil,
+			wantUnmanaged:       false,
+		},
+		"environment referencing another environment reports unmanaged": {
+			managedEnvironments: []string{"real-env"},
+			wantUnmanaged:       true,
+		},
+		"multiple environment references reports unmanaged": {
+			managedEnvironments: []string{"real-env-1", "real-env-2"},
+			wantUnmanaged:       true,
+		},
+		"axway-managed hosting with environment references still reports unmanaged": {
+			managedEnvironments: []string{"real-env"},
+			axwayManaged:        true,
+			wantUnmanaged:       true,
+		},
+		"axway-managed hosting with no environment references reports managed": {
+			managedEnvironments: nil,
+			axwayManaged:        true,
+			wantUnmanaged:       false,
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			environmentRes := management.NewEnvironment("v7")
+			environmentRes.Title = "v7"
+			environmentRes.Metadata.ID = "123"
+			environmentRes.Spec.AxwayManaged = tc.axwayManaged
+			environmentRes.References.ManagedEnvironments = tc.managedEnvironments
+
+			s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				if strings.Contains(req.RequestURI, "/auth") {
+					resp.Write([]byte(testAuthTokenResponse))
+					return
+				}
+				if strings.Contains(req.RequestURI, testEnvironmentsV7URL) {
+					buf, _ := json.Marshal(environmentRes)
+					resp.Write(buf)
+					return
+				}
+				if strings.Contains(req.RequestURI, testPlatformTeamsURL) {
+					resp.Write([]byte("[]"))
+					return
+				}
+			}))
+			defer s.Close()
+
+			cfg := createCentralCfg(s.URL, "v7")
+			cfg.AgentType = config.TraceabilityAgent
+			cfg.SetTeamID("existing-team-id") // skip the team lookup call, not under test here
+			agent.cfg = cfg
+			initializeTokenRequester(agent.cfg)
+			apiClient := apic.New(agent.cfg, agent.tokenRequester, agent.cacheManager)
+
+			defer resetResources()
+			err := initEnvResources(agent.cfg, apiClient)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.wantUnmanaged, cfg.IsUnmanagedEnvironment())
+		})
+	}
+}
+
 func TestAgentConfigOverride(t *testing.T) {
 	const (
 		daName = "discovery"
@@ -416,16 +497,16 @@ func TestAgentConfigOverride(t *testing.T) {
 			Title:    "v7",
 		},
 	}
-	discoveryAgentRes := createDiscoveryAgentRes("111", daName, "v7-dataplane", "")
-	traceabilityAgentRes := createTraceabilityAgentRes("111", taName, "v7-dataplane", false)
+	discoveryAgentRes := createDiscoveryAgentRes("111", daName, testDataplaneV7, "")
+	traceabilityAgentRes := createTraceabilityAgentRes("111", taName, testDataplaneV7, false)
 
 	s := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.Contains(req.RequestURI, "/auth") {
-			token := "{\"access_token\":\"somevalue\",\"expires_in\": 12235677}"
+			token := testAuthTokenResponse
 			resp.Write([]byte(token))
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7/discoveryagents/"+daName) {
+		if strings.Contains(req.RequestURI, testDiscoveryAgentsV7URL+daName) {
 			buf, _ := json.Marshal(discoveryAgentRes)
 			resp.Write(buf)
 			return
@@ -437,13 +518,13 @@ func TestAgentConfigOverride(t *testing.T) {
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/apis/management/v1/environments/v7") {
+		if strings.Contains(req.RequestURI, testEnvironmentsV7URL) {
 			buf, _ := json.Marshal(environmentRes)
 			resp.Write(buf)
 			return
 		}
 
-		if strings.Contains(req.RequestURI, "/api/v1/platformTeams") {
+		if strings.Contains(req.RequestURI, testPlatformTeamsURL) {
 			buf, _ := json.Marshal(teams)
 			resp.Write(buf)
 			return

--- a/pkg/config/centralconfig.go
+++ b/pkg/config/centralconfig.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorhill/cronexpr"
+
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	mv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1"
 	"github.com/Axway/agent-sdk/pkg/cmd/properties"
 	"github.com/Axway/agent-sdk/pkg/util"
 	"github.com/Axway/agent-sdk/pkg/util/exception"
 	"github.com/Axway/agent-sdk/pkg/util/log"
-	"github.com/gorhill/cronexpr"
 )
 
 const (
@@ -177,6 +178,8 @@ type CentralConfig interface {
 	SetEnvironmentID(environmentID string)
 	IsAxwayManaged() bool
 	SetAxwayManaged(isAxwayManaged bool)
+	IsUnmanagedEnvironment() bool
+	SetUnmanagedEnvironment(isUnmanaged bool)
 	GetEnvironmentName() string
 	GetAgentName() string
 	GetTeamName() string
@@ -278,6 +281,7 @@ type CentralConfiguration struct {
 	isSingleURLSet            bool
 	isRegionSet               bool
 	isAxwayManaged            bool
+	isUnmanagedEnvironment    bool
 	WatchResourceFilters      []ResourceFilter
 
 	qaVars bool
@@ -379,14 +383,25 @@ func (c *CentralConfiguration) SetEnvironmentID(environmentID string) {
 	c.environmentID = environmentID
 }
 
-// IsAxwayManaged - Returns the environment ID
+// IsAxwayManaged - Returns true if the environment is hosted in the Axway Managed Cloud
 func (c *CentralConfiguration) IsAxwayManaged() bool {
 	return c.isAxwayManaged
 }
 
-// SetAxwayManaged - Sets the environment ID
+// SetAxwayManaged - Sets whether the environment is hosted in the Axway Managed Cloud
 func (c *CentralConfiguration) SetAxwayManaged(isManaged bool) {
 	c.isAxwayManaged = isManaged
+}
+
+// IsUnmanagedEnvironment - Returns true if the environment references other environments,
+// meaning its API data is a derived clone rather than gateway-discovered
+func (c *CentralConfiguration) IsUnmanagedEnvironment() bool {
+	return c.isUnmanagedEnvironment
+}
+
+// SetUnmanagedEnvironment - Sets whether the environment references other environments
+func (c *CentralConfiguration) SetUnmanagedEnvironment(isUnmanaged bool) {
+	c.isUnmanagedEnvironment = isUnmanaged
 }
 
 // GetEnvironmentName - Returns the environment name

--- a/pkg/transaction/metric/contract_test.go
+++ b/pkg/transaction/metric/contract_test.go
@@ -70,7 +70,7 @@ func TestContractMetricV3(t *testing.T) {
 			check: func(t *testing.T, cm *centralMetric, raw string) {
 				assert.Equal(t, "3", cm.Version)
 				require.NotNil(t, cm.Environment)
-				assert.Equal(t, runtimeTypeUnmanaged, cm.Environment.RuntimeType)
+				assert.Equal(t, runtimeTypeManaged, cm.Environment.RuntimeType)
 
 				event := V4Event{
 					Version: "4",

--- a/pkg/transaction/metric/util.go
+++ b/pkg/transaction/metric/util.go
@@ -75,10 +75,10 @@ func centralConfigFields() (apicDeployment, agentName, runtimeType string) {
 	if cfg == nil {
 		return
 	}
-	if cfg.IsAxwayManaged() {
-		runtimeType = runtimeTypeManaged
-	} else {
+	if cfg.IsUnmanagedEnvironment() {
 		runtimeType = runtimeTypeUnmanaged
+	} else {
+		runtimeType = runtimeTypeManaged
 	}
 	apicDeployment = cfg.GetAPICDeployment()
 	agentName = cfg.GetAgentName()

--- a/pkg/transaction/metric/util_test.go
+++ b/pkg/transaction/metric/util_test.go
@@ -472,14 +472,14 @@ func TestCentralConfigFields(t *testing.T) {
 			wantRuntime:            runtimeTypeUnmanaged,
 			wantAgentName:          "agent-clone",
 		},
-		"axway-managed hosting has no bearing on runtime type when environment has references": {
+		"axway-managed hosting with references still returns unmanaged": {
 			isUnmanagedEnvironment: true,
 			axwayManaged:           true,
 			agentName:              "agent-managed-hosting-unmanaged-env",
 			wantRuntime:            runtimeTypeUnmanaged,
 			wantAgentName:          "agent-managed-hosting-unmanaged-env",
 		},
-		"axway-managed hosting has no bearing on runtime type when environment has no references": {
+		"axway-managed hosting with no references still returns managed": {
 			isUnmanagedEnvironment: false,
 			axwayManaged:           true,
 			agentName:              "agent-managed-hosting-managed-env",

--- a/pkg/transaction/metric/util_test.go
+++ b/pkg/transaction/metric/util_test.go
@@ -61,7 +61,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-1",
 				Observation: &models.ObservationDetails{
 					Start: 10,
@@ -137,7 +137,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-1",
 				Reporter: &Reporter{
 					AgentVersion:     cmd.BuildVersion,
@@ -205,7 +205,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-no-owner",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -244,7 +244,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-with-owner",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -278,7 +278,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-no-revision",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -308,7 +308,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "id-with-revision",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -344,7 +344,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "evt-api-demotion",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -384,7 +384,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 			},
 			expectedOutput: &centralMetric{
 				Version:     "3",
-				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeUnmanaged},
+				Environment: &EnvironmentInfo{RuntimeType: runtimeTypeManaged},
 				EventID:     "evt-app-demotion",
 				Observation: &models.ObservationDetails{Start: 1, End: 2},
 				Reporter: &Reporter{
@@ -454,28 +454,44 @@ func TestIsKnownID(t *testing.T) {
 
 func TestCentralConfigFields(t *testing.T) {
 	cases := map[string]struct {
-		axwayManaged  bool
-		agentName     string
-		wantRuntime   string
-		wantAgentName string
+		isUnmanagedEnvironment bool
+		axwayManaged           bool
+		agentName              string
+		wantRuntime            string
+		wantAgentName          string
 	}{
-		"non-managed config returns unmanaged": {
-			axwayManaged:  false,
-			agentName:     "agent-connected",
-			wantRuntime:   runtimeTypeUnmanaged,
-			wantAgentName: "agent-connected",
+		"environment with no environment references returns managed": {
+			isUnmanagedEnvironment: false,
+			agentName:              "agent-connected",
+			wantRuntime:            runtimeTypeManaged,
+			wantAgentName:          "agent-connected",
 		},
-		"axway-managed config returns managed": {
-			axwayManaged:  true,
-			agentName:     "agent-managed",
-			wantRuntime:   runtimeTypeManaged,
-			wantAgentName: "agent-managed",
+		"environment referencing other environments returns unmanaged": {
+			isUnmanagedEnvironment: true,
+			agentName:              "agent-clone",
+			wantRuntime:            runtimeTypeUnmanaged,
+			wantAgentName:          "agent-clone",
+		},
+		"axway-managed hosting has no bearing on runtime type when environment has references": {
+			isUnmanagedEnvironment: true,
+			axwayManaged:           true,
+			agentName:              "agent-managed-hosting-unmanaged-env",
+			wantRuntime:            runtimeTypeUnmanaged,
+			wantAgentName:          "agent-managed-hosting-unmanaged-env",
+		},
+		"axway-managed hosting has no bearing on runtime type when environment has no references": {
+			isUnmanagedEnvironment: false,
+			axwayManaged:           true,
+			agentName:              "agent-managed-hosting-managed-env",
+			wantRuntime:            runtimeTypeManaged,
+			wantAgentName:          "agent-managed-hosting-managed-env",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cfg := &config.CentralConfiguration{AgentName: tc.agentName}
 			cfg.SetAxwayManaged(tc.axwayManaged)
+			cfg.SetUnmanagedEnvironment(tc.isUnmanagedEnvironment)
 			agent.InitializeForTest(nil, agent.TestWithCentralConfig(cfg))
 
 			_, agentName, runtimeType := centralConfigFields()


### PR DESCRIPTION
data.environment.runtimeType in the v3 metric event ("managed" | "unmanaged") was being derived from cfg.IsAxwayManaged(), which reflects where the Environment is hosted (Axway's managed cloud vs. on-prem). That's a completely different concept from what the field is supposed to represent : whether the API data is real, gateway-discovered data vs. a synthesized clone (the pattern used by Graylog-style agents).

Confirmed with AHurst that an environment is "unmanaged" when it references other environments — i.e. len(env.References.ManagedEnvironments) > 0. This data is already returned by the existing client.GetEnvironment() call. It just wasn't being captured.

Changes

1. added IsUnmanagedEnvironment()/SetUnmanagedEnvironment() to the CentralConfig interface and CentralConfiguration struct, mirroring the existing IsAxwayManaged/SetAxwayManaged pattern. Also fixed copy-paste doc comments on IsAxwayManaged/SetAxwayManaged left over from SetEnvironmentID, and corrected an unrelated import-ordering issue in the same file.

2. len(env.References.ManagedEnvironments) > 0 into the new field alongside the existing AxwayManaged capture.

3. runtimeType now derived from the new flag instead of IsAxwayManaged(). IsAxwayManaged() itself is untouched. It's still correctly used elsewhere for unrelated usage/volume billing logic.

4. Update tests and fixed various sonar issues

