### PR TITLE
APIGOV-33596 - Metric events showing incorrect or incomplete owner and context data in some cases

### DIFF
--- a/pkg/transaction/metric/contract_test.go
+++ b/pkg/transaction/metric/contract_test.go
@@ -133,7 +133,7 @@ func TestContractMetricV3(t *testing.T) {
 				assert.Equal(t, "team-ctr-2", cm.API.Owner.TeamGUID)
 			},
 		},
-		"api owner falls back to unknown on cache miss": {
+		"api owner falls back to none on cache miss": {
 			setup: func() {
 				agent.InitializeForTest(nil, agent.TestWithCentralConfig(&config.CentralConfiguration{AgentName: contractAgentName}))
 			},
@@ -150,7 +150,7 @@ func TestContractMetricV3(t *testing.T) {
 			check: func(t *testing.T, cm *centralMetric, raw string) {
 				require.NotNil(t, cm.API)
 				require.NotNil(t, cm.API.Owner)
-				assert.Equal(t, "unknown", cm.API.Owner.Type)
+				assert.Equal(t, "none", cm.API.Owner.Type)
 			},
 		},
 		"application owner populated from cache": {

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -586,9 +586,10 @@ func (c *collector) getAccessRequestAndManagedApp(cacheManager cache.Manager, de
 
 	// get the managed application
 	// cached metrics will only have the catalog api id
-	managedApp := cacheManager.GetManagedApplicationByApplicationID(detail.AppDetails.ID)
+	appID := transutil.StripApplicationIDPrefix(detail.AppDetails.ID)
+	managedApp := cacheManager.GetManagedApplicationByApplicationID(appID)
 	if managedApp == nil {
-		managedApp = cacheManager.GetManagedApplication(detail.AppDetails.ID)
+		managedApp = cacheManager.GetManagedApplication(appID)
 	}
 	if managedApp == nil {
 		managedApp = cacheManager.GetManagedApplicationByName(detail.AppDetails.Name)

--- a/pkg/transaction/metric/metricscollector.go
+++ b/pkg/transaction/metric/metricscollector.go
@@ -720,6 +720,7 @@ func (c *collector) getProduct(accessRequest *management.AccessRequest) *models.
 		return &models.ProductResourceReference{
 			ResourceReference: models.ResourceReference{ID: unknown},
 			VersionID:         unknown,
+			Owner:             &models.Owner{Type: none},
 		}
 	}
 
@@ -732,8 +733,9 @@ func (c *collector) getProduct(accessRequest *management.AccessRequest) *models.
 	}
 	if productRef.ID != "" {
 		ref.ID = productRef.ID
-		// owner only applies once the product itself is resolved
 		ref.Owner = transutil.ResolveProductOwner(accessRequest.GetEmbeddedReferenceByGVK(catalog.PublishedProductGVK()))
+	} else {
+		ref.Owner = &models.Owner{Type: none}
 	}
 	if releaseRef.ID != "" {
 		ref.VersionID = releaseRef.ID

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -1545,11 +1545,11 @@ func TestCreateAPIDetail(t *testing.T) {
 			wantOwnGUID:  testTeamGUID1,
 			wantSvcID:    "svc-meta-api-2",
 		},
-		"api not found in cache returns unknown owner and apiServiceId": {
+		"api not found in cache returns none owner and unknown apiServiceId": {
 			apiServiceRI: nil,
 			apiID:        transutil.SummaryEventProxyIDPrefix + "missing-api",
 			apiName:      "missing",
-			wantOwnType:  "unknown",
+			wantOwnType:  "none",
 			wantSvcID:    unknown,
 		},
 	}
@@ -1858,17 +1858,17 @@ func TestGetProduct(t *testing.T) {
 		wantVersionID string
 		wantOwner     *models.Owner
 	}{
-		"nil access request returns unknown id and versionId, no owner": {
+		"nil access request returns unknown id and versionId, owner none": {
 			accessRequest: nil,
 			wantID:        unknown,
 			wantVersionID: unknown,
-			wantOwner:     nil,
+			wantOwner:     &models.Owner{Type: "none"},
 		},
-		"no product or release reference returns unknown id and versionId, no owner": {
+		"no product or release reference returns unknown id and versionId, owner none": {
 			accessRequest: &management.AccessRequest{},
 			wantID:        unknown,
 			wantVersionID: unknown,
-			wantOwner:     nil,
+			wantOwner:     &models.Owner{Type: "none"},
 		},
 		"product reference resolves id and owner, versionId stays unknown without a release reference": {
 			accessRequest: &management.AccessRequest{

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
 	apiv1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
@@ -1574,6 +1575,356 @@ func TestCreateAPIDetail(t *testing.T) {
 			if tc.wantOwnGUID != "" {
 				assert.Equal(t, tc.wantOwnGUID, ref.Owner.TeamGUID)
 			}
+		})
+	}
+}
+
+func TestGetAccessRequestAndManagedApp(t *testing.T) {
+	const (
+		remoteAppMetaID = "app-remote"
+		plainAppMetaID  = "app-plain"
+		otherAppMetaID  = "app-other"
+	)
+	cases := map[string]struct {
+		managedAppRI *apiv1.ResourceInstance
+		appID        string
+		appName      string
+		wantAppMeta  string
+	}{
+		"remoteAppId_ prefix stripped before lookup": {
+			managedAppRI: createManagedApplication(remoteAppMetaID, testManagedApp1, ""),
+			appID:        transutil.SummaryEventApplicationIDPrefix + remoteAppMetaID,
+			wantAppMeta:  remoteAppMetaID,
+		},
+		"unprefixed appID still resolves": {
+			managedAppRI: createManagedApplication(plainAppMetaID, testManagedApp1, ""),
+			appID:        plainAppMetaID,
+			wantAppMeta:  plainAppMetaID,
+		},
+		"app not found in cache returns nil": {
+			managedAppRI: createManagedApplication(otherAppMetaID, testManagedApp1, ""),
+			appID:        transutil.SummaryEventApplicationIDPrefix + "missing-app",
+			appName:      "no-such-app",
+			wantAppMeta:  "",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			agent.InitializeForTest(nil, agent.TestWithCentralConfig(newUtilCacheConfig()))
+			agent.GetCacheManager().AddManagedApplication(tc.managedAppRI)
+
+			c := &collector{logger: log.NewFieldLogger()}
+			_, managedApp := c.getAccessRequestAndManagedApp(agent.GetCacheManager(), transactionContext{
+				AppDetails: models.AppDetails{ID: tc.appID, Name: tc.appName},
+			})
+
+			if tc.wantAppMeta == "" {
+				assert.Nil(t, managedApp)
+				return
+			}
+			require.NotNil(t, managedApp)
+			assert.Equal(t, tc.wantAppMeta, managedApp.Metadata.ID)
+		})
+	}
+}
+
+// quotaReference builds the raw references[] sub-resource entry getQuota reads to find a
+// quota's name for a given unit. Production access requests take this same map shape only
+// after a JSON round trip through ResourceInstance; the literal here reproduces that shape
+// directly since getQuota type-asserts each entry to map[string]interface{}.
+func quotaReference(unit, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"kind": catalog.QuotaGVK().Kind,
+		"unit": unit,
+		"name": name,
+	}
+}
+
+func TestGetQuota(t *testing.T) {
+	const (
+		quotaRefPrefix    = "org/catalog/"
+		quotaUnitName     = "widgets"
+		quotaRefName      = "quota-ref-name"
+		quotaGUID         = "quota-guid-1"
+		otherQuotaRefName = "quota-ref-name-2"
+		otherQuotaGUID    = "quota-guid-2"
+	)
+	metaRefFor := func(name, id string) apiv1.Reference {
+		return apiv1.Reference{Group: catalog.QuotaGVK().Group, Kind: catalog.QuotaGVK().Kind, Name: name, ID: id}
+	}
+
+	cases := map[string]struct {
+		accessRequest *management.AccessRequest
+		unitName      string
+		wantID        string
+	}{
+		"nil access request returns unknown": {
+			accessRequest: nil,
+			unitName:      defaultUnit,
+			wantID:        unknown,
+		},
+		"no quota reference for unit returns unknown": {
+			accessRequest: &management.AccessRequest{
+				References: []interface{}{quotaReference(quotaUnitName, quotaRefPrefix+quotaRefName)},
+			},
+			unitName: defaultUnit,
+			wantID:   unknown,
+		},
+		"quota name resolved but no matching metadata reference returns unknown": {
+			accessRequest: &management.AccessRequest{
+				References: []interface{}{quotaReference(defaultUnit, quotaRefPrefix+quotaRefName)},
+			},
+			unitName: defaultUnit,
+			wantID:   unknown,
+		},
+		"quota resolves to id for default unit": {
+			accessRequest: &management.AccessRequest{
+				References: []interface{}{quotaReference(defaultUnit, quotaRefPrefix+quotaRefName)},
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{metaRefFor(quotaRefName, quotaGUID)}},
+				},
+			},
+			unitName: defaultUnit,
+			wantID:   quotaGUID,
+		},
+		"empty unit name falls back to default unit": {
+			accessRequest: &management.AccessRequest{
+				References: []interface{}{quotaReference(defaultUnit, quotaRefPrefix+quotaRefName)},
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{metaRefFor(quotaRefName, quotaGUID)}},
+				},
+			},
+			unitName: "",
+			wantID:   quotaGUID,
+		},
+		"quota resolves to id for a named custom unit, ignoring other units' quotas": {
+			accessRequest: &management.AccessRequest{
+				References: []interface{}{
+					quotaReference(defaultUnit, quotaRefPrefix+quotaRefName),
+					quotaReference(quotaUnitName, quotaRefPrefix+otherQuotaRefName),
+				},
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{
+						metaRefFor(quotaRefName, quotaGUID),
+						metaRefFor(otherQuotaRefName, otherQuotaGUID),
+					}},
+				},
+			},
+			unitName: quotaUnitName,
+			wantID:   otherQuotaGUID,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.getQuota(tc.accessRequest, tc.unitName)
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.wantID, ref.ID)
+		})
+	}
+}
+
+// metaRef builds a Metadata.References entry for gvk, the structured relationship reference
+// read by GetReferenceByGVK (distinct from the raw references[] sub-resource getQuota reads).
+func metaRef(gvk apiv1.GroupVersionKind, id string) apiv1.Reference {
+	return apiv1.Reference{Group: gvk.Group, Kind: gvk.Kind, ID: id}
+}
+
+func TestGetAPIServiceRevision(t *testing.T) {
+	const revisionGUID = "instance-guid-1"
+
+	cases := map[string]struct {
+		accessRequest *management.AccessRequest
+		wantID        string
+	}{
+		"nil access request returns unknown": {
+			accessRequest: nil,
+			wantID:        unknown,
+		},
+		"no APIServiceInstance reference returns unknown": {
+			accessRequest: &management.AccessRequest{},
+			wantID:        unknown,
+		},
+		"APIServiceInstance reference resolves to its id": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{
+						metaRef(management.APIServiceInstanceGVK(), revisionGUID),
+					}},
+				},
+			},
+			wantID: revisionGUID,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.getAPIServiceRevision(tc.accessRequest)
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.wantID, ref.ID)
+		})
+	}
+}
+
+func TestGetAssetResource(t *testing.T) {
+	const assetGUID = "asset-guid-1"
+
+	cases := map[string]struct {
+		accessRequest *management.AccessRequest
+		wantID        string
+	}{
+		"nil access request returns unknown": {
+			accessRequest: nil,
+			wantID:        unknown,
+		},
+		"no AssetResource reference returns unknown": {
+			accessRequest: &management.AccessRequest{},
+			wantID:        unknown,
+		},
+		"AssetResource reference resolves to its id": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{
+						metaRef(catalog.AssetResourceGVK(), assetGUID),
+					}},
+				},
+			},
+			wantID: assetGUID,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.getAssetResource(tc.accessRequest)
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.wantID, ref.ID)
+		})
+	}
+}
+
+func TestGetProductPlan(t *testing.T) {
+	const planGUID = "plan-guid-1"
+
+	cases := map[string]struct {
+		accessRequest *management.AccessRequest
+		wantID        string
+	}{
+		"nil access request returns unknown": {
+			accessRequest: nil,
+			wantID:        unknown,
+		},
+		"no ProductPlan reference returns unknown": {
+			accessRequest: &management.AccessRequest{},
+			wantID:        unknown,
+		},
+		"ProductPlan reference resolves to its id": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{References: []apiv1.Reference{
+						metaRef(catalog.ProductPlanGVK(), planGUID),
+					}},
+				},
+			},
+			wantID: planGUID,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.getProductPlan(tc.accessRequest)
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.wantID, ref.ID)
+		})
+	}
+}
+
+func TestGetProduct(t *testing.T) {
+	const (
+		productGUID    = "product-guid-1"
+		releaseGUID    = "release-guid-1"
+		productOwnerID = "product-team-guid-1"
+	)
+	embeddedOwner := func(owner *apiv1.Owner) map[string]apiv1.EmbeddedReferences {
+		return map[string]apiv1.EmbeddedReferences{
+			"metadata.references": {References: []apiv1.EmbeddedReference{
+				{Group: catalog.PublishedProductGVK().Group, Kind: catalog.PublishedProductGVK().Kind, Owner: owner},
+			}},
+		}
+	}
+
+	cases := map[string]struct {
+		accessRequest *management.AccessRequest
+		wantID        string
+		wantVersionID string
+		wantOwner     *models.Owner
+	}{
+		"nil access request returns unknown id and versionId, no owner": {
+			accessRequest: nil,
+			wantID:        unknown,
+			wantVersionID: unknown,
+			wantOwner:     nil,
+		},
+		"no product or release reference returns unknown id and versionId, no owner": {
+			accessRequest: &management.AccessRequest{},
+			wantID:        unknown,
+			wantVersionID: unknown,
+			wantOwner:     nil,
+		},
+		"product reference resolves id and owner, versionId stays unknown without a release reference": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{
+						References: []apiv1.Reference{metaRef(catalog.ProductGVK(), productGUID)},
+					},
+					Embedded: embeddedOwner(&apiv1.Owner{Type: apiv1.TeamOwner, ID: productOwnerID}),
+				},
+			},
+			wantID:        productGUID,
+			wantVersionID: unknown,
+			wantOwner:     &models.Owner{Type: "team", TeamGUID: productOwnerID},
+		},
+		"product and release references both resolve": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{
+						References: []apiv1.Reference{
+							metaRef(catalog.ProductGVK(), productGUID),
+							metaRef(catalog.ProductReleaseGVK(), releaseGUID),
+						},
+					},
+					Embedded: embeddedOwner(&apiv1.Owner{Type: apiv1.TeamOwner, ID: productOwnerID}),
+				},
+			},
+			wantID:        productGUID,
+			wantVersionID: releaseGUID,
+			wantOwner:     &models.Owner{Type: "team", TeamGUID: productOwnerID},
+		},
+		"product resolved without an embedded owner reference returns owner type none": {
+			accessRequest: &management.AccessRequest{
+				ResourceMeta: apiv1.ResourceMeta{
+					Metadata: apiv1.Metadata{
+						References: []apiv1.Reference{metaRef(catalog.ProductGVK(), productGUID)},
+					},
+				},
+			},
+			wantID:        productGUID,
+			wantVersionID: unknown,
+			wantOwner:     &models.Owner{Type: "none"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &collector{logger: log.NewFieldLogger()}
+			ref := c.getProduct(tc.accessRequest)
+			require.NotNil(t, ref)
+			assert.Equal(t, tc.wantID, ref.ID)
+			assert.Equal(t, tc.wantVersionID, ref.VersionID)
+			assert.Equal(t, tc.wantOwner, ref.Owner)
 		})
 	}
 }

--- a/pkg/transaction/metric/metricscollector_test.go
+++ b/pkg/transaction/metric/metricscollector_test.go
@@ -1628,10 +1628,6 @@ func TestGetAccessRequestAndManagedApp(t *testing.T) {
 	}
 }
 
-// quotaReference builds the raw references[] sub-resource entry getQuota reads to find a
-// quota's name for a given unit. Production access requests take this same map shape only
-// after a JSON round trip through ResourceInstance; the literal here reproduces that shape
-// directly since getQuota type-asserts each entry to map[string]interface{}.
 func quotaReference(unit, name string) map[string]interface{} {
 	return map[string]interface{}{
 		"kind": catalog.QuotaGVK().Kind,

--- a/pkg/transaction/metric/util.go
+++ b/pkg/transaction/metric/util.go
@@ -141,6 +141,7 @@ func resolveAppOwnerFromCache(appID string) *models.Owner {
 	if cacheManager == nil {
 		return &models.Owner{Type: unknown}
 	}
+	appID = transutil.StripApplicationIDPrefix(appID)
 	managedApp := cacheManager.GetManagedApplicationByApplicationID(appID)
 	if managedApp == nil {
 		managedApp = cacheManager.GetManagedApplication(appID)

--- a/pkg/transaction/metric/util.go
+++ b/pkg/transaction/metric/util.go
@@ -139,7 +139,7 @@ func buildAppRef(app models.AppDetails) *models.ApplicationResourceReference {
 func resolveAppOwnerFromCache(appID string) *models.Owner {
 	cacheManager := agent.GetCacheManager()
 	if cacheManager == nil {
-		return &models.Owner{Type: unknown}
+		return &models.Owner{Type: none}
 	}
 	appID = transutil.StripApplicationIDPrefix(appID)
 	managedApp := cacheManager.GetManagedApplicationByApplicationID(appID)
@@ -149,7 +149,7 @@ func resolveAppOwnerFromCache(appID string) *models.Owner {
 	if managedApp != nil {
 		return transutil.ResolveAppOwnerFromManagedApp(managedApp)
 	}
-	return &models.Owner{Type: unknown}
+	return &models.Owner{Type: none}
 }
 
 func buildAPIRef(api models.APIDetails) *models.APIResourceReference {

--- a/pkg/transaction/metric/util_test.go
+++ b/pkg/transaction/metric/util_test.go
@@ -180,7 +180,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 					},
 					Name:         "api",
 					APIServiceID: "",
-					Owner:        &models.Owner{Type: "unknown"},
+					Owner:        &models.Owner{Type: "none"},
 				},
 				Product: &models.ProductResourceReference{
 					ResourceReference: models.ResourceReference{
@@ -193,7 +193,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 						ID: "app",
 					},
 					ConsumerOrgID: "org",
-					Owner:         &models.Owner{Type: "unknown"},
+					Owner:         &models.Owner{Type: "none"},
 				},
 				Subscription: &models.ResourceReference{
 					ID: "sub",
@@ -337,7 +337,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 				APIServiceRevision: &models.ResourceReference{ID: "revision-id-1"},
 			},
 		},
-		"api owner demoted to unknown when cached APIService has empty team GUID": {
+		"api owner demoted to none when cached APIService has empty team GUID": {
 			setupCache: func() {
 				agent.GetCacheManager().AddAPIService(
 					makeAPIServiceRI(testAPIEmptyGUID, &v1.Owner{Type: v1.TeamOwner, ID: ""}),
@@ -373,11 +373,11 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 				API: &models.APIResourceReference{
 					ResourceReference: models.ResourceReference{ID: testAPIEmptyGUID},
 					Name:              "api-svc",
-					Owner:             &models.Owner{Type: "unknown"},
+					Owner:             &models.Owner{Type: "none"},
 				},
 			},
 		},
-		"app owner demoted to unknown when cached ManagedApp has empty team GUID": {
+		"app owner demoted to none when cached ManagedApp has empty team GUID": {
 			setupCache: func() {
 				agent.GetCacheManager().AddManagedApplication(
 					makeAppRI(testAppEmptyGUID, &v1.Owner{Type: v1.TeamOwner, ID: ""}),
@@ -412,7 +412,7 @@ func TestCentralMetricFromAPIMetric(t *testing.T) {
 				},
 				App: &models.ApplicationResourceReference{
 					ResourceReference: models.ResourceReference{ID: testAppEmptyGUID},
-					Owner:             &models.Owner{Type: "unknown"},
+					Owner:             &models.Owner{Type: "none"},
 				},
 			},
 		},
@@ -516,10 +516,10 @@ func TestResolveAppOwnerFromCache(t *testing.T) {
 		wantType string
 		wantGUID string
 	}{
-		"app not found in cache returns unknown": {
+		"app not found in cache returns none": {
 			appRI:    nil,
 			appID:    "missing-app",
-			wantType: "unknown",
+			wantType: "none",
 		},
 		"app found with team owner returns team block": {
 			appRI:    makeAppRI("app-team", &v1.Owner{Type: v1.TeamOwner, ID: testTeamGUID1}),
@@ -532,10 +532,10 @@ func TestResolveAppOwnerFromCache(t *testing.T) {
 			appID:    "app-no-owner",
 			wantType: "none",
 		},
-		"app with empty team GUID returns unknown": {
+		"app with empty team GUID returns none": {
 			appRI:    makeAppRI(testAppEmptyGUID, &v1.Owner{Type: v1.TeamOwner, ID: ""}),
 			appID:    testAppEmptyGUID,
-			wantType: "unknown",
+			wantType: "none",
 		},
 		"remoteAppId_ prefix stripped before lookup": {
 			appRI:    makeAppRI("app-remote", &v1.Owner{Type: v1.TeamOwner, ID: testTeamGUID1}),
@@ -586,11 +586,11 @@ func TestBuildAPIRef(t *testing.T) {
 			wantOwnGUID:  testTeamGUID1,
 			wantSvcID:    "svc-meta-api-2",
 		},
-		"api not found in cache returns unknown owner and empty apiServiceId": {
+		"api not found in cache returns none owner and empty apiServiceId": {
 			apiServiceRI: nil,
 			apiID:        transutil.SummaryEventProxyIDPrefix + "missing-api",
 			apiName:      "missing",
-			wantOwnType:  "unknown",
+			wantOwnType:  "none",
 			wantSvcID:    "",
 		},
 	}

--- a/pkg/transaction/metric/util_test.go
+++ b/pkg/transaction/metric/util_test.go
@@ -537,6 +537,12 @@ func TestResolveAppOwnerFromCache(t *testing.T) {
 			appID:    testAppEmptyGUID,
 			wantType: "unknown",
 		},
+		"remoteAppId_ prefix stripped before lookup": {
+			appRI:    makeAppRI("app-remote", &v1.Owner{Type: v1.TeamOwner, ID: testTeamGUID1}),
+			appID:    transutil.SummaryEventApplicationIDPrefix + "app-remote",
+			wantType: "team",
+			wantGUID: testTeamGUID1,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/transaction/util/ownerresolver.go
+++ b/pkg/transaction/util/ownerresolver.go
@@ -14,14 +14,14 @@ var logger = log.NewFieldLogger().
 
 func ResolveAPIOwner(apiExternalID string, cacheManager cache.Manager) *models.Owner {
 	if cacheManager == nil {
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	apiID := StripSummaryEventPrefix(apiExternalID)
 	ri := cacheManager.GetAPIServiceWithAPIID(apiID)
 	if ri == nil {
 		logger.WithField("apiID", apiID).Trace("api service not found in cache, owner is unknown")
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	return ResolveAPIOwnerFromInstance(ri)
@@ -29,12 +29,12 @@ func ResolveAPIOwner(apiExternalID string, cacheManager cache.Manager) *models.O
 
 func ResolveAPIOwnerFromInstance(ri *v1.ResourceInstance) *models.Owner {
 	if ri == nil {
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	svc := &management.APIService{}
 	if err := svc.FromInstance(ri); err != nil {
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	if svc.Owner == nil {
@@ -44,7 +44,7 @@ func ResolveAPIOwnerFromInstance(ri *v1.ResourceInstance) *models.Owner {
 
 	if svc.Owner.Type == v1.TeamOwner {
 		if svc.Owner.ID == "" {
-			return &models.Owner{Type: "unknown"}
+			return &models.Owner{Type: "none"}
 		}
 		if svc.Owner.User != nil && svc.Owner.User.ID != "" {
 			logger.WithField("apiName", ri.Name).WithField("userGUID", svc.Owner.User.ID).Trace("resolved api owner as user (x-private team)")
@@ -54,7 +54,7 @@ func ResolveAPIOwnerFromInstance(ri *v1.ResourceInstance) *models.Owner {
 		return &models.Owner{Type: "team", TeamGUID: svc.Owner.ID}
 	}
 
-	return &models.Owner{Type: "unknown"}
+	return &models.Owner{Type: "none"}
 }
 
 func ResolveProductOwner(ref v1.EmbeddedReference) *models.Owner {
@@ -63,24 +63,24 @@ func ResolveProductOwner(ref v1.EmbeddedReference) *models.Owner {
 	}
 	if ref.Owner.Type == v1.TeamOwner {
 		if ref.Owner.ID == "" {
-			return &models.Owner{Type: "unknown"}
+			return &models.Owner{Type: "none"}
 		}
 		if ref.Owner.User != nil && ref.Owner.User.ID != "" {
 			return &models.Owner{Type: "user", TeamGUID: ref.Owner.ID, UserGUID: ref.Owner.User.ID}
 		}
 		return &models.Owner{Type: "team", TeamGUID: ref.Owner.ID}
 	}
-	return &models.Owner{Type: "unknown"}
+	return &models.Owner{Type: "none"}
 }
 
 func ResolveAppOwnerFromManagedApp(manApp *v1.ResourceInstance) *models.Owner {
 	if manApp == nil {
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	app := &management.ManagedApplication{}
 	if err := app.FromInstance(manApp); err != nil {
-		return &models.Owner{Type: "unknown"}
+		return &models.Owner{Type: "none"}
 	}
 
 	owner := app.Marketplace.Resource.Owner
@@ -91,7 +91,7 @@ func ResolveAppOwnerFromManagedApp(manApp *v1.ResourceInstance) *models.Owner {
 
 	if owner.Type == v1.TeamOwner {
 		if owner.ID == "" {
-			return &models.Owner{Type: "unknown"}
+			return &models.Owner{Type: "none"}
 		}
 		if owner.User != nil && owner.User.ID != "" {
 			logger.WithField("appName", manApp.Name).WithField("userGUID", owner.User.ID).Trace("resolved app owner as user (x-private team)")
@@ -101,5 +101,5 @@ func ResolveAppOwnerFromManagedApp(manApp *v1.ResourceInstance) *models.Owner {
 		return &models.Owner{Type: "team", TeamGUID: owner.ID}
 	}
 
-	return &models.Owner{Type: "unknown"}
+	return &models.Owner{Type: "none"}
 }

--- a/pkg/transaction/util/ownerresolver_test.go
+++ b/pkg/transaction/util/ownerresolver_test.go
@@ -54,15 +54,15 @@ func TestResolveAPIOwner(t *testing.T) {
 		cache    agentcache.Manager
 		expected *models.Owner
 	}{
-		"nil cache manager returns unknown": {
+		"nil cache manager returns none": {
 			apiID:    "api-1",
 			cache:    nil,
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
-		"cache miss returns unknown": {
+		"cache miss returns none": {
 			apiID:    "not-in-cache",
 			cache:    newCacheWithAPIService("api-1", &v1.Owner{Type: v1.TeamOwner, ID: "team-1"}),
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"api service with nil owner": {
 			apiID:    "api-2",
@@ -77,7 +77,7 @@ func TestResolveAPIOwner(t *testing.T) {
 		"api service team owner with empty GUID": {
 			apiID:    "api-4",
 			cache:    newCacheWithAPIService("api-4", &v1.Owner{Type: v1.TeamOwner, ID: ""}),
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"prefix stripped before lookup": {
 			apiID:    SummaryEventProxyIDPrefix + "api-5",
@@ -108,9 +108,9 @@ func TestResolveAPIOwnerFromInstance(t *testing.T) {
 		ri       *v1.ResourceInstance
 		expected *models.Owner
 	}{
-		"nil resource instance returns unknown": {
+		"nil resource instance returns none": {
 			ri:       nil,
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"api service with nil owner returns none": {
 			ri:       apiServiceRI("api-1", nil),
@@ -122,7 +122,7 @@ func TestResolveAPIOwnerFromInstance(t *testing.T) {
 		},
 		"api service team owner with empty GUID": {
 			ri:       apiServiceRI("api-3", &v1.Owner{Type: v1.TeamOwner, ID: ""}),
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"api service x-private owner": {
 			ri:       apiServiceRI("api-4", &v1.Owner{Type: v1.TeamOwner, ID: testOwnerTeamGUID1, User: &v1.OwnerUser{ID: testOwnerUserGUID}}),
@@ -153,7 +153,7 @@ func TestResolveProductOwner(t *testing.T) {
 		},
 		"product ref team owner with empty GUID": {
 			ref:      v1.EmbeddedReference{Owner: &v1.Owner{Type: v1.TeamOwner, ID: ""}},
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"reference with name but no owner returns none": {
 			ref:      v1.EmbeddedReference{Kind: "PublishedProduct", Name: "product-1"},
@@ -176,9 +176,9 @@ func TestResolveAppOwnerFromManagedApp(t *testing.T) {
 		manApp   *v1.ResourceInstance
 		expected *models.Owner
 	}{
-		"nil resource instance returns unknown": {
+		"nil resource instance returns none": {
 			manApp:   nil,
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"managed app with nil owner": {
 			manApp:   managedAppRI("app-1", nil),
@@ -190,7 +190,7 @@ func TestResolveAppOwnerFromManagedApp(t *testing.T) {
 		},
 		"managed app team owner with empty GUID": {
 			manApp:   managedAppRI("app-3", &v1.Owner{Type: v1.TeamOwner, ID: ""}),
-			expected: &models.Owner{Type: "unknown"},
+			expected: &models.Owner{Type: "none"},
 		},
 		"managed app x-private owner": {
 			manApp:   managedAppRI("app-4", &v1.Owner{Type: v1.TeamOwner, ID: testOwnerTeamGUID2, User: &v1.OwnerUser{ID: testOwnerUserGUID}}),

--- a/pkg/transaction/util/util.go
+++ b/pkg/transaction/util/util.go
@@ -34,6 +34,12 @@ func StripSummaryEventPrefix(apiID string) string {
 	return apiID
 }
 
+// StripApplicationIDPrefix removes the synthetic application-ID prefix ResolveIDWithPrefix produced,
+// leaving the bare value used as a cache lookup key.
+func StripApplicationIDPrefix(appID string) string {
+	return strings.TrimPrefix(appID, SummaryEventApplicationIDPrefix)
+}
+
 // GetAccessRequest -
 func GetAccessRequest(cacheManager cache.Manager, managedApp *v1.ResourceInstance, apiID, stage, version string) *management.AccessRequest {
 	if managedApp == nil {

--- a/pkg/transaction/util/util_test.go
+++ b/pkg/transaction/util/util_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
+	management "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/management/v1"
 	"github.com/Axway/agent-sdk/pkg/transaction/models"
 )
 
@@ -158,7 +159,49 @@ func TestStripSummaryEventPrefix(t *testing.T) {
 	}
 }
 
+func TestStripApplicationIDPrefix(t *testing.T) {
+	tests := map[string]struct {
+		appID    string
+		expected string
+	}{
+		"app-ID prefix stripped": {
+			appID:    SummaryEventApplicationIDPrefix + "dwight",
+			expected: "dwight",
+		},
+		"no prefix, returned as-is": {
+			appID:    "dwight",
+			expected: "dwight",
+		},
+		"empty string": {
+			appID:    "",
+			expected: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, StripApplicationIDPrefix(tc.appID))
+		})
+	}
+}
+
+func marketplaceAppRI(marketplaceName string, owner *v1.Owner) *v1.ResourceInstance {
+	app := management.NewManagedApplication("mp-app", "env1")
+	app.Marketplace = management.ManagedApplicationMarketplace{
+		Name:     marketplaceName,
+		Resource: management.ManagedApplicationMarketplaceResource{Owner: owner},
+	}
+	ri, _ := app.AsInstance()
+	return ri
+}
+
 func TestGetMarketplaceDetails(t *testing.T) {
+	const (
+		testMarketplaceGUID  = "marketplace-guid-1"
+		testConsumerOrgID    = "consumer-org-1"
+		testConsumerTeamGUID = "consumer-team-1"
+	)
+
 	// "marketplace" as a string instead of an object triggers a real parse failure.
 	malformedInstance := &v1.ResourceInstance{}
 	err := json.Unmarshal([]byte(`{"marketplace":"not-an-object"}`), malformedInstance)
@@ -179,6 +222,29 @@ func TestGetMarketplaceDetails(t *testing.T) {
 		"malformed instance returns unknown guid since marketplace context could not be determined": {
 			ri:       malformedInstance,
 			expected: &models.MarketplaceReference{GUID: unknown, ConsumerOrgID: none},
+		},
+		"resolved marketplace name and consumer org resolve to real values": {
+			ri: marketplaceAppRI(testMarketplaceGUID, &v1.Owner{
+				ID:           testConsumerTeamGUID,
+				Organization: v1.Organization{ID: testConsumerOrgID},
+			}),
+			expected: &models.MarketplaceReference{
+				GUID:           testMarketplaceGUID,
+				ConsumerOrgID:  testConsumerOrgID,
+				ConsumerTeamID: testConsumerTeamGUID,
+			},
+		},
+		"marketplace name resolved but owner absent leaves consumer org as none": {
+			ri:       marketplaceAppRI(testMarketplaceGUID, nil),
+			expected: &models.MarketplaceReference{GUID: testMarketplaceGUID, ConsumerOrgID: none},
+		},
+		"owner present without an organization id leaves consumer org as none": {
+			ri: marketplaceAppRI(testMarketplaceGUID, &v1.Owner{ID: testConsumerTeamGUID}),
+			expected: &models.MarketplaceReference{
+				GUID:           testMarketplaceGUID,
+				ConsumerOrgID:  none,
+				ConsumerTeamID: testConsumerTeamGUID,
+			},
 		},
 	}
 

--- a/pkg/transaction/v2event.go
+++ b/pkg/transaction/v2event.go
@@ -202,7 +202,7 @@ var eventTypeMap = map[string]string{
 }
 
 // BuildTransactionV2Data constructs an InsightsEvent from a LogEvent for the ground agent path.
-// cacheManager may be nil in tests. Owner resolution will return "unknown" in that case.
+// cacheManager may be nil in tests. Owner resolution will return "none" in that case.
 func BuildTransactionV2Data(
 	logger log.FieldLogger,
 	logEvent LogEvent,
@@ -488,7 +488,7 @@ func formatLegID(s string) string {
 func resolveAPIDetailFromCache(apiID string, cacheManager cache.Manager) *insightsAPIDetail {
 	detail := &insightsAPIDetail{
 		ID:    apiID,
-		Owner: &models.Owner{Type: "unknown"},
+		Owner: &models.Owner{Type: "none"},
 	}
 	if cacheManager == nil || apiID == "" {
 		return detail

--- a/pkg/transaction/v2event_test.go
+++ b/pkg/transaction/v2event_test.go
@@ -417,8 +417,8 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				assert.Equal(t, testTeamGUID, data.ConsumerDetails.Application.Owner.TeamGUID)
 			},
 		},
-		// nil OwnerInfo falls through to "unknown" when cacheManager is nil
-		"summary nil OwnerInfo with nil cache produces unknown owner": {
+		// nil OwnerInfo falls through to "none" when cacheManager is nil
+		"summary nil OwnerInfo with nil cache produces none owner": {
 			logEvent: LogEvent{
 				Type:          TypeTransactionSummary,
 				TransactionID: testTxnOwner3,
@@ -434,7 +434,7 @@ func TestBuildTransactionV2Data(t *testing.T) {
 				require.True(t, ok)
 				require.NotNil(t, data.API)
 				require.NotNil(t, data.API.Owner)
-				assert.Equal(t, "unknown", data.API.Owner.Type)
+				assert.Equal(t, "none", data.API.Owner.Type)
 			},
 		},
 		// nil AppOwnerInfo produces no owner on consumerDetails application


### PR DESCRIPTION
Fix application-owner lookups for remoteAppId_-prefixed IDs. Some agents report applications using an internally-generated remoteAppId_<value> ID when the real catalog ID isn't available. The lookup didn't strip this prefix, so it always missed and fell back to "unknown" — same bug class already fixed for API owners in APIGOV-33468. Added StripApplicationIDPrefix and applied it in resolveAppOwnerFromCache and getAccessRequestAndManagedApp.

Replace every owner-fallback "unknown" with "none". "unknown" is reserved for retroactively upgrading old historical events; live events should resolve to a real owner or "none" — "unknown" forces an expensive account-wide lookup at query time for no benefit. Updated all fallbacks in ownerresolver.go (API/product/app owner resolution) and resolveAPIDetailFromCache (leg/summary event path).  See Alasdair's explanation in the jira ticket https://jira.axway.com/browse/APIGOV-33596

Fix getProduct dropping Product.Owner instead of reporting "none". Owner was only set on a resolved product reference. Otherwise it stayed nil and got omitted from the JSON. Now explicitly "none" in both unresolved branches.

ID-only fields (subscription/product/asset-resource/app IDs, quota IDs, etc.) are untouched. They correctly still fall back to "unknown".