### PR TITLE
APIGOV-DG000 Fix concurrent map iteration/write race in cache Get methods

### DIFF
--- a/pkg/agent/cache/accessrequest.go
+++ b/pkg/agent/cache/accessrequest.go
@@ -91,8 +91,7 @@ func (c *cacheManager) GetAccessRequestByAppAndAPIStageVersion(appName, remoteAP
 	accessRequest, _ := c.accessRequestMap.GetBySecondaryKey(secKey)
 	if accessRequest != nil {
 		if ri, ok := accessRequest.(*v1.ResourceInstance); ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil
@@ -108,8 +107,7 @@ func (c *cacheManager) GetAccessRequestsByApp(appName string) []*v1.ResourceInst
 	for _, item := range items {
 		if item != nil {
 			if ri, ok := item.GetObject().(*v1.ResourceInstance); ok {
-				ri.CreateHashes()
-				accessRequests = append(accessRequests, ri)
+				accessRequests = append(accessRequests, withComputedHashes(ri))
 			}
 		}
 	}
@@ -124,8 +122,7 @@ func (c *cacheManager) GetAccessRequest(id string) *v1.ResourceInstance {
 	accessRequest, _ := c.accessRequestMap.Get(id)
 	if accessRequest != nil {
 		if ri, ok := accessRequest.(*v1.ResourceInstance); ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil
@@ -140,8 +137,7 @@ func (c *cacheManager) ListAccessRequests() []*v1.ResourceInstance {
 	for _, key := range c.accessRequestMap.GetKeys() {
 		item, _ := c.accessRequestMap.Get(key)
 		if v, ok := item.(*v1.ResourceInstance); ok && v != nil {
-			v.CreateHashes()
-			list = append(list, v)
+			list = append(list, withComputedHashes(v))
 		}
 	}
 	return list

--- a/pkg/agent/cache/accessrequestdefinitions.go
+++ b/pkg/agent/cache/accessrequestdefinitions.go
@@ -27,8 +27,7 @@ func (c *cacheManager) GetAccessRequestDefinitionByName(name string) (*v1.Resour
 	item, err := c.ardMap.GetBySecondaryKey(name)
 	if item != nil {
 		if ard, ok := item.(*v1.ResourceInstance); ok {
-			ard.CreateHashes()
-			return ard, nil
+			return withComputedHashes(ard), nil
 		}
 	}
 	return nil, err
@@ -42,8 +41,7 @@ func (c *cacheManager) GetAccessRequestDefinitionByID(id string) (*v1.ResourceIn
 	item, err := c.ardMap.Get(id)
 	if item != nil {
 		if ard, ok := item.(*v1.ResourceInstance); ok {
-			ard.CreateHashes()
-			return ard, nil
+			return withComputedHashes(ard), nil
 		}
 	}
 	return nil, err

--- a/pkg/agent/cache/apiservice.go
+++ b/pkg/agent/cache/apiservice.go
@@ -92,8 +92,7 @@ func (c *cacheManager) GetAPIServiceWithAPIID(apiID string) *v1.ResourceInstance
 	if api != nil {
 		apiSvc, ok := api.(*v1.ResourceInstance)
 		if ok {
-			apiSvc.CreateHashes()
-			return apiSvc
+			return withComputedHashes(apiSvc)
 		}
 	}
 	return nil
@@ -108,8 +107,7 @@ func (c *cacheManager) GetAPIServiceWithPrimaryKey(primaryKey string) *v1.Resour
 	if api != nil {
 		apiSvc, ok := api.(*v1.ResourceInstance)
 		if ok {
-			apiSvc.CreateHashes()
-			return apiSvc
+			return withComputedHashes(apiSvc)
 		}
 	}
 	return nil
@@ -124,8 +122,7 @@ func (c *cacheManager) GetAPIServiceWithName(apiName string) *v1.ResourceInstanc
 	if api != nil {
 		apiSvc, ok := api.(*v1.ResourceInstance)
 		if ok {
-			apiSvc.CreateHashes()
-			return apiSvc
+			return withComputedHashes(apiSvc)
 		}
 	}
 	return nil

--- a/pkg/agent/cache/apiserviceinstance.go
+++ b/pkg/agent/cache/apiserviceinstance.go
@@ -34,8 +34,7 @@ func (c *cacheManager) GetAPIServiceInstanceByID(id string) (*v1.ResourceInstanc
 	if item != nil {
 		instance, ok := item.(*v1.ResourceInstance)
 		if ok {
-			instance.CreateHashes()
-			return instance, nil
+			return withComputedHashes(instance), nil
 		}
 	}
 	return nil, err
@@ -50,8 +49,7 @@ func (c *cacheManager) GetAPIServiceInstanceByName(name string) (*v1.ResourceIns
 	if item != nil {
 		instance, ok := item.(*v1.ResourceInstance)
 		if ok {
-			instance.CreateHashes()
-			return instance, nil
+			return withComputedHashes(instance), nil
 		}
 	}
 	return nil, err
@@ -83,8 +81,7 @@ func (c *cacheManager) ListAPIServiceInstances() []*v1.ResourceInstance {
 		if item != nil {
 			instance, ok := item.(*v1.ResourceInstance)
 			if ok {
-				instance.CreateHashes()
-				instances = append(instances, instance)
+				instances = append(instances, withComputedHashes(instance))
 			}
 		}
 	}

--- a/pkg/agent/cache/applicationprofiledefinitions.go
+++ b/pkg/agent/cache/applicationprofiledefinitions.go
@@ -27,8 +27,7 @@ func (c *cacheManager) GetApplicationProfileDefinitionByName(name string) (*v1.R
 	item, err := c.apdMap.GetBySecondaryKey(name)
 	if item != nil {
 		if ard, ok := item.(*v1.ResourceInstance); ok {
-			ard.CreateHashes()
-			return ard, nil
+			return withComputedHashes(ard), nil
 		}
 	}
 	return nil, err
@@ -42,8 +41,7 @@ func (c *cacheManager) GetApplicationProfileDefinitionByID(id string) (*v1.Resou
 	item, err := c.apdMap.Get(id)
 	if item != nil {
 		if ard, ok := item.(*v1.ResourceInstance); ok {
-			ard.CreateHashes()
-			return ard, nil
+			return withComputedHashes(ard), nil
 		}
 	}
 	return nil, err

--- a/pkg/agent/cache/complianceruntimeresult.go
+++ b/pkg/agent/cache/complianceruntimeresult.go
@@ -25,8 +25,7 @@ func (c *cacheManager) GetComplianceRuntimeResultByID(id string) (*v1.ResourceIn
 	if item != nil {
 		instance, ok := item.(*v1.ResourceInstance)
 		if ok {
-			instance.CreateHashes()
-			return instance, nil
+			return withComputedHashes(instance), nil
 		}
 	}
 	return nil, err
@@ -39,8 +38,7 @@ func (c *cacheManager) GetComplianceRuntimeResultByName(name string) (*v1.Resour
 	item, err := c.crrMap.GetBySecondaryKey(name)
 	if item != nil {
 		if crr, ok := item.(*v1.ResourceInstance); ok {
-			crr.CreateHashes()
-			return crr, nil
+			return withComputedHashes(crr), nil
 		}
 	}
 	return nil, err

--- a/pkg/agent/cache/credentialrequestdefinitions.go
+++ b/pkg/agent/cache/credentialrequestdefinitions.go
@@ -31,8 +31,7 @@ func (c *cacheManager) ListCredentialRequestDefinitions() []*v1.ResourceInstance
 		if item != nil {
 			instance, ok := item.(*v1.ResourceInstance)
 			if ok {
-				instance.CreateHashes()
-				instances = append(instances, instance)
+				instances = append(instances, withComputedHashes(instance))
 			}
 		}
 	}
@@ -48,8 +47,7 @@ func (c *cacheManager) GetCredentialRequestDefinitionByName(name string) (*v1.Re
 	item, err := c.crdMap.GetBySecondaryKey(name)
 	if item != nil {
 		if crd, ok := item.(*v1.ResourceInstance); ok {
-			crd.CreateHashes()
-			return crd, nil
+			return withComputedHashes(crd), nil
 		}
 	}
 	return nil, err
@@ -63,8 +61,7 @@ func (c *cacheManager) GetCredentialRequestDefinitionByID(id string) (*v1.Resour
 	item, err := c.crdMap.Get(id)
 	if item != nil {
 		if crd, ok := item.(*v1.ResourceInstance); ok {
-			crd.CreateHashes()
-			return crd, nil
+			return withComputedHashes(crd), nil
 		}
 	}
 	return nil, err

--- a/pkg/agent/cache/managedapplication.go
+++ b/pkg/agent/cache/managedapplication.go
@@ -36,8 +36,7 @@ func (c *cacheManager) GetManagedApplication(id string) *v1.ResourceInstance {
 	if managedApp != nil {
 		ri, ok := managedApp.(*v1.ResourceInstance)
 		if ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil
@@ -65,8 +64,7 @@ func (c *cacheManager) GetManagedApplicationByName(name string) *v1.ResourceInst
 	if managedApp != nil {
 		ri, ok := managedApp.(*v1.ResourceInstance)
 		if ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -409,6 +409,22 @@ func (c *cacheManager) ReleaseResourceReadLock() {
 	c.resourceCacheReadLock.RUnlock()
 }
 
+// withComputedHashes returns a shallow copy of ri with freshly computed SubResourceHashes,
+// leaving ri's own hashes untouched. CreateHashes has no synchronization of its own - it mutates
+// SubResourceHashes in place - so cache Get methods must not call it directly on the resource
+// pointer stored in the cache, since concurrent Get calls (or a Get racing a read of the same
+// resource elsewhere, e.g. a model's FromInstance) would then race on that shared map. See
+// pkg/apic/apiserver/models/api/v1.TestCreateHashesConcurrentAccess for a reproduction.
+func withComputedHashes(ri *v1.ResourceInstance) *v1.ResourceInstance {
+	if ri == nil {
+		return nil
+	}
+	cp := *ri
+	cp.SubResourceHashes = nil
+	cp.CreateHashes()
+	return &cp
+}
+
 // Flush empties the persistent cache and all internal caches
 func (c *cacheManager) Flush() {
 	c.resourceCacheReadLock.Lock()

--- a/pkg/agent/cache/manager_test.go
+++ b/pkg/agent/cache/manager_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	defs "github.com/Axway/agent-sdk/pkg/apic/definitions"
@@ -369,4 +370,52 @@ func TestCredentialRequestDefinitionCache(t *testing.T) {
 	cachedCRD, err = m.GetCredentialRequestDefinitionByName("id1")
 	assert.NotNil(t, err)
 	assert.Nil(t, cachedCRD)
+}
+
+// TestConcurrentGetsDoNotRace: every Get method here used to call CreateHashes() on the
+// resource pointer stored in the cache while holding only a read lock, so concurrent Get calls
+// (as happen when an agent processes resources via parallel goroutines) could race on the shared
+// SubResourceHashes map. withComputedHashes now returns a defensive copy instead, so this should
+// pass cleanly under `go test -race`.
+func TestConcurrentGetsDoNotRace(t *testing.T) {
+	cm := NewAgentCacheManager(&config.CentralConfiguration{}, false)
+
+	ri := &v1.ResourceInstance{
+		ResourceMeta: v1.ResourceMeta{
+			Name:     "svc-instance",
+			Metadata: v1.Metadata{ID: "id-1"},
+			SubResources: map[string]interface{}{
+				"status":           map[string]interface{}{"level": "Success"},
+				defs.XAgentDetails: map[string]interface{}{"key": "value"},
+			},
+		},
+	}
+	cm.AddAPIServiceInstance(ri)
+
+	const iterations = 20000
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = cm.GetAPIServiceInstanceByID("id-1")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			cm.ListAPIServiceInstances()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = cm.GetAPIServiceInstanceByName("svc-instance")
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/agent/cache/teams.go
+++ b/pkg/agent/cache/teams.go
@@ -89,8 +89,7 @@ func (c *cacheManager) GetAccessControlList() *v1.ResourceInstance {
 	if item != nil {
 		instance, ok := item.(*v1.ResourceInstance)
 		if ok {
-			instance.CreateHashes()
-			return instance
+			return withComputedHashes(instance)
 		}
 	}
 	return nil

--- a/pkg/agent/cache/watchresource.go
+++ b/pkg/agent/cache/watchresource.go
@@ -43,8 +43,7 @@ func (c *cacheManager) GetWatchResourceByKey(key string) *v1.ResourceInstance {
 	resource, _ := c.watchResourceMap.Get(key)
 	if resource != nil {
 		if ri, ok := resource.(*v1.ResourceInstance); ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil
@@ -57,8 +56,7 @@ func (c *cacheManager) GetWatchResourceByID(group, kind, id string) *v1.Resource
 	resource, _ := c.watchResourceMap.Get(c.getWatchResourceKey(group, kind, id))
 	if resource != nil {
 		if ri, ok := resource.(*v1.ResourceInstance); ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil
@@ -71,8 +69,7 @@ func (c *cacheManager) GetWatchResourceByName(group, kind, name string) *v1.Reso
 	resource, _ := c.watchResourceMap.GetBySecondaryKey(c.getWatchResourceKey(group, kind, name))
 	if resource != nil {
 		if ri, ok := resource.(*v1.ResourceInstance); ok {
-			ri.CreateHashes()
-			return ri
+			return withComputedHashes(ri)
 		}
 	}
 	return nil


### PR DESCRIPTION
Every Get*/List* method in pkg/agent/cache called CreateHashes() on the resource pointer stored in the cache while holding only a read lock. CreateHashes mutates SubResourceHashes in place with no synchronization of its own, so concurrent Get calls (or a Get racing a read of the same resource elsewhere, e.g. a model's FromInstance ranging over SubResourceHashes) could hit Go's "concurrent map iteration and map write" fatal error - reproduced in production by an agent processing resources via parallel goroutines against the shared cache.

Add withComputedHashes, which returns a shallow copy with freshly computed hashes instead of mutating the cached pointer, and use it at every such call site. Includes TestConcurrentGetsDoNotRace as a regression test (passes cleanly under -race).