### PR TITLE
APIGOV33468 - fix remoteApiName_ prefix not stripped in metric API detail lookups

### DIFF
--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -659,7 +659,7 @@ func (c *collector) createAPIDetail(api models.APIDetails) *models.APIResourceRe
 		Name: api.Name,
 	}
 	cacheManager := agent.GetCacheManager()
-	svc := cacheManager.GetAPIServiceWithAPIID(strings.TrimPrefix(api.ID, transutil.SummaryEventProxyIDPrefix))
+	svc := cacheManager.GetAPIServiceWithAPIID(transutil.StripSummaryEventPrefix(api.ID))
 	ref.APIServiceID = unknown
 	if svc != nil {
 		ref.APIServiceID = svc.Metadata.ID

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/traceability"
 	"github.com/Axway/agent-sdk/pkg/transaction/models"
+	transutil "github.com/Axway/agent-sdk/pkg/transaction/util"
 	"github.com/Axway/agent-sdk/pkg/util/healthcheck"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
@@ -1204,6 +1205,65 @@ func TestCollectorCreateOrUpdateHistogramIDResolution(t *testing.T) {
 			// This would require proper mock setup for the collector
 			// The test would verify that detail.APIDetails.ID gets resolved correctly
 			// before being used in the metric generation
+		})
+	}
+}
+
+func TestCreateAPIDetail(t *testing.T) {
+	cases := map[string]struct {
+		apiServiceRI *apiv1.ResourceInstance
+		apiID        string
+		apiName      string
+		wantOwnType  string
+		wantOwnGUID  string
+		wantSvcID    string
+	}{
+		"real ID prefix resolves owner and apiServiceId from cache": {
+			apiServiceRI: withMetaID(makeAPIServiceRI("api-1", &apiv1.Owner{Type: apiv1.TeamOwner, ID: testTeamGUID1}), "svc-meta-api-1"),
+			apiID:        transutil.SummaryEventProxyIDPrefix + "api-1",
+			apiName:      "api-one",
+			wantOwnType:  "team",
+			wantOwnGUID:  testTeamGUID1,
+			wantSvcID:    "svc-meta-api-1",
+		},
+		"name-fallback prefix resolves owner and apiServiceId from cache": {
+			apiServiceRI: withMetaID(makeAPIServiceRI("api-2", &apiv1.Owner{Type: apiv1.TeamOwner, ID: testTeamGUID1}), "svc-meta-api-2"),
+			apiID:        transutil.SummaryEventAPINamePrefix + "api-2",
+			apiName:      "api-two",
+			wantOwnType:  "team",
+			wantOwnGUID:  testTeamGUID1,
+			wantSvcID:    "svc-meta-api-2",
+		},
+		"api not found in cache returns unknown owner and apiServiceId": {
+			apiServiceRI: nil,
+			apiID:        transutil.SummaryEventProxyIDPrefix + "missing-api",
+			apiName:      "missing",
+			wantOwnType:  "unknown",
+			wantSvcID:    unknown,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			agent.InitializeForTest(nil, agent.TestWithCentralConfig(newUtilCacheConfig()))
+			if tc.apiServiceRI != nil {
+				agent.GetCacheManager().AddAPIService(tc.apiServiceRI)
+			}
+
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.createAPIDetail(models.APIDetails{ID: tc.apiID, Name: tc.apiName})
+			if ref == nil {
+				t.Fatal("expected non-nil API resource reference")
+			}
+			assert.Equal(t, tc.apiID, ref.ID)
+			assert.Equal(t, tc.apiName, ref.Name)
+			assert.Equal(t, tc.wantSvcID, ref.APIServiceID)
+			if ref.Owner == nil {
+				t.Fatal("expected non-nil owner")
+			}
+			assert.Equal(t, tc.wantOwnType, ref.Owner.Type)
+			if tc.wantOwnGUID != "" {
+				assert.Equal(t, tc.wantOwnGUID, ref.Owner.TeamGUID)
+			}
 		})
 	}
 }

--- a/pkg/transaction/metric/util.go
+++ b/pkg/transaction/metric/util.go
@@ -157,7 +157,7 @@ func buildAPIRef(api models.APIDetails) *models.APIResourceReference {
 		Name:              api.Name,
 	}
 	cacheManager := agent.GetCacheManager()
-	svc := cacheManager.GetAPIServiceWithAPIID(strings.TrimPrefix(api.ID, transutil.SummaryEventProxyIDPrefix))
+	svc := cacheManager.GetAPIServiceWithAPIID(transutil.StripSummaryEventPrefix(api.ID))
 	if svc != nil {
 		ref.APIServiceID = svc.Metadata.ID
 	}

--- a/pkg/transaction/metric/util_test.go
+++ b/pkg/transaction/metric/util_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Axway/agent-sdk/pkg/cmd"
 	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/transaction/models"
+	transutil "github.com/Axway/agent-sdk/pkg/transaction/util"
 )
 
 const (
@@ -27,6 +28,13 @@ func makeAPIServiceRI(apiID string, owner *v1.Owner) *v1.ResourceInstance {
 	}
 	svc.Owner = owner
 	ri, _ := svc.AsInstance()
+	return ri
+}
+
+// withMetaID sets the resource's metadata ID, letting a test case declare the
+// cached resource's identity inline instead of mutating it in the test runner.
+func withMetaID(ri *v1.ResourceInstance, id string) *v1.ResourceInstance {
+	ri.Metadata.ID = id
 	return ri
 }
 
@@ -542,6 +550,60 @@ func TestResolveAppOwnerFromCache(t *testing.T) {
 			assert.Equal(t, tc.wantType, owner.Type)
 			if tc.wantGUID != "" {
 				assert.Equal(t, tc.wantGUID, owner.TeamGUID)
+			}
+		})
+	}
+}
+
+func TestBuildAPIRef(t *testing.T) {
+	cases := map[string]struct {
+		apiServiceRI *v1.ResourceInstance
+		apiID        string
+		apiName      string
+		wantOwnType  string
+		wantOwnGUID  string
+		wantSvcID    string
+	}{
+		"real ID prefix resolves owner and apiServiceId from cache": {
+			apiServiceRI: withMetaID(makeAPIServiceRI("api-1", &v1.Owner{Type: v1.TeamOwner, ID: testTeamGUID1}), "svc-meta-api-1"),
+			apiID:        transutil.SummaryEventProxyIDPrefix + "api-1",
+			apiName:      "api-one",
+			wantOwnType:  "team",
+			wantOwnGUID:  testTeamGUID1,
+			wantSvcID:    "svc-meta-api-1",
+		},
+		"name-fallback prefix resolves owner and apiServiceId from cache": {
+			apiServiceRI: withMetaID(makeAPIServiceRI("api-2", &v1.Owner{Type: v1.TeamOwner, ID: testTeamGUID1}), "svc-meta-api-2"),
+			apiID:        transutil.SummaryEventAPINamePrefix + "api-2",
+			apiName:      "api-two",
+			wantOwnType:  "team",
+			wantOwnGUID:  testTeamGUID1,
+			wantSvcID:    "svc-meta-api-2",
+		},
+		"api not found in cache returns unknown owner and empty apiServiceId": {
+			apiServiceRI: nil,
+			apiID:        transutil.SummaryEventProxyIDPrefix + "missing-api",
+			apiName:      "missing",
+			wantOwnType:  "unknown",
+			wantSvcID:    "",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			agent.InitializeForTest(nil, agent.TestWithCentralConfig(newUtilCacheConfig()))
+			if tc.apiServiceRI != nil {
+				agent.GetCacheManager().AddAPIService(tc.apiServiceRI)
+			}
+
+			ref := buildAPIRef(models.APIDetails{ID: tc.apiID, Name: tc.apiName})
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.apiID, ref.ID)
+			assert.Equal(t, tc.apiName, ref.Name)
+			assert.Equal(t, tc.wantSvcID, ref.APIServiceID)
+			require.NotNil(t, ref.Owner)
+			assert.Equal(t, tc.wantOwnType, ref.Owner.Type)
+			if tc.wantOwnGUID != "" {
+				assert.Equal(t, tc.wantOwnGUID, ref.Owner.TeamGUID)
 			}
 		})
 	}

--- a/pkg/transaction/util/ownerresolver.go
+++ b/pkg/transaction/util/ownerresolver.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"strings"
-
 	"github.com/Axway/agent-sdk/pkg/agent/cache"
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
 	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1"
@@ -19,7 +17,7 @@ func ResolveAPIOwner(apiExternalID string, cacheManager cache.Manager) *models.O
 		return &models.Owner{Type: "unknown"}
 	}
 
-	apiID := strings.TrimPrefix(apiExternalID, SummaryEventProxyIDPrefix)
+	apiID := StripSummaryEventPrefix(apiExternalID)
 	ri := cacheManager.GetAPIServiceWithAPIID(apiID)
 	if ri == nil {
 		logger.WithField("apiID", apiID).Trace("api service not found in cache, owner is unknown")

--- a/pkg/transaction/util/ownerresolver_test.go
+++ b/pkg/transaction/util/ownerresolver_test.go
@@ -84,6 +84,11 @@ func TestResolveAPIOwner(t *testing.T) {
 			cache:    newCacheWithAPIService("api-5", &v1.Owner{Type: v1.TeamOwner, ID: "team-5"}),
 			expected: &models.Owner{Type: "team", TeamGUID: "team-5"},
 		},
+		"name-fallback prefix stripped before lookup": {
+			apiID:    SummaryEventAPINamePrefix + "api-7",
+			cache:    newCacheWithAPIService("api-7", &v1.Owner{Type: v1.TeamOwner, ID: "team-7"}),
+			expected: &models.Owner{Type: "team", TeamGUID: "team-7"},
+		},
 		"api service x-private owner": {
 			apiID:    "api-6",
 			cache:    newCacheWithAPIService("api-6", &v1.Owner{Type: v1.TeamOwner, ID: "team-guid-6", User: &v1.OwnerUser{ID: testOwnerUserGUID}}),

--- a/pkg/transaction/util/util.go
+++ b/pkg/transaction/util/util.go
@@ -26,6 +26,14 @@ const (
 	SummaryEventApplicationIDPrefix = "remoteAppId_"
 )
 
+// StripSummaryEventPrefix removes whichever proxy-ID prefix ResolveIDWithPrefix produced.
+// Meaning the real-ID prefix or the name-fallback prefix, leaving the bare value used as a cache lookup key.
+func StripSummaryEventPrefix(apiID string) string {
+	apiID = strings.TrimPrefix(apiID, SummaryEventProxyIDPrefix)
+	apiID = strings.TrimPrefix(apiID, SummaryEventAPINamePrefix)
+	return apiID
+}
+
 // GetAccessRequest -
 func GetAccessRequest(cacheManager cache.Manager, managedApp *v1.ResourceInstance, apiID, stage, version string) *management.AccessRequest {
 	if managedApp == nil {
@@ -33,9 +41,7 @@ func GetAccessRequest(cacheManager cache.Manager, managedApp *v1.ResourceInstanc
 	}
 
 	// Lookup Access Request
-	// apiID may carry either prefix depending on whether ResolveIDWithPrefix resolved a real ID or fell back to the name. The cache key needs the bare value either way.
-	apiID = strings.TrimPrefix(apiID, SummaryEventProxyIDPrefix)
-	apiID = strings.TrimPrefix(apiID, SummaryEventAPINamePrefix)
+	apiID = StripSummaryEventPrefix(apiID)
 	accessReq := &management.AccessRequest{}
 	ri := cacheManager.GetAccessRequestByAppAndAPIStageVersion(managedApp.Name, apiID, stage, version)
 	if ri == nil {

--- a/pkg/transaction/util/util.go
+++ b/pkg/transaction/util/util.go
@@ -33,7 +33,9 @@ func GetAccessRequest(cacheManager cache.Manager, managedApp *v1.ResourceInstanc
 	}
 
 	// Lookup Access Request
+	// apiID may carry either prefix depending on whether ResolveIDWithPrefix resolved a real ID or fell back to the name. The cache key needs the bare value either way.
 	apiID = strings.TrimPrefix(apiID, SummaryEventProxyIDPrefix)
+	apiID = strings.TrimPrefix(apiID, SummaryEventAPINamePrefix)
 	accessReq := &management.AccessRequest{}
 	ri := cacheManager.GetAccessRequestByAppAndAPIStageVersion(managedApp.Name, apiID, stage, version)
 	if ri == nil {

--- a/pkg/transaction/util/util_test.go
+++ b/pkg/transaction/util/util_test.go
@@ -128,6 +128,36 @@ func TestResolveIDWithPrefix(t *testing.T) {
 	}
 }
 
+func TestStripSummaryEventPrefix(t *testing.T) {
+	tests := map[string]struct {
+		apiID    string
+		expected string
+	}{
+		"real ID prefix stripped": {
+			apiID:    SummaryEventProxyIDPrefix + "dwight",
+			expected: "dwight",
+		},
+		"name-fallback prefix stripped": {
+			apiID:    SummaryEventAPINamePrefix + "schrute",
+			expected: "schrute",
+		},
+		"no prefix, returned as-is": {
+			apiID:    "dwight",
+			expected: "dwight",
+		},
+		"empty string": {
+			apiID:    "",
+			expected: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, StripSummaryEventPrefix(tc.apiID))
+		})
+	}
+}
+
 func TestGetMarketplaceDetails(t *testing.T) {
 	// "marketplace" as a string instead of an object triggers a real parse failure.
 	malformedInstance := &v1.ResourceInstance{}

--- a/pkg/transaction/v2event.go
+++ b/pkg/transaction/v2event.go
@@ -402,7 +402,7 @@ func buildSummaryAPIDetail(logger log.FieldLogger, apiID, apiName, apiServiceID 
 
 	detail := &insightsAPIDetail{ID: apiID, Name: apiName, Owner: apiOwner, APIServiceID: apiServiceID}
 	if apiServiceID == "" && cacheManager != nil {
-		stripped := strings.TrimPrefix(apiID, transutil.SummaryEventProxyIDPrefix)
+		stripped := transutil.StripSummaryEventPrefix(apiID)
 		if svc := cacheManager.GetAPIServiceWithAPIID(stripped); svc != nil {
 			detail.APIServiceID = svc.Metadata.ID
 		}

--- a/pkg/transaction/v2event_test.go
+++ b/pkg/transaction/v2event_test.go
@@ -8,11 +8,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Axway/agent-sdk/pkg/agent/cache"
+	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1"
+	"github.com/Axway/agent-sdk/pkg/config"
 	"github.com/Axway/agent-sdk/pkg/traceability/redaction"
 	"github.com/Axway/agent-sdk/pkg/transaction/metric"
 	"github.com/Axway/agent-sdk/pkg/transaction/models"
+	transutil "github.com/Axway/agent-sdk/pkg/transaction/util"
 	"github.com/Axway/agent-sdk/pkg/util/log"
 )
+
+func newAPIServiceRIForTest(apiID, metaID string, owner *v1.Owner) *v1.ResourceInstance {
+	svc := management.NewAPIService("svc-"+apiID, "env1")
+	svc.SubResources = map[string]interface{}{
+		"x-agent-details": map[string]interface{}{"externalAPIID": apiID},
+	}
+	svc.Owner = owner
+	ri, _ := svc.AsInstance()
+	ri.Metadata.ID = metaID
+	return ri
+}
 
 // compile-time assertions. Both data types must satisfy the V4Data interface.
 var _ metric.V4Data = (*TransactionLegData)(nil)
@@ -1186,4 +1202,57 @@ func TestV4DataInterfaceMethods(t *testing.T) {
 		fields := d.GetLogFields()
 		assert.Equal(t, "Success", fields["status"])
 	})
+}
+
+func TestBuildSummaryAPIDetailAPIServiceIDFallback(t *testing.T) {
+	const (
+		testAPIServiceGUID  = "team-guid-svc"
+		testFallbackAPIName = "api-name"
+	)
+
+	cases := map[string]struct {
+		apiServiceRI     *v1.ResourceInstance
+		apiID            string
+		apiServiceIDArg  string
+		wantAPIServiceID string
+	}{
+		"apiServiceId already populated skips cache lookup": {
+			// meta ID deliberately differs from apiServiceIDArg to prove the cache is never consulted.
+			apiServiceRI:     newAPIServiceRIForTest("api-pre", "unused-cached-id", &v1.Owner{Type: v1.TeamOwner, ID: testAPIServiceGUID}),
+			apiID:            transutil.SummaryEventProxyIDPrefix + "api-pre",
+			apiServiceIDArg:  "already-known-id",
+			wantAPIServiceID: "already-known-id",
+		},
+		"real ID prefix resolves apiServiceId via cache fallback": {
+			apiServiceRI:     newAPIServiceRIForTest("api-real", "svc-meta-api-real", &v1.Owner{Type: v1.TeamOwner, ID: testAPIServiceGUID}),
+			apiID:            transutil.SummaryEventProxyIDPrefix + "api-real",
+			apiServiceIDArg:  "",
+			wantAPIServiceID: "svc-meta-api-real",
+		},
+		"name-fallback prefix resolves apiServiceId via cache fallback": {
+			apiServiceRI:     newAPIServiceRIForTest(testFallbackAPIName, "svc-meta-api-name", &v1.Owner{Type: v1.TeamOwner, ID: testAPIServiceGUID}),
+			apiID:            transutil.SummaryEventAPINamePrefix + testFallbackAPIName,
+			apiServiceIDArg:  "",
+			wantAPIServiceID: "svc-meta-api-name",
+		},
+		"api not found in cache leaves apiServiceId empty": {
+			apiServiceRI:     nil,
+			apiID:            transutil.SummaryEventProxyIDPrefix + "missing-api",
+			apiServiceIDArg:  "",
+			wantAPIServiceID: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cacheManager := cache.NewAgentCacheManager(&config.CentralConfiguration{}, false)
+			if tc.apiServiceRI != nil {
+				cacheManager.AddAPIService(tc.apiServiceRI)
+			}
+
+			detail := buildSummaryAPIDetail(log.NewFieldLogger(), tc.apiID, testFallbackAPIName, tc.apiServiceIDArg, nil, cacheManager)
+			require.NotNil(t, detail)
+			assert.Equal(t, tc.wantAPIServiceID, detail.APIServiceID)
+		})
+	}
 }


### PR DESCRIPTION
Fixes a bug where Azure (and any agent whose API ID equals its display name) traceability events showed "unknown" for Subscription, Product, ProductPlan, Quota, AssetResource, APIServiceRevision, consumer Application, api.owner, and api.apiServiceId — even when the correct AccessRequest and APIService were cached. 

Root cause: ResolveIDWithPrefix falls back to prefixing the API name with remoteApiName_ when no real ID is available. Five separate cache-lookup call sites only ever stripped the remoteApiId_ prefix, never the remoteApiName_ fallback, so the lookup key never matched and every downstream field defaulted to unknown.

Adds StripSummaryEventPrefix in pkg/transaction/util/util.go, which strips both possible prefixes, and points all five affected call sites at it:
1. GetAccessRequest (util.go)
2. ResolveAPIOwner (ownerresolver.go)
3. buildSummaryAPIDetail's apiServiceId fallback (v2event.go)
4. createAPIDetail (metricscollector.go)
5. buildAPIRef (metric/util.go)

Adds table-driven test coverage for all affected sites, including the name-fallback regression case specifically: 
1. TestStripSummaryEventPrefix, updated TestResolveAPIOwner, TestBuildAPIRef, TestCreateAPIDetail,
2. TestBuildSummaryAPIDetailAPIServiceIDFallback.

No behavior change for any agent whose API ID never collapses to the name-fallback form (e.g. v7, webmethods) — verified live against azure-agents, webmethods-agents, and sample-agent with no regression.