### PR TITLE
APIGOV-33625 - Allow multiple proxy resource event handlers

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -861,8 +861,8 @@ func newHandlers() map[string][]handler.Handler {
 	handlers[management.DiscoveryAgentGVK().Kind] = append(handlers[management.DiscoveryAgentGVK().Kind], agentResHandler)
 	handlers[management.TraceabilityAgentGVK().Kind] = append(handlers[management.TraceabilityAgentGVK().Kind], agentResHandler)
 	handlers[management.ComplianceAgentGVK().Kind] = append(handlers[management.ComplianceAgentGVK().Kind], agentResHandler)
-	for kind, proxyHandler := range agent.proxyResourceHandler.GetHandlers() {
-		handlers[kind] = append(handlers[kind], proxyHandler)
+	for kind, proxyHandlers := range agent.proxyResourceHandler.GetHandlers() {
+		handlers[kind] = append(handlers[kind], proxyHandlers...)
 	}
 
 	return handlers

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -579,6 +579,30 @@ func TestAgentAgentFeaturesDisabled(t *testing.T) {
 	assert.Nil(t, agent.apicClient)
 }
 
+// TestNewHandlers_multipleProxyHandlersForSameKind proves that registering more than one resource
+// event handler for the same kind (e.g. multiple RegisterResourceEventHandler calls, as happens
+// when more than one dataplane feature targets the same kind) dispatches all of them, rather than
+// silently keeping only the last one registered.
+func TestNewHandlers_multipleProxyHandlersForSameKind(t *testing.T) {
+	cfg := createCentralCfg("http://test", "v7")
+	resetResources()
+	err := Initialize(cfg)
+	assert.NoError(t, err)
+	defer resetResources()
+
+	const kind = "CustomTestKind"
+	h1 := &mockHandler{}
+	h2 := &mockHandler{}
+	RegisterResourceEventHandler(kind, h1)
+	RegisterResourceEventHandler(kind, h2)
+	defer UnregisterResourceEventHandler(kind)
+
+	got := newHandlers()[kind]
+	assert.Len(t, got, 2, "both handlers registered for the same kind must be dispatched, not just the last one")
+	assert.Same(t, h1, got[0])
+	assert.Same(t, h2, got[1])
+}
+
 func assertResource(t *testing.T, res, expectedRes *v1.ResourceInstance) {
 	assert.Equal(t, expectedRes.Group, res.Group)
 	assert.Equal(t, expectedRes.Kind, res.Kind)

--- a/pkg/agent/events/eventlistener.go
+++ b/pkg/agent/events/eventlistener.go
@@ -68,14 +68,28 @@ type EventListener struct {
 	seqTracker                 *sequenceTracker
 }
 
+type eventResourceWrapper struct {
+	once  sync.Once
+	ri    *apiv1.ResourceInstance
+	fetch func(event *proto.Event, apiServerFields []string) (*apiv1.ResourceInstance, error)
+	err   error
+}
+
+func (r *eventResourceWrapper) get(event *proto.Event, apiServerFields []string) (*apiv1.ResourceInstance, error) {
+	r.once.Do(func() {
+		r.ri, r.err = r.fetch(event, apiServerFields)
+	})
+	return r.ri, r.err
+}
+
 type handlerData struct {
-	event            *proto.Event
-	ctx              context.Context
-	handler          handler.Handler
-	logger           log.FieldLogger
-	apiServerFields  []string
-	getEventResource func(event *proto.Event, apiServerFields []string) (*apiv1.ResourceInstance, error)
-	onComplete       func()
+	event           *proto.Event
+	ctx             context.Context
+	handler         handler.Handler
+	logger          log.FieldLogger
+	apiServerFields []string
+	eventResource   *eventResourceWrapper
+	onComplete      func()
 }
 
 // sequenceTracker tracks, per dispatched event, how many handlerData items are still outstanding,
@@ -273,7 +287,7 @@ func worker(jobs <-chan handlerData) {
 }
 
 func workerProcess(handlerData handlerData) {
-	ri, err := handlerData.getEventResource(handlerData.event, handlerData.apiServerFields)
+	ri, err := handlerData.eventResource.get(handlerData.event, handlerData.apiServerFields)
 	if err != nil {
 		handlerData.logger.WithError(err).Error("failed to get event resource")
 		return
@@ -323,15 +337,20 @@ func (em *EventListener) handleEvent(event *proto.Event) error {
 		em.advanceSequence(watermark)
 	}
 
+	// shared across every handler dispatched below
+	eventResource := &eventResourceWrapper{
+		fetch: em.getEventResource,
+	}
+
 	for _, h := range toDispatch {
 		select {
 		case jobs <- handlerData{
-			event:            event,
-			ctx:              ctx,
-			handler:          h,
-			apiServerFields:  apiServerFields,
-			getEventResource: em.getEventResource,
-			logger:           logger,
+			event:           event,
+			ctx:             ctx,
+			handler:         h,
+			apiServerFields: apiServerFields,
+			eventResource:   eventResource,
+			logger:          logger,
 			onComplete: func() {
 				if watermark, advanced := em.seqTracker.complete(seq); advanced {
 					em.advanceSequence(watermark)

--- a/pkg/agent/events/eventlistener_test.go
+++ b/pkg/agent/events/eventlistener_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -256,6 +257,92 @@ func Test_sequenceTracker(t *testing.T) {
 	}
 }
 
+// TestEventResourceWrapper_get proves the sync.Once memoization: however many times get is called,
+// fetch only runs once and every caller observes the same cached result - whether that's a resource
+// or an error - the property that lets handleEvent hand the same eventResourceWrapper to every
+// handler dispatched for one event instead of each handler fetching the resource itself.
+func TestEventResourceWrapper_get(t *testing.T) {
+	tests := []struct {
+		name    string
+		ri      *apiv1.ResourceInstance
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "caches a successful fetch",
+			ri:      &apiv1.ResourceInstance{ResourceMeta: apiv1.ResourceMeta{Name: "cached"}},
+			wantMsg: "fetch must run at most once, regardless of how many times get is called",
+		},
+		{
+			name:    "caches a failed fetch",
+			err:     fmt.Errorf("boom"),
+			wantMsg: "an error result must also be cached, not retried on every call",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			wrapper := &eventResourceWrapper{
+				fetch: func(_ *proto.Event, _ []string) (*apiv1.ResourceInstance, error) {
+					calls++
+					return tc.ri, tc.err
+				},
+			}
+
+			for i := 0; i < 5; i++ {
+				ri, err := wrapper.get(nil, nil)
+				assert.Same(t, tc.ri, ri)
+				assert.Equal(t, tc.err, err)
+			}
+			assert.Equal(t, 1, calls, tc.wantMsg)
+		})
+	}
+}
+
+// TestEventListener_handleEvent_sharesEventResourceAcrossHandlers proves handleEvent builds one
+// eventResourceWrapper per event and hands it to every handler dispatched for that event, so the
+// underlying resource is only fetched once even when several handlers are registered for the same
+// kind (e.g. two RegisterResourceEventHandler calls for the same kind - see
+// agent.newHandlers/GetHandlers).
+func TestEventListener_handleEvent_sharesEventResourceAcrossHandlers(t *testing.T) {
+	const kind = "SharedKind"
+	cacheManager := agentcache.NewAgentCacheManager(&config.CentralConfiguration{}, false)
+	sequenceManager := NewSequenceProvider(cacheManager, "testWatch")
+
+	client := &countingAPIClient{ri: &apiv1.ResourceInstance{ResourceMeta: apiv1.ResourceMeta{Name: "name"}}}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	listener := NewEventListener(
+		ctx, cancel,
+		make(chan *proto.Event),
+		client,
+		"https://apicentral.example.com",
+		sequenceManager,
+		map[string][]handler.Handler{kind: {&mockHandler{}, &mockHandler{}}},
+	)
+	ch := make(chan handlerData, 2)
+	listener.kindJobs[kind] = []chan handlerData{ch}
+
+	event := newTestEvent(1)
+	event.Payload.Kind = kind
+
+	assert.NoError(t, listener.handleEvent(event))
+	assert.Len(t, ch, 2, "both handlers registered for the kind should be dispatched")
+
+	first := <-ch
+	second := <-ch
+	assert.Same(t, first.eventResource, second.eventResource,
+		"handlers dispatched for the same event must share one eventResourceWrapper")
+
+	_, err := first.eventResource.get(event, nil)
+	assert.NoError(t, err)
+	_, err = second.eventResource.get(event, nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, client.calls.Load(),
+		"the underlying resource must be fetched only once, even though two handlers need it")
+}
+
 type blockingHandler struct {
 	release chan struct{}
 }
@@ -491,8 +578,10 @@ func TestEventListener_provisioningShards_runConcurrently(t *testing.T) {
 			ctx:     context.Background(),
 			handler: slow,
 			logger:  log.NewFieldLogger(),
-			getEventResource: func(_ *proto.Event, _ []string) (*apiv1.ResourceInstance, error) {
-				return &apiv1.ResourceInstance{}, nil
+			eventResource: &eventResourceWrapper{
+				fetch: func(_ *proto.Event, _ []string) (*apiv1.ResourceInstance, error) {
+					return &apiv1.ResourceInstance{}, nil
+				},
 			},
 		}
 	}
@@ -624,6 +713,35 @@ func TestEventListener_kindLanePreservesPerResourceOrder(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("handlers did not finish in time")
 	}
+}
+
+// countingAPIClient counts ExecuteAPI calls, using a pointer-friendly atomic counter so the count
+// is observable regardless of how the client is passed around - used to prove a resource is
+// fetched only once even when shared across multiple dispatched handlers.
+type countingAPIClient struct {
+	ri    *apiv1.ResourceInstance
+	calls atomic.Int32
+}
+
+func (c *countingAPIClient) ExecuteAPI(_, _ string, _ map[string]string, _ []byte) ([]byte, error) {
+	c.calls.Add(1)
+	return json.Marshal(c.ri)
+}
+
+func (c *countingAPIClient) GetResource(_ string) (*apiv1.ResourceInstance, error) {
+	return c.ri, nil
+}
+
+func (c *countingAPIClient) CreateResourceInstance(_ apiv1.Interface) (*apiv1.ResourceInstance, error) {
+	return c.ri, nil
+}
+
+func (c *countingAPIClient) DeleteResourceInstance(_ apiv1.Interface) error {
+	return nil
+}
+
+func (c *countingAPIClient) GetAPIV1ResourceInstances(_ map[string]string, _ string) ([]*apiv1.ResourceInstance, error) {
+	return nil, nil
 }
 
 type mockHandler struct {

--- a/pkg/agent/handler/proxy.go
+++ b/pkg/agent/handler/proxy.go
@@ -1,12 +1,5 @@
 package handler
 
-import (
-	"context"
-
-	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
-	"github.com/Axway/agent-sdk/pkg/watchmanager/proto"
-)
-
 // ProxyHandler interface to represent the proxy resource handler.
 type ProxyHandler interface {
 	// RegisterTargetHandler adds the target handler
@@ -17,58 +10,32 @@ type ProxyHandler interface {
 
 // StreamWatchProxyHandler - proxy handler for stream watch
 type StreamWatchProxyHandler struct {
-	targetResourceHandlerMap map[string]Handler
+	targetResourceHandlerMap map[string][]Handler
 }
 
 // NewStreamWatchProxyHandler - creates a Handler to proxy target resource handler
 func NewStreamWatchProxyHandler() *StreamWatchProxyHandler {
 	return &StreamWatchProxyHandler{
-		targetResourceHandlerMap: make(map[string]Handler),
+		targetResourceHandlerMap: make(map[string][]Handler),
 	}
 }
 
 // RegisterTargetHandler adds the target handler
 func (h *StreamWatchProxyHandler) RegisterTargetHandler(name string, resourceHandler Handler) {
-	h.targetResourceHandlerMap[name] = resourceHandler
+	handlers, ok := h.targetResourceHandlerMap[name]
+	if !ok {
+		handlers = make([]Handler, 0)
+	}
+	handlers = append(handlers, resourceHandler)
+
+	h.targetResourceHandlerMap[name] = handlers
 }
 
-func (h *StreamWatchProxyHandler) GetHandlers() map[string]Handler {
+func (h *StreamWatchProxyHandler) GetHandlers() map[string][]Handler {
 	return h.targetResourceHandlerMap
 }
 
 // UnregisterTargetHandler removes the specified handler
 func (h *StreamWatchProxyHandler) UnregisterTargetHandler(name string) {
 	delete(h.targetResourceHandlerMap, name)
-}
-
-// GetAPIServerFields delegates to the target handler registered for the event's kind, if it
-// implements RequiredFieldsHandler. Returns nil (no restriction) otherwise.
-func (h *StreamWatchProxyHandler) GetAPIServerFields(ctx context.Context, event *proto.Event) []string {
-	if handler, ok := h.targetResourceHandlerMap[event.Payload.Kind]; ok {
-		if rfh, ok := handler.(RequiredFieldsHandler); ok {
-			return rfh.GetAPIServerFields(ctx, event)
-		}
-	}
-	return nil
-}
-
-func (h *StreamWatchProxyHandler) ShouldHandle(ctx context.Context, event *proto.Event) bool {
-	if handler, ok := h.targetResourceHandlerMap[event.Payload.Kind]; ok {
-		if handler.ShouldHandle(ctx, event) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Handle receives the type of the event (add, update, delete), event metadata and updated API Server resource
-func (h *StreamWatchProxyHandler) Handle(ctx context.Context, eventMetadata *proto.EventMeta, resource *v1.ResourceInstance) error {
-	if handler, ok := h.targetResourceHandlerMap[resource.Kind]; ok {
-		err := handler.Handle(ctx, eventMetadata, resource)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/agent/handler/proxy_test.go
+++ b/pkg/agent/handler/proxy_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	v1 "github.com/Axway/agent-sdk/pkg/apic/apiserver/models/api/v1"
@@ -11,8 +10,7 @@ import (
 )
 
 type customHandler struct {
-	err  error
-	kind string
+	err error
 }
 
 func (c *customHandler) Handle(_ context.Context, _ *proto.EventMeta, _ *v1.ResourceInstance) error {
@@ -23,79 +21,48 @@ func (c *customHandler) ShouldHandle(_ context.Context, _ *proto.Event) bool {
 	return true
 }
 
-func TestProxyHandler(t *testing.T) {
+// GetAPIServerFields makes customHandler implement RequiredFieldsHandler, so tests can prove the
+// proxy no longer consults it.
+func (c *customHandler) GetAPIServerFields(_ context.Context, _ *proto.Event) []string {
+	return []string{"field"}
+}
+
+func TestStreamWatchProxyHandler_RegisterTargetHandler(t *testing.T) {
 	tests := []struct {
 		name     string
 		handlers []*customHandler
-		event    proto.Event_Type
-		hasError bool
 	}{
 		{
-			name:     "should not register any handlers, and return nil when Handle is called",
-			event:    proto.Event_UPDATED,
+			name:     "no handlers registered for a name",
 			handlers: nil,
-			hasError: false,
 		},
 		{
-			name:  "should register a handler and return nil when Handle is called",
-			event: proto.Event_CREATED,
+			name: "a single handler registered for a name",
 			handlers: []*customHandler{
-				&customHandler{},
+				{},
 			},
-			hasError: false,
 		},
 		{
-			name:  "should register two handlers and return nil when Handle is called",
-			event: proto.Event_CREATED,
+			name: "multiple handlers registered for the same name are appended, not overwritten",
 			handlers: []*customHandler{
-				&customHandler{},
-				&customHandler{},
+				{},
+				{},
+				{},
 			},
-			hasError: false,
-		},
-		{
-			name:  "should register a handler and return an error when Handle is called",
-			event: proto.Event_CREATED,
-			handlers: []*customHandler{
-				&customHandler{err: fmt.Errorf("error")},
-			},
-			hasError: true,
-		},
-		{
-			name:  "should register two handlers and return an error when Handle is called",
-			event: proto.Event_CREATED,
-			handlers: []*customHandler{
-				&customHandler{},
-				&customHandler{err: fmt.Errorf("error")},
-			},
-			hasError: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ri := &v1.ResourceInstance{
-				ResourceMeta: v1.ResourceMeta{
-					Name:  "name",
-					Title: "title",
-				},
-			}
-
 			proxy := NewStreamWatchProxyHandler()
-
 			for _, h := range tc.handlers {
-				proxy.RegisterTargetHandler(h.kind, h)
+				proxy.RegisterTargetHandler("Kind", h)
 			}
 
-			err := proxy.Handle(NewEventContext(tc.event, nil, ri.Kind, ri.Name), nil, ri)
-			if tc.hasError {
-				assert.Error(t, err)
-			} else {
-				assert.Nil(t, err)
-			}
-
-			for i := range tc.handlers {
-				proxy.UnregisterTargetHandler(fmt.Sprintf("%d", i))
+			got := proxy.GetHandlers()["Kind"]
+			assert.Len(t, got, len(tc.handlers))
+			for i, h := range tc.handlers {
+				assert.Same(t, h, got[i], "handlers must be returned in registration order")
 			}
 		})
 	}


### PR DESCRIPTION
- Updated proxy resource event handler registration to setup multiple event handler based on resource kind
- Updated event dispatch for fetching resource once for event before handling over to the kind handlers
- Removed ShouldHandle, Handle, GetAPIServerFields from proxy handler, these interfaces will be invoked for each proxied handlers by eventlistener