### PR TITLE
APIGOV-33344 - update trans leg and summary with only required fields

### DIFF
--- a/pkg/transaction/contract_test.go
+++ b/pkg/transaction/contract_test.go
@@ -67,9 +67,8 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.Equal(t, "2", data.Version)
 				assert.Equal(t, contractAPICDeploy, data.APICDeployment)
 				assert.Equal(t, contractLegTxnID, data.TransactionID)
-				assert.Equal(t, 0, data.LegID)
+				assert.Equal(t, "leg0", data.ID)
 				require.NotNil(t, data.API)
-				require.NotNil(t, data.Proxy)
 
 				assert.Contains(t, raw, `"api.transaction.event"`)
 				assert.Contains(t, raw, `"version":"4"`)
@@ -174,14 +173,8 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.Equal(t, contractAgentName, data.Reporter.AgentName)
 
 				require.NotNil(t, data.Product)
-				assert.Equal(t, "contract-product-name", data.Product.Name)
-				assert.Equal(t, "contract-version-name", data.Product.VersionName)
-				require.NotNil(t, data.Product.Owner)
-				assert.Equal(t, "product-team-contract", data.Product.Owner.TeamGUID)
 				require.NotNil(t, data.ConsumerDetails.PublishedProduct)
-				assert.Equal(t, "contract-published-product-name", data.ConsumerDetails.PublishedProduct.Name)
 				require.NotNil(t, data.ConsumerDetails.Subscription)
-				assert.Equal(t, "contract-subscription-name", data.ConsumerDetails.Subscription.Name)
 
 				assert.Contains(t, raw, `"api.transaction.summary"`)
 				assert.Contains(t, raw, `"version":"4"`)

--- a/pkg/transaction/contract_test.go
+++ b/pkg/transaction/contract_test.go
@@ -46,6 +46,8 @@ func TestContractTransactionV2Data(t *testing.T) {
 					Status:    "Pass",
 					Duration:  340,
 					Direction: "Inbound",
+					ProxyID:   "contract-proxy-id",
+					ProxyName: "contract-proxy-name",
 				},
 			},
 			orgID: contractOrg,
@@ -66,6 +68,8 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.Equal(t, contractAPICDeploy, data.APICDeployment)
 				assert.Equal(t, contractLegTxnID, data.TransactionID)
 				assert.Equal(t, 0, data.LegID)
+				require.NotNil(t, data.API)
+				require.NotNil(t, data.Proxy)
 
 				assert.Contains(t, raw, `"api.transaction.event"`)
 				assert.Contains(t, raw, `"version":"4"`)
@@ -77,6 +81,10 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.NotContains(t, raw, `"entryPoint"`)
 				assert.NotContains(t, raw, `"assetResource"`)
 				assert.NotContains(t, raw, `"apiServiceRevision"`)
+				assert.NotContains(t, raw, `"transactionId"`)
+				assert.NotContains(t, raw, `"legId"`)
+				assert.NotContains(t, raw, `"api":`)
+				assert.NotContains(t, raw, `"proxy":`)
 			},
 		},
 		"summary event v2 has correct envelope and data shape": {
@@ -94,10 +102,28 @@ func TestContractTransactionV2Data(t *testing.T) {
 						Path:   "/pets/123",
 						Host:   "api.example.com",
 					},
+					Product: &models.Product{
+						ID:          "product-contract",
+						Name:        "contract-product-name",
+						VersionName: "contract-version-name",
+						Owner:       &models.Owner{Type: "team", TeamGUID: "product-team-contract"},
+					},
 					ConsumerDetails: &models.ConsumerDetails{
 						Marketplace: &models.MarketplaceReference{
 							GUID:          "mp-guid-contract",
 							ConsumerOrgID: "consumer-org-contract",
+						},
+						Application: &models.AppDetails{
+							ID:   "app-contract",
+							Name: "contract-app-name",
+						},
+						PublishedProduct: &models.Product{
+							ID:   "published-product-contract",
+							Name: "contract-published-product-name",
+						},
+						Subscription: &models.Subscription{
+							ID:   "subscription-contract",
+							Name: "contract-subscription-name",
 						},
 					},
 					AppOwnerInfo: &models.Owner{Type: "team", TeamGUID: "app-team-contract"},
@@ -147,6 +173,16 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.Equal(t, contractSDKVersion, data.Reporter.AgentSDKVersion)
 				assert.Equal(t, contractAgentName, data.Reporter.AgentName)
 
+				require.NotNil(t, data.Product)
+				assert.Equal(t, "contract-product-name", data.Product.Name)
+				assert.Equal(t, "contract-version-name", data.Product.VersionName)
+				require.NotNil(t, data.Product.Owner)
+				assert.Equal(t, "product-team-contract", data.Product.Owner.TeamGUID)
+				require.NotNil(t, data.ConsumerDetails.PublishedProduct)
+				assert.Equal(t, "contract-published-product-name", data.ConsumerDetails.PublishedProduct.Name)
+				require.NotNil(t, data.ConsumerDetails.Subscription)
+				assert.Equal(t, "contract-subscription-name", data.ConsumerDetails.Subscription.Name)
+
 				assert.Contains(t, raw, `"api.transaction.summary"`)
 				assert.Contains(t, raw, `"version":"4"`)
 				assert.Contains(t, raw, `"version":"2"`)
@@ -159,6 +195,12 @@ func TestContractTransactionV2Data(t *testing.T) {
 				assert.NotContains(t, raw, `"api.teamId"`)
 				assert.NotContains(t, raw, `"proxy.apiServiceInstance"`)
 				assert.NotContains(t, raw, `"proxy.revision"`)
+				assert.NotContains(t, raw, `"contract-product-name"`)
+				assert.NotContains(t, raw, `"versionName"`)
+				assert.NotContains(t, raw, `"contract-app-name"`)
+				assert.NotContains(t, raw, `"contract-published-product-name"`)
+				assert.NotContains(t, raw, `"contract-subscription-name"`)
+				assert.NotContains(t, raw, `"product-team-contract"`)
 			},
 		},
 		"deprecated proxy fields present when proxy is set": {

--- a/pkg/transaction/v2event.go
+++ b/pkg/transaction/v2event.go
@@ -43,21 +43,18 @@ type insightsAPIDetail struct {
 // insightsConsumerAppDetail is the application sub-object within consumerDetails.
 type insightsConsumerAppDetail struct {
 	ID            string        `json:"id,omitempty"`
-	Name          string        `json:"-"`
 	ConsumerOrgID string        `json:"consumerOrgId,omitempty"`
 	Owner         *models.Owner `json:"owner,omitempty"`
 }
 
 // insightsPublishedProduct is the publishedProduct sub-object within consumerDetails.
 type insightsPublishedProduct struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"-"`
+	ID string `json:"id,omitempty"`
 }
 
 // insightsSubscription is the subscription sub-object within consumerDetails.
 type insightsSubscription struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"-"`
+	ID string `json:"id,omitempty"`
 }
 
 // insightsConsumerDetails is the consumerDetails sub-object for leg and summary v2.
@@ -75,11 +72,8 @@ type insightsMarketplace struct {
 
 // insightsSummaryProduct is the product sub-object for summary v2.
 type insightsSummaryProduct struct {
-	ID          string        `json:"id,omitempty"`
-	Name        string        `json:"-"`
-	VersionID   string        `json:"versionId,omitempty"`
-	VersionName string        `json:"-"`
-	Owner       *models.Owner `json:"-"`
+	ID        string `json:"id,omitempty"`
+	VersionID string `json:"versionId,omitempty"`
 }
 
 // insightsReporter is the reporter sub-object.
@@ -99,7 +93,7 @@ type legProtocol struct {
 	Status int    `json:"status"`
 }
 
-// insightsProxy is the nested proxy sub-object for leg and summary v2 data.
+// insightsProxy is the nested proxy sub-object for summary v2 data.
 type insightsProxy struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
@@ -111,7 +105,6 @@ type TransactionLegData struct {
 	APICDeployment string             `json:"apicDeployment,omitempty"`
 	TransactionID  string             `json:"-"`
 	ID             string             `json:"id,omitempty"`
-	LegID          int                `json:"-"`
 	ParentID       string             `json:"parentId,omitempty"`
 	Source         string             `json:"source,omitempty"`
 	Destination    string             `json:"destination,omitempty"`
@@ -121,7 +114,6 @@ type TransactionLegData struct {
 	Protocol       *legProtocol       `json:"protocol,omitempty"`
 	API            *insightsAPIDetail `json:"-"`
 	Reporter       *insightsReporter  `json:"reporter,omitempty"`
-	Proxy          *insightsProxy     `json:"-"`
 }
 
 // GetStartTime implements metric.V4Data.
@@ -135,7 +127,7 @@ func (d *TransactionLegData) GetEventID() string { return d.TransactionID }
 
 // GetLogFields implements metric.V4Data.
 func (d *TransactionLegData) GetLogFields() logrus.Fields {
-	f := logrus.Fields{"transactionId": d.TransactionID, "legId": d.LegID}
+	f := logrus.Fields{"transactionId": d.TransactionID}
 	if d.API != nil {
 		f["apiId"] = d.API.ID
 	}
@@ -285,33 +277,21 @@ func buildLegV2Data(logEvent LogEvent, summaryProxy *Proxy, cacheManager cache.M
 	}
 
 	apiID := txEvent.ProxyID
-	proxyName := txEvent.ProxyName
 
 	if apiID == "" && summaryProxy != nil {
 		apiID = summaryProxy.ID
-		if proxyName == "" {
-			proxyName = summaryProxy.Name
-		}
 	}
 	if apiID == "" && txEvent.Source != "" {
 		apiID = transutil.ResolveIDWithPrefix(txEvent.Source, "")
 	}
 
 	apiDetail := resolveAPIDetailFromCache(apiID, cacheManager)
-	if proxyName == "" && apiDetail != nil {
-		proxyName = apiDetail.Name
-	}
-	var legProxy *insightsProxy
-	if apiID != "" || proxyName != "" {
-		legProxy = &insightsProxy{ID: apiID, Name: proxyName}
-	}
 
 	data := &TransactionLegData{
 		Version:        legDataVersion,
 		APICDeployment: logEvent.APICDeployment,
 		TransactionID:  logEvent.TransactionID,
 		ID:             fmt.Sprintf("leg%d", legID), // legID already normalized via parseLegID
-		LegID:          legID,
 		ParentID:       formatLegID(txEvent.ParentID),
 		Source:         txEvent.Source,
 		Destination:    txEvent.Destination,
@@ -320,7 +300,6 @@ func buildLegV2Data(logEvent LogEvent, summaryProxy *Proxy, cacheManager cache.M
 		Direction:      strings.ToLower(txEvent.Direction),
 		Protocol:       proto,
 		API:            apiDetail,
-		Proxy:          legProxy,
 		Reporter: &insightsReporter{
 			Version:         reporter.AgentVersion,
 			Type:            reporter.AgentType,
@@ -366,11 +345,8 @@ func buildSummaryV2Data(logger log.FieldLogger, logEvent LogEvent, cacheManager 
 
 	if summary.Product != nil && summary.Product.ID != "" {
 		data.Product = &insightsSummaryProduct{
-			ID:          summary.Product.ID,
-			Name:        summary.Product.Name,
-			VersionID:   summary.Product.VersionID,
-			VersionName: summary.Product.VersionName,
-			Owner:       summary.Product.Owner,
+			ID:        summary.Product.ID,
+			VersionID: summary.Product.VersionID,
 		}
 	}
 	if summary.ProductPlan != nil && summary.ProductPlan.ID != "" {
@@ -469,7 +445,6 @@ func buildConsumerDetails(cd *models.ConsumerDetails, appOwner *models.Owner) *i
 	appDetail := &insightsConsumerAppDetail{}
 	if cd.Application != nil {
 		appDetail.ID = cd.Application.ID
-		appDetail.Name = cd.Application.Name
 		appDetail.ConsumerOrgID = cd.Application.ConsumerOrgID
 	}
 	if appOwner != nil {
@@ -478,29 +453,13 @@ func buildConsumerDetails(cd *models.ConsumerDetails, appOwner *models.Owner) *i
 	out.Application = appDetail
 
 	if cd.PublishedProduct != nil && cd.PublishedProduct.ID != "" {
-		out.PublishedProduct = &insightsPublishedProduct{
-			ID:   cd.PublishedProduct.ID,
-			Name: cd.PublishedProduct.Name,
-		}
+		out.PublishedProduct = &insightsPublishedProduct{ID: cd.PublishedProduct.ID}
 	}
 	if cd.Subscription != nil && cd.Subscription.ID != "" {
-		out.Subscription = &insightsSubscription{
-			ID:   cd.Subscription.ID,
-			Name: cd.Subscription.Name,
-		}
+		out.Subscription = &insightsSubscription{ID: cd.Subscription.ID}
 	}
 
 	return out
-}
-
-// SetLegProxy sets the proxy block on a TransactionLegData after it has been built.
-// Used by the agents-controller to populate proxy from enriched API details post-build,
-// since insightsProxy is unexported and cannot be constructed externally.
-func SetLegProxy(leg *TransactionLegData, proxyID, proxyName string) {
-	if leg == nil || (proxyID == "" && proxyName == "") {
-		return
-	}
-	leg.Proxy = &insightsProxy{ID: proxyID, Name: proxyName}
 }
 
 // parseLegID accepts "N" or "legN" and returns N; returns 0 on any other input.

--- a/pkg/transaction/v2event.go
+++ b/pkg/transaction/v2event.go
@@ -43,7 +43,7 @@ type insightsAPIDetail struct {
 // insightsConsumerAppDetail is the application sub-object within consumerDetails.
 type insightsConsumerAppDetail struct {
 	ID            string        `json:"id,omitempty"`
-	Name          string        `json:"name,omitempty"`
+	Name          string        `json:"-"`
 	ConsumerOrgID string        `json:"consumerOrgId,omitempty"`
 	Owner         *models.Owner `json:"owner,omitempty"`
 }
@@ -51,13 +51,13 @@ type insightsConsumerAppDetail struct {
 // insightsPublishedProduct is the publishedProduct sub-object within consumerDetails.
 type insightsPublishedProduct struct {
 	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name string `json:"-"`
 }
 
 // insightsSubscription is the subscription sub-object within consumerDetails.
 type insightsSubscription struct {
 	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Name string `json:"-"`
 }
 
 // insightsConsumerDetails is the consumerDetails sub-object for leg and summary v2.
@@ -76,10 +76,10 @@ type insightsMarketplace struct {
 // insightsSummaryProduct is the product sub-object for summary v2.
 type insightsSummaryProduct struct {
 	ID          string        `json:"id,omitempty"`
-	Name        string        `json:"name,omitempty"`
+	Name        string        `json:"-"`
 	VersionID   string        `json:"versionId,omitempty"`
-	VersionName string        `json:"versionName,omitempty"`
-	Owner       *models.Owner `json:"owner,omitempty"`
+	VersionName string        `json:"-"`
+	Owner       *models.Owner `json:"-"`
 }
 
 // insightsReporter is the reporter sub-object.
@@ -109,9 +109,9 @@ type insightsProxy struct {
 type TransactionLegData struct {
 	Version        string             `json:"version"`
 	APICDeployment string             `json:"apicDeployment,omitempty"`
-	TransactionID  string             `json:"transactionId,omitempty"`
+	TransactionID  string             `json:"-"`
 	ID             string             `json:"id,omitempty"`
-	LegID          int                `json:"legId"`
+	LegID          int                `json:"-"`
 	ParentID       string             `json:"parentId,omitempty"`
 	Source         string             `json:"source,omitempty"`
 	Destination    string             `json:"destination,omitempty"`
@@ -119,9 +119,9 @@ type TransactionLegData struct {
 	Duration       int                `json:"duration"`
 	Direction      string             `json:"direction,omitempty"`
 	Protocol       *legProtocol       `json:"protocol,omitempty"`
-	API            *insightsAPIDetail `json:"api,omitempty"`
+	API            *insightsAPIDetail `json:"-"`
 	Reporter       *insightsReporter  `json:"reporter,omitempty"`
-	Proxy          *insightsProxy     `json:"proxy,omitempty"`
+	Proxy          *insightsProxy     `json:"-"`
 }
 
 // GetStartTime implements metric.V4Data.

--- a/pkg/transaction/v2event_test.go
+++ b/pkg/transaction/v2event_test.go
@@ -143,7 +143,6 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, legDataVersion, data.Version)
 				assert.Equal(t, "prod", data.APICDeployment)
-				assert.Equal(t, 1, data.LegID)
 				assert.Equal(t, "leg1", data.ID)
 			},
 		},
@@ -158,7 +157,6 @@ func TestBuildTransactionV2Data(t *testing.T) {
 			check: func(t *testing.T, ie *InsightsEvent) {
 				data, ok := ie.Data.(*TransactionLegData)
 				require.True(t, ok)
-				assert.Equal(t, 0, data.LegID)
 				assert.Equal(t, "leg0", data.ID)
 			},
 		},
@@ -492,11 +490,7 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.True(t, ok)
 				require.NotNil(t, data.Product)
 				assert.Equal(t, "prod-id-1", data.Product.ID)
-				assert.Equal(t, "my-product", data.Product.Name)
 				assert.Equal(t, "ver-id-1", data.Product.VersionID)
-				assert.Equal(t, "1.0.0", data.Product.VersionName)
-				require.NotNil(t, data.Product.Owner)
-				assert.Equal(t, testTeamGUID, data.Product.Owner.TeamGUID)
 			},
 		},
 		"summary with productPlan and quota populates those fields": {
@@ -560,7 +554,6 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.NotNil(t, data.ConsumerDetails)
 				require.NotNil(t, data.ConsumerDetails.Application)
 				assert.Equal(t, "app-id-1", data.ConsumerDetails.Application.ID)
-				assert.Equal(t, "my-app", data.ConsumerDetails.Application.Name)
 				assert.Equal(t, testConsumerOrgID, data.ConsumerDetails.Application.ConsumerOrgID)
 			},
 		},
@@ -584,10 +577,8 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.NotNil(t, data.ConsumerDetails)
 				require.NotNil(t, data.ConsumerDetails.PublishedProduct)
 				assert.Equal(t, "pp-id-1", data.ConsumerDetails.PublishedProduct.ID)
-				assert.Equal(t, "published-product", data.ConsumerDetails.PublishedProduct.Name)
 				require.NotNil(t, data.ConsumerDetails.Subscription)
 				assert.Equal(t, "sub-id-1", data.ConsumerDetails.Subscription.ID)
-				assert.Equal(t, "my-sub", data.ConsumerDetails.Subscription.Name)
 			},
 		},
 		// proxy path picks up apiServiceRevision from summary.API when both are set
@@ -653,32 +644,6 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.True(t, ok)
 				require.NotNil(t, data.API)
 				assert.Equal(t, "remoteApiId_abc123", data.API.ID)
-			},
-		},
-		// leg proxy is populated from SetProxy call
-		"leg proxy populated from SetProxy": {
-			logEvent: LogEvent{
-				Type:          TypeTransactionEvent,
-				TransactionID: "txn-leg-proxy",
-				TransactionEvent: &Event{
-					ID:        "0",
-					Status:    "Pass",
-					Source:    "remoteApiId_abc123",
-					ProxyName: testAPIName,
-				},
-			},
-			orgID:         testOrgID,
-			environmentID: testEnvID,
-			check: func(t *testing.T, ie *InsightsEvent) {
-				data, ok := ie.Data.(*TransactionLegData)
-				require.True(t, ok)
-				require.NotNil(t, data.Proxy)
-				assert.Equal(t, "remoteApiId_abc123", data.Proxy.ID)
-				assert.Equal(t, testAPIName, data.Proxy.Name)
-
-				b, err := json.Marshal(data)
-				require.NoError(t, err)
-				assert.NotContains(t, string(b), `"proxy":`)
 			},
 		},
 		// direction is lowercased regardless of what the agent passes
@@ -1203,64 +1168,9 @@ func TestBuildTransactionV2DataLegIDs(t *testing.T) {
 	}
 }
 
-func TestSetLegProxy(t *testing.T) {
-	cases := map[string]struct {
-		leg           *TransactionLegData
-		proxyID       string
-		proxyName     string
-		wantNilProxy  bool
-		wantProxyID   string
-		wantProxyName string
-	}{
-		"nil leg is a no-op": {
-			leg:          nil,
-			proxyID:      "id-1",
-			proxyName:    "name-1",
-			wantNilProxy: true,
-		},
-		"both IDs empty is a no-op": {
-			leg:          &TransactionLegData{},
-			wantNilProxy: true,
-		},
-		"both IDs set populates proxy": {
-			leg:           &TransactionLegData{},
-			proxyID:       "remoteApiId_ext-1",
-			proxyName:     testAPIName,
-			wantProxyID:   "remoteApiId_ext-1",
-			wantProxyName: testAPIName,
-		},
-		"only proxyID set populates proxy": {
-			leg:         &TransactionLegData{},
-			proxyID:     "remoteApiId_ext-2",
-			wantProxyID: "remoteApiId_ext-2",
-		},
-		"only proxyName set populates proxy": {
-			leg:           &TransactionLegData{},
-			proxyName:     "my-api-2",
-			wantProxyName: "my-api-2",
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			SetLegProxy(tc.leg, tc.proxyID, tc.proxyName)
-			if tc.leg == nil {
-				return
-			}
-			if tc.wantNilProxy {
-				assert.Nil(t, tc.leg.Proxy)
-				return
-			}
-			assert.NotNil(t, tc.leg.Proxy)
-			assert.Equal(t, tc.wantProxyID, tc.leg.Proxy.ID)
-			assert.Equal(t, tc.wantProxyName, tc.leg.Proxy.Name)
-		})
-	}
-}
-
 func TestV4DataInterfaceMethods(t *testing.T) {
 	t.Run("TransactionLegData interface methods", func(t *testing.T) {
-		d := &TransactionLegData{TransactionID: testTxnIfaceLeg, LegID: 0}
+		d := &TransactionLegData{TransactionID: testTxnIfaceLeg}
 		assert.Equal(t, TypeTransactionEvent, d.GetType())
 		assert.Equal(t, testTxnIfaceLeg, d.GetEventID())
 		assert.Equal(t, (time.Time{}), d.GetStartTime())

--- a/pkg/transaction/v2event_test.go
+++ b/pkg/transaction/v2event_test.go
@@ -678,7 +678,7 @@ func TestBuildTransactionV2Data(t *testing.T) {
 
 				b, err := json.Marshal(data)
 				require.NoError(t, err)
-				assert.Contains(t, string(b), `"proxy":`)
+				assert.NotContains(t, string(b), `"proxy":`)
 			},
 		},
 		// direction is lowercased regardless of what the agent passes


### PR DESCRIPTION
Fix:

Remove the following out-of-spec fields specifically from api.transaction.event (DO NOT remove from api.transaction.summary *or *api.transaction.status.metric)

data.transactionId
data.legId
data.api
Whole object including data.api.id, data.api.owner.type, data.api.owner.team_guid etc...
data.proxy
Whole object including data.proxy.id, data.proxy.name etc..


Remove the following out-of-spec fields specifically from api.transaction.summary (DO NOT remove from api.transaction.event or api.transaction.status.metric)

data.product.name
data.product.versionName
data.product.owner
Whole object including data.product.owner.type etc...
data.consumerDetails.application.name
data.consumerDetails.publishedProduct.name
data.consumerDetails.subscription.name