### PR TITLE
APIGOV-33548 - attempt to fix race condition in metrics causing invalid timestamp

### DIFF
--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -264,6 +264,11 @@ func (c *collector) AddMetric(apiDetails models.APIDetails, statusCode string, d
 	defer c.lock.Unlock()
 	c.batchLock.Lock()
 	defer c.batchLock.Unlock()
+	c.addMetric(bytes)
+}
+
+// addMetric - updates start time, usage, and volume. Caller must hold c.lock/c.batchLock.
+func (c *collector) addMetric(bytes int64) {
 	c.updateStartTime()
 	c.updateUsage(1)
 	c.updateVolume(bytes)
@@ -271,7 +276,12 @@ func (c *collector) AddMetric(apiDetails models.APIDetails, statusCode string, d
 
 // AddMetricDetail - add metric for API transaction and consumer subscription to collection
 func (c *collector) AddMetricDetail(metricDetail Detail) {
-	c.AddMetric(metricDetail.APIDetails, metricDetail.StatusCode, metricDetail.Duration, metricDetail.Bytes, metricDetail.APIDetails.Name)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.batchLock.Lock()
+	defer c.batchLock.Unlock()
+
+	c.addMetric(metricDetail.Bytes)
 	c.createOrUpdateAPICounter(metricDetail)
 }
 
@@ -282,11 +292,12 @@ func (c *collector) AddAPIMetricDetail(detail MetricDetail) {
 	}
 
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.batchLock.Lock()
+	defer c.batchLock.Unlock()
+
 	c.updateStartTime()
 	c.updateUsage(detail.Count)
-	c.batchLock.Unlock()
-	c.lock.Unlock()
 
 	c.createOrUpdateAPICounterStats(Detail{
 		APIDetails: detail.APIDetails,

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -1724,3 +1724,119 @@ func TestGetOrgGUID(t *testing.T) {
 		})
 	}
 }
+
+const raceTestIterations = 20000
+
+// TestGroupStartTimeRace guards against an issue where AddMetricDetail/AddAPIMetricDetail
+// released c.lock/c.batchLock before finishing their update, leaving a window where a concurrent
+// publish cycle's reset of c.metricStartTime (see generateEvents) could be read as the zero value
+// and inserted into a metric's groupStartTime.
+func TestGroupStartTimeRace(t *testing.T) {
+	apiDetails := models.APIDetails{ID: "race-api", Name: "race-api"}
+	appDetails := models.AppDetails{ID: "race-app", Name: "race-app"}
+
+	tests := map[string]struct {
+		addMetric func(c *collector)
+	}{
+		"AddMetricDetail": {
+			addMetric: func(c *collector) {
+				c.AddMetricDetail(Detail{
+					APIDetails: apiDetails,
+					AppDetails: appDetails,
+					StatusCode: "200",
+					Duration:   10,
+					Bytes:      10,
+				})
+			},
+		},
+		"AddAPIMetricDetail": {
+			addMetric: func(c *collector) {
+				c.AddAPIMetricDetail(MetricDetail{
+					APIDetails: apiDetails,
+					AppDetails: appDetails,
+					StatusCode: "200",
+					Count:      1,
+				})
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			runGroupStartTimeRaceCase(t, tc.addMetric)
+		})
+	}
+}
+
+// runGroupStartTimeRaceCase builds a fresh collector, races addMetric against a simulated
+// generateEvents() reset of c.metricStartTime, then fails if any metric ends up with a
+// zero-value groupStartTime.
+func runGroupStartTimeRaceCase(t *testing.T, addMetric func(c *collector)) {
+	t.Helper()
+	defer cleanUpCachedMetricFile()
+	s := &testHTTPServer{}
+	defer s.closeServer()
+	s.startServer()
+	traceability.SetDataDirPath(".")
+
+	cfg := createCentralCfg(s.server.URL, "demo")
+	cfg.MetricReporting.(*config.MetricReportingConfiguration).Publish = true
+	cfg.SetEnvironmentID(testEnvID)
+	cmd.BuildDataPlaneType = "Azure"
+	agent.Initialize(cfg)
+
+	c := createMetricCollector().(*collector)
+
+	stop := make(chan struct{})
+	var resetWG sync.WaitGroup
+	resetWG.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// exactly what generateEvents() does to c.metricStartTime, under the same lock
+				c.lock.Lock()
+				c.metricStartTime = time.Time{}
+				c.lock.Unlock()
+			}
+		}
+	})
+
+	var addWG sync.WaitGroup
+	for range raceTestIterations {
+		addWG.Go(func() {
+			addMetric(c)
+		})
+	}
+	addWG.Wait()
+	close(stop)
+	resetWG.Wait()
+
+	assertNoZeroGroupStartTime(t, c)
+}
+
+// assertNoZeroGroupStartTime fails the test if any metric in the collector's registry has a
+// groupStartTime matching the Go zero-value time.Time.
+func assertNoZeroGroupStartTime(t *testing.T, c *collector) {
+	t.Helper()
+	zeroMillis := time.Time{}.UnixMilli()
+	found := 0
+	c.registry.Each(func(name string, m any) {
+		group, ok := m.(groupedMetrics)
+		if !ok {
+			return
+		}
+		for key, metric := range group.metrics {
+			if metric.groupStartTime == zeroMillis {
+				found++
+				t.Logf("corrupted metric found: registry=%s key=%s groupStartTime=%d", name, key, metric.groupStartTime)
+			}
+		}
+	})
+
+	if found > 0 {
+		t.Fatalf("found %d metric(s) with a zero-value groupStartTime out of %d add attempts", found, raceTestIterations)
+	}
+}


### PR DESCRIPTION
Agent-sdk's metric collector intermittently publishes events with an invalid timestamp of 0001-01-01T00:00:00Z (-62135596800000 ms). First reported by Alasdair on the "Alpha Galactosidase" org. The corrupted event kept resending hourly with the same event ID since the failed batch never acked/cleaned up.

AddMetricDetail/AddAPIMetricDetail in pkg/transaction/metric/metricscollector.go looks to be releasing the collector's locks before finishing their update, leaving c.metricStartTime readable unprotected. The scheduled publish job resets that same field to the Go zero-value once per cycle, under lock. If the reset lands in that unprotected gap, the metric being recorded picks up the zero value, which then publishes as its timestamp. 

Race opens once per publish cycle, matching the "hourly" pattern. AddCustomMetricDetail/AddAPIMetric already locked correctly and were unaffected. Present in main (via PR #1080, commit e47d9c55) and in [APIGOV-33037](https://jira.axway.com/browse/APIGOV-33037)-JC.

seen locally and in continuous testing cluseter